### PR TITLE
Ensure managers change zone and provider region with cloud manager

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -47,8 +47,27 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :create_host_aggregate
 
   before_create :ensure_managers,
-                    :ensure_cinder_managers,
-                    :ensure_swift_managers
+                :ensure_cinder_managers,
+                :ensure_swift_managers
+
+  before_update :ensure_managers_zone_and_provider_region
+
+  def ensure_managers_zone_and_provider_region
+    if network_manager
+      network_manager.zone_id         = zone_id
+      network_manager.provider_region = provider_region
+    end
+
+    if cinder_manager
+      cinder_manager.zone_id         = zone_id
+      cinder_manager.provider_region = provider_region
+    end
+
+    if swift_manager
+      swift_manager.zone_id         = zone_id
+      swift_manager.provider_region = provider_region
+    end
+  end
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -20,6 +20,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   before_save :ensure_parent_provider
   before_destroy :destroy_parent_provider
   before_create :ensure_managers
+  before_update :ensure_managers_zone_and_provider_region
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -11,6 +11,41 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     expect(described_class.description).to eq('OpenStack')
   end
 
+  it "moves the child managers to the same zone and provider region as the cloud_manager" do
+    zone1 = FactoryGirl.create(:zone)
+    zone2 = FactoryGirl.create(:zone)
+
+    ems = FactoryGirl.create(:ems_openstack, :zone => zone1, :provider_region => "region1")
+    expect(ems.network_manager.zone).to eq zone1
+    expect(ems.network_manager.zone_id).to eq zone1.id
+    expect(ems.network_manager.provider_region).to eq "region1"
+
+    expect(ems.cinder_manager.zone).to eq zone1
+    expect(ems.cinder_manager.zone_id).to eq zone1.id
+    expect(ems.cinder_manager.provider_region).to eq "region1"
+
+    expect(ems.swift_manager.zone).to eq zone1
+    expect(ems.swift_manager.zone_id).to eq zone1.id
+    expect(ems.swift_manager.provider_region).to eq "region1"
+
+    ems.zone = zone2
+    ems.provider_region = "region2"
+    ems.save!
+    ems.reload
+
+    expect(ems.network_manager.zone).to eq zone2
+    expect(ems.network_manager.zone_id).to eq zone2.id
+    expect(ems.network_manager.provider_region).to eq "region2"
+
+    expect(ems.cinder_manager.zone).to eq zone2
+    expect(ems.cinder_manager.zone_id).to eq zone2.id
+    expect(ems.cinder_manager.provider_region).to eq "region2"
+
+    expect(ems.swift_manager.zone).to eq zone2
+    expect(ems.swift_manager.zone_id).to eq zone2.id
+    expect(ems.swift_manager.provider_region).to eq "region2"
+  end
+
   describe ".metrics_collector_queue_name" do
     it "returns the correct queue name" do
       worker_queue = ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker.default_queue_name


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14741

Ensure managers change zone and provider region with cloud manager

The bug occurs when Cloud Manager is moved to a different zone. Then network and storage managers gets stuck and stop doing refresh.

Related to AWS BZ, same issue is for OpenStack:
https://bugzilla.redhat.com/show_bug.cgi?id=1439268