### PR TITLE
Only consider network interface when finding network metrics

### DIFF
--- a/app/models/manageiq/providers/openstack/base_metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/base_metrics_capture.rb
@@ -95,27 +95,13 @@ class ManageIQ::Providers::Openstack::BaseMetricsCapture < ManageIQ::Providers::
 
   def find_meter_counters(metric_capture_module, resource_filter, metadata_filter, log_header)
     counters = list_resource_meters(resource_filter, log_header) + list_metadata_meters(metadata_filter, log_header)
-
-    # With Gnocchi, the network metrics are not associated with the instance's resource id
-    # but with the instance's network interface resource id. Here we fetch the counters
-    # for the network interface, so that the network metrics can be fetched.
-    if target.respond_to?(:network_ports)
-      target.network_ports.each do |port|
-        # fetch the list of resources and use the original_resource_id and type to find
-        # the network interface's resource
-        original_resource_id = "#{target.ems_ref}-tap#{port.ems_ref[0..10]}"
-        resources = @perf_ems.list_resources.body
-        resources.each do |r|
-          if r["type"].to_s == "instance_network_interface" && r["original_resource_id"].include?(original_resource_id)
-            resource_filter = {"field" => "resource_id", "value" => r["id"]}
-            counters = counters + list_resource_meters(resource_filter, log_header)
-          end
-        end
-      end
-    end
-
+    add_gnocchi_meter_counters(counters, resource_filter)
     # Select only allowed counters, with unique names
     counters.select { |c| meter_names(metric_capture_module).include?(c["name"]) }.uniq { |x| x['name'] }
+  end
+
+  def add_gnocchi_meter_counters(_counters, _resource_filter)
+    raise NotImplementedError, _("add_gnocchi_meter_counters must be implemented in a subclass")
   end
 
   def list_resource_meters(resource_filter, log_header)

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
@@ -125,4 +125,8 @@ class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::P
     perf_capture_data_openstack_base(self.class, start_time, end_time, resource_filter,
                                      metadata_filter)
   end
+
+  def add_gnocchi_meter_counters(_counters, _resource_filter)
+    # NOOP, gnocchi not used in undercloud
+  end
 end


### PR DESCRIPTION
Previously we were looking at all resources when we were finding
the network interface's resource id. We can reduce the number
of resources we inspect by limiting them to network interface
resources.

This requires a fog-openstack change to add a new request:
https://github.com/fog/fog-openstack/pull/283

This PR should be merged only when the fog-openstack change
has been released and the manageiq-gems-pending gemspec has been
updated with the release version containing that change.