### PR TITLE
Fix Openstack Services on Host

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -139,14 +139,14 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
   end
 
   def refresh_openstack_services(ssu)
-    openstack_status = ssu.shell_exec("openstack-status")
+    openstack_status = ssu.shell_exec("systemctl -la --plain | awk '/openstack/ {gsub(/ +/, \" \"); gsub(\".service\", \":\"); gsub(\"not-found\",\"(disabled)\"); split($0,s,\" \"); print s[1],s[3],s[2]}' | sed \"s/ loaded//g\"")
     services = MiqLinux::Utils.parse_openstack_status(openstack_status)
     self.host_service_group_openstacks = services.map do |service|
       # find OpenstackHostServiceGroup records by host and name and initialize if not found
       host_service_group_openstacks.where(:name => service['name'])
         .first_or_initialize.tap do |host_service_group_openstack|
         # find SystemService records by host
-        # filter SystemService records by names from openstack-status results
+        # filter SystemService records by names from openstack systemctl status results
         sys_services = system_services.where(:name => service['services'].map { |ser| ser['name'] })
         # associate SystemService record with OpenstackHostServiceGroup
         host_service_group_openstack.system_services = sys_services

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -2,25 +2,22 @@ describe ManageIQ::Providers::Openstack::InfraManager::Host do
   describe "#refresh_openstack_services" do
     let(:openstack_status_text) do
       <<-EOT
-== Nova services ==
 openstack-nova-api:                     active
 openstack-nova-cert:                    inactive  (disabled on boot)
 openstack-nova-compute:                 active
 openstack-nova-network:                 inactive  (disabled on boot)
 openstack-nova-scheduler:               active
 openstack-nova-conductor:               active
-== Glance services ==
 openstack-glance-api:                   active
 openstack-glance-registry:              active
 openstack-glance-for-test:              active
-== Keystone service ==
 openstack-keystone:                     active
       EOT
     end
 
     let(:ssu) do
       double('ssu').tap do |ssu|
-        expect(ssu).to receive(:shell_exec).with("openstack-status").and_return(openstack_status_text)
+        expect(ssu).to receive(:shell_exec).with(/systemctl/).and_return(openstack_status_text)
       end
     end
 
@@ -64,7 +61,7 @@ openstack-keystone:                     active
     end
 
     before do
-      FactoryGirl.create(:host_service_group_openstack, :host => host, :name =>  'Keystone service')
+      FactoryGirl.create(:host_service_group_openstack, :host => host, :name => 'Keystone')
     end
 
     context "with stubbed MiqLinux::Utils" do
@@ -94,15 +91,15 @@ openstack-keystone:                     active
 
       let(:expected) do
         [
-          'Nova services',
-          'Glance services',
-          'Keystone service',
+          'Nova',
+          'Glance',
+          'Keystone',
         ]
       end
 
       let(:unexpected) do
         [
-          'Swift services',
+          'Swift',
         ]
       end
 
@@ -156,7 +153,7 @@ openstack-keystone:                     active
     describe "existing HostServiceGroupOpenstack gets updated" do
       let(:glance_host_service_group) do
         host.refresh_openstack_services(ssu)
-        host.host_service_group_openstacks.where(:name => 'Glance services').first
+        host.host_service_group_openstacks.where(:name => 'Glance').first
       end
 
       describe "system_service names" do


### PR DESCRIPTION
Openstack-status command which is used for getting Openstack
services status on the Host during SSA was removed.

PR https://github.com/ManageIQ/manageiq-gems-pending/pull/104
introduces another way for capuring services data. This commit
updates code to work with it.

https://bugzilla.redhat.com/show_bug.cgi?id=1434552