### PR TITLE
Change memory utilization calculation for OpenStack infrastructure

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
@@ -1,7 +1,9 @@
 class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::Providers::Openstack::BaseMetricsCapture
   CPU_METERS     = %w(hardware.cpu.util)
   MEMORY_METERS  = %w(hardware.memory.used
-                      hardware.memory.total)
+                      hardware.memory.total
+                      hardware.memory.buffer
+                      hardware.memory.cached)
   SWAP_METERS    = %w(hardware.memory.swap.avail
                       hardware.memory.swap.total)
   DISK_METERS    = %w(hardware.system_stats.io.outgoing.blocks
@@ -21,7 +23,7 @@ class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::P
   # TODO(lsmola) until we have hardware.memory.util in Ceilometer, we have to compute it, but this computation
   # should be done rather on the Ceilometer side
   def self.memory_util_calculation(stats, _)
-    stats['hardware.memory.total'] > 0 ? 100.0 / stats['hardware.memory.total'] * stats['hardware.memory.used'] : 0
+    stats['hardware.memory.total'] > 0 ? 100.0 / stats['hardware.memory.total'] * (stats['hardware.memory.used'] - stats['hardware.memory.cached'] - stats['hardware.memory.buffer']) : 0
   end
 
   def self.memory_swapped_calculation(stats, _)

--- a/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
@@ -672,15 +672,25 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       # grab read bytes and write bytes data, these values are pulled directly from
       # spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
-      @memory_used =  filter_statistics(@mock_stats_data.get_statistics("hardware.memory.used",
-                                                                        "multiple_collection_periods"),
-                                        '<=',
-                                        NET_SECOND_COLLECTION_PERIOD_START)
+      @memory_used =   filter_statistics(@mock_stats_data.get_statistics("hardware.memory.used",
+                                                                         "multiple_collection_periods"),
+                                         '<=',
+                                         NET_SECOND_COLLECTION_PERIOD_START)
 
-      @memory_total = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.total",
-                                                                        "multiple_collection_periods"),
-                                        '<=',
-                                        NET_SECOND_COLLECTION_PERIOD_START)
+      @memory_total =  filter_statistics(@mock_stats_data.get_statistics("hardware.memory.total",
+                                                                         "multiple_collection_periods"),
+                                         '<=',
+                                         NET_SECOND_COLLECTION_PERIOD_START)
+
+      @memory_cached = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.cached",
+                                                                         "multiple_collection_periods"),
+                                         '<=',
+                                         NET_SECOND_COLLECTION_PERIOD_START)
+
+      @memory_buffer = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.buffer",
+                                                                         "multiple_collection_periods"),
+                                         '<=',
+                                         NET_SECOND_COLLECTION_PERIOD_START)
 
       @swap_avail = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.swap.avail",
                                                                       "multiple_collection_periods"),
@@ -709,13 +719,13 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       )
 
       avg_stat1_computed_elsewhere = 73.2421875
-      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 1)
+      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 1)
       avg_stat2_computed_elsewhere = 48.828125
-      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 2)
+      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 2)
       avg_stat3_computed_elsewhere = 56.15234375
-      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 3)
+      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 3)
       avg_stat4_computed_elsewhere = 31.73828125
-      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 4)
+      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 4)
 
       # ensure computations are equal
       expect(avg_stat1_manual).to eq avg_stat1_computed_elsewhere
@@ -751,11 +761,11 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
     it "checks that the mem_usage_absolute_average has aligned data and computed stats correctly" do
       # make computation of stats for comparison
-      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 1)
-      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 2)
-      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 3)
-      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 4)
-      avg_stat5 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 5)
+      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 1)
+      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 2)
+      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 3)
+      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 4)
+      avg_stat5 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 5)
 
       # ensure that the first 30 statistics match avg_stat1
       (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat1 }
@@ -781,7 +791,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
     end
 
     it "tests that last computed statistic has the right value" do
-      avg_stat5 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 5)
+      avg_stat5 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 5)
 
       # Test that last value of 1. collection period is this. This test continues in 2. collection period test. This
       # value has to be different to first value of 2.collection period
@@ -848,17 +858,28 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       # grab read bytes and write bytes data, these values are pulled directly from
       # spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
-      @memory_used =  filter_statistics(@mock_stats_data.get_statistics("hardware.memory.used",
-                                                                        "multiple_collection_periods"),
-                                        '>',
-                                        NET_SECOND_COLLECTION_PERIOD_START,
-                                        NET_COLLECTION_OVERLAP_PERIOD)
+      @memory_used =   filter_statistics(@mock_stats_data.get_statistics("hardware.memory.used",
+                                                                         "multiple_collection_periods"),
+                                         '>',
+                                         NET_SECOND_COLLECTION_PERIOD_START,
+                                         NET_COLLECTION_OVERLAP_PERIOD)
 
-      @memory_total = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.total",
-                                                                        "multiple_collection_periods"),
-                                        '>',
-                                        NET_SECOND_COLLECTION_PERIOD_START,
-                                        NET_COLLECTION_OVERLAP_PERIOD)
+      @memory_total =  filter_statistics(@mock_stats_data.get_statistics("hardware.memory.total",
+                                                                         "multiple_collection_periods"),
+                                         '>',
+                                         NET_SECOND_COLLECTION_PERIOD_START,
+                                         NET_COLLECTION_OVERLAP_PERIOD)
+      @memory_cached = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.cached",
+                                                                         "multiple_collection_periods"),
+                                         '>',
+                                         NET_SECOND_COLLECTION_PERIOD_START,
+                                         NET_COLLECTION_OVERLAP_PERIOD)
+
+      @memory_buffer = filter_statistics(@mock_stats_data.get_statistics("hardware.memory.buffer",
+                                                                         "multiple_collection_periods"),
+                                         '>',
+                                         NET_SECOND_COLLECTION_PERIOD_START,
+                                         NET_COLLECTION_OVERLAP_PERIOD)
       # Drop fist element of write bytes, as that is an incomplete stat
       @memory_total.shift
       # Drop pre last element of write bytes cause it doesn't have pair sample, therefore it is an incomplete stat
@@ -874,10 +895,10 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
     it "checks that the mem_usage_absolute_average has aligned data and computed stats correctly" do
       # make computation of stats for comparison
-      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 1)
-      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 2)
-      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 3)
-      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 4)
+      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 1)
+      avg_stat2 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 2)
+      avg_stat3 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 3)
+      avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 4)
 
       # ensure that the next 30 statistics match avg_stat1
       (21..50).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat1 }
@@ -905,7 +926,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
     it "checks that last sample of 1. collection period is different to first sample of 2. collection period" do
       # make computation of stats for comparison
-      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 1)
+      avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, @memory_cached, @memory_buffer, 1)
 
       expect(avg_stat1).not_to eq MEM_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
@@ -959,11 +980,13 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       }, nil)
   end
 
-  def make_memory_util_calculation(counter_info, memory_used, memory_total, index)
+  def make_memory_util_calculation(counter_info, memory_used, memory_total, memory_cached, memory_buffer, index)
     counter_info[:calculation].call(
       {
-        "hardware.memory.used"  => memory_used[index]['avg'],
-        "hardware.memory.total" => memory_total[index]['avg'],
+        "hardware.memory.used"   => memory_used[index]['avg'],
+        "hardware.memory.total"  => memory_total[index]['avg'],
+        "hardware.memory.cached" => memory_cached[index]['avg'],
+        "hardware.memory.buffer" => memory_buffer[index]['avg'],
       }, nil)
   end
 
@@ -993,5 +1016,24 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
   def parse_datetime(datetime)
     datetime << "Z" if datetime.size == 19
     Time.parse(datetime)
+  end
+
+  context "memory utilization calculation" do
+    it "cached and buffer memory should not count towards utilized memory as it can be freed" do
+      # hardware.memory.used is calculated by subtracting free memory from total memory.
+      # See https://review.openstack.org/#/c/157257
+      # Cached and buffer memory should be subtracted from hardware.memory.used to get a more
+      # accurate representation of memory that is utilized and can't be freed from memory
+      # pressure.
+      stats = {}
+      stats['hardware.memory.total'] = 100
+      stats['hardware.memory.used'] = 90
+      stats['hardware.memory.buffer'] = 20
+      stats['hardware.memory.cached'] = 10
+
+      used_memory_utilization = 100 * (stats['hardware.memory.used'] - stats['hardware.memory.cached'] - stats['hardware.memory.buffer']) / stats['hardware.memory.total']
+
+      expect(described_class.memory_util_calculation(stats, 'dummy')).to eq used_memory_utilization
+    end
   end
 end

--- a/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
@@ -1242,6 +1242,200 @@
     period_start: "2013-08-28T11:14:20"
     avg: 4096.0
     sum: 58234626048.0
+  hardware.memory.cached:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:00:09"
+    min: 58125377536.0
+    max: 58125377536.0
+    duration_end: "2013-08-28T11:00:09"
+    period: 20
+    period_end: "2013-08-28T11:00:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:00:00"
+    avg: 0.0
+    sum: 58125377536.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 58149425152.0
+    max: 58149425152.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:00"
+    avg: 0.0
+    sum: 58149425152.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:15"
+    min: 58192719872.0
+    max: 58192719872.0
+    duration_end: "2013-08-28T11:04:15"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 58192719872.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:18"
+    min: 58206168192.0
+    max: 58206168192.0
+    duration_end: "2013-08-28T11:06:18"
+    period: 20
+    period_end: "2013-08-28T11:06:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:00"
+    avg: 0.0
+    sum: 58206168192.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:21"
+    min: 58212818944.0
+    max: 58212818944.0
+    duration_end: "2013-08-28T11:08:21"
+    period: 20
+    period_end: "2013-08-28T11:08:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:20"
+    avg: 0.0
+    sum: 58212818944.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:25"
+    min: 58223599616.0
+    max: 58223599616.0
+    duration_end: "2013-08-28T11:10:25"
+    period: 20
+    period_end: "2013-08-28T11:10:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:20"
+    avg: 0.0
+    sum: 58223599616.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:12:27"
+    min: 58229735424.0
+    max: 58229735424.0
+    duration_end: "2013-08-28T11:12:27"
+    period: 20
+    period_end: "2013-08-28T11:12:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:12:20"
+    avg: 0.0
+    sum: 58229735424.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:14:28"
+    min: 58234626048.0
+    max: 58234626048.0
+    duration_end: "2013-08-28T11:14:28"
+    period: 20
+    period_end: "2013-08-28T11:14:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:14:20"
+    avg: 0.0
+    sum: 58234626048.0
+  hardware.memory.buffer:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:00:09"
+    min: 58125377536.0
+    max: 58125377536.0
+    duration_end: "2013-08-28T11:00:09"
+    period: 20
+    period_end: "2013-08-28T11:00:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:00:00"
+    avg: 0.0
+    sum: 58125377536.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 58149425152.0
+    max: 58149425152.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:00"
+    avg: 0.0
+    sum: 58149425152.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:15"
+    min: 58192719872.0
+    max: 58192719872.0
+    duration_end: "2013-08-28T11:04:15"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 58192719872.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:18"
+    min: 58206168192.0
+    max: 58206168192.0
+    duration_end: "2013-08-28T11:06:18"
+    period: 20
+    period_end: "2013-08-28T11:06:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:00"
+    avg: 0.0
+    sum: 58206168192.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:21"
+    min: 58212818944.0
+    max: 58212818944.0
+    duration_end: "2013-08-28T11:08:21"
+    period: 20
+    period_end: "2013-08-28T11:08:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:20"
+    avg: 0.0
+    sum: 58212818944.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:25"
+    min: 58223599616.0
+    max: 58223599616.0
+    duration_end: "2013-08-28T11:10:25"
+    period: 20
+    period_end: "2013-08-28T11:10:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:20"
+    avg: 0.0
+    sum: 58223599616.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:12:27"
+    min: 58229735424.0
+    max: 58229735424.0
+    duration_end: "2013-08-28T11:12:27"
+    period: 20
+    period_end: "2013-08-28T11:12:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:12:20"
+    avg: 0.0
+    sum: 58229735424.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:14:28"
+    min: 58234626048.0
+    max: 58234626048.0
+    duration_end: "2013-08-28T11:14:28"
+    period: 20
+    period_end: "2013-08-28T11:14:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:14:20"
+    avg: 0.0
+    sum: 58234626048.0
   hardware.memory.swap.avail:
   -
     count: 1

--- a/spec/tools/openstack_data/openstack_perf_data/metadata_counters.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/metadata_counters.yml
@@ -78,6 +78,20 @@
   unit: "B"
 -
   user_id: "62992b0399a34653907ded01238a9b2b"
+  name: "hardware.memory.cached"
+  resource_id: "998f6beb-825c-44f3-9fad-6f3270cab1d8"
+  project_id: "3bbc20f34655462d8112ef8db50e5a19"
+  type: "gauge"
+  unit: "B"
+-
+  user_id: "62992b0399a34653907ded01238a9b2b"
+  name: "hardware.memory.buffer"
+  resource_id: "998f6beb-825c-44f3-9fad-6f3270cab1d8"
+  project_id: "3bbc20f34655462d8112ef8db50e5a19"
+  type: "gauge"
+  unit: "B"
+-
+  user_id: "62992b0399a34653907ded01238a9b2b"
   name: "hardware.memory.swap.avail"
   resource_id: "998f6beb-825c-44f3-9fad-6f3270cab1d8"
   project_id: "3bbc20f34655462d8112ef8db50e5a19"
@@ -90,3 +104,4 @@
   project_id: "3bbc20f34655462d8112ef8db50e5a19"
   type: "gauge"
   unit: "B"
+

--- a/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
@@ -1605,6 +1605,272 @@
     period_start: "2013-08-28T12:44:20"
     avg: 4096.0
     sum: 89.74293759622134
+  hardware.memory.cached:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:09"
+    min: 196678550.0
+    max: 196678550.0
+    duration_end: "2013-08-28T11:04:09"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 196678550.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:14:12"
+    min: 196679966.0
+    max: 196679966.0
+    duration_end: "2013-08-28T11:14:12"
+    period: 20
+    period_end: "2013-08-28T11:14:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:14:00"
+    avg: 0.0
+    sum: 196679966.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:24:15"
+    min: 196691325.0
+    max: 196691325.0
+    duration_end: "2013-08-28T11:24:15"
+    period: 20
+    period_end: "2013-08-28T11:24:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:24:00"
+    avg: 0.0
+    sum: 196691325.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:34:18"
+    min: 196692783.0
+    max: 196692783.0
+    duration_end: "2013-08-28T11:34:18"
+    period: 20
+    period_end: "2013-08-28T11:34:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:34:00"
+    avg: 0.0
+    sum: 196692783.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:44:21"
+    min: 196694199.0
+    max: 196694199.0
+    duration_end: "2013-08-28T11:44:21"
+    period: 20
+    period_end: "2013-08-28T11:44:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:44:20"
+    avg: 0.0
+    sum: 196694199.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:54:23"
+    min: 196695615.0
+    max: 196695615.0
+    duration_end: "2013-08-28T11:54:23"
+    period: 20
+    period_end: "2013-08-28T11:54:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:54:20"
+    avg: 0.0
+    sum: 196695615.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:04:25"
+    min: 196706601.0
+    max: 196706601.0
+    duration_end: "2013-08-28T12:04:25"
+    period: 20
+    period_end: "2013-08-28T12:04:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:04:20"
+    avg: 0.0
+    sum: 196706601.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:14:27"
+    min: 196708017.0
+    max: 196708017.0
+    duration_end: "2013-08-28T12:14:27"
+    period: 20
+    period_end: "2013-08-28T12:14:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:14:20"
+    avg: 0.0
+    sum: 196708017.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:24:28"
+    min: 196709433.0
+    max: 196709433.0
+    duration_end: "2013-08-28T12:24:28"
+    period: 20
+    period_end: "2013-08-28T12:24:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:24:20"
+    avg: 0.0
+    sum: 196709433.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:34:29"
+    min: 196711321.0
+    max: 196711321.0
+    duration_end: "2013-08-28T12:34:29"
+    period: 20
+    period_end: "2013-08-28T12:34:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:34:20"
+    avg: 0.0
+    sum: 196711321.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:44:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T12:44:39"
+    period: 20
+    period_end: "2013-08-28T12:44:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:44:20"
+    avg: 0.0
+    sum: 89.74293759622134
+  hardware.memory.buffer:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:09"
+    min: 196678550.0
+    max: 196678550.0
+    duration_end: "2013-08-28T11:04:09"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 196678550.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:14:12"
+    min: 196679966.0
+    max: 196679966.0
+    duration_end: "2013-08-28T11:14:12"
+    period: 20
+    period_end: "2013-08-28T11:14:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:14:00"
+    avg: 0.0
+    sum: 196679966.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:24:15"
+    min: 196691325.0
+    max: 196691325.0
+    duration_end: "2013-08-28T11:24:15"
+    period: 20
+    period_end: "2013-08-28T11:24:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:24:00"
+    avg: 0.0
+    sum: 196691325.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:34:18"
+    min: 196692783.0
+    max: 196692783.0
+    duration_end: "2013-08-28T11:34:18"
+    period: 20
+    period_end: "2013-08-28T11:34:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:34:00"
+    avg: 0.0
+    sum: 196692783.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:44:21"
+    min: 196694199.0
+    max: 196694199.0
+    duration_end: "2013-08-28T11:44:21"
+    period: 20
+    period_end: "2013-08-28T11:44:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:44:20"
+    avg: 0.0
+    sum: 196694199.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:54:23"
+    min: 196695615.0
+    max: 196695615.0
+    duration_end: "2013-08-28T11:54:23"
+    period: 20
+    period_end: "2013-08-28T11:54:40"
+    duration: 0.0
+    period_start: "2013-08-28T11:54:20"
+    avg: 0.0
+    sum: 196695615.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:04:25"
+    min: 196706601.0
+    max: 196706601.0
+    duration_end: "2013-08-28T12:04:25"
+    period: 20
+    period_end: "2013-08-28T12:04:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:04:20"
+    avg: 0.0
+    sum: 196706601.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:14:27"
+    min: 196708017.0
+    max: 196708017.0
+    duration_end: "2013-08-28T12:14:27"
+    period: 20
+    period_end: "2013-08-28T12:14:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:14:20"
+    avg: 0.0
+    sum: 196708017.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:24:28"
+    min: 196709433.0
+    max: 196709433.0
+    duration_end: "2013-08-28T12:24:28"
+    period: 20
+    period_end: "2013-08-28T12:24:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:24:20"
+    avg: 0.0
+    sum: 196709433.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:34:29"
+    min: 196711321.0
+    max: 196711321.0
+    duration_end: "2013-08-28T12:34:29"
+    period: 20
+    period_end: "2013-08-28T12:34:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:34:20"
+    avg: 0.0
+    sum: 196711321.0
+  -
+    count: 1
+    duration_start: "2013-08-28T12:44:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T12:44:39"
+    period: 20
+    period_end: "2013-08-28T12:44:40"
+    duration: 0.0
+    period_start: "2013-08-28T12:44:20"
+    avg: 0.0
+    sum: 89.74293759622134
   hardware.memory.swap.avail:
   -
     count: 1

--- a/spec/tools/openstack_data/openstack_perf_data/standard.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/standard.yml
@@ -1451,6 +1451,248 @@
     period_start: "2013-08-28T11:10:00"
     avg: 4096.0
     sum: 196711321.0
+  hardware.memory.cached:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 196678550.0
+    max: 196678550.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:00"
+    avg: 0.0
+    sum: 196678550.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:09"
+    min: 196679966.0
+    max: 196679966.0
+    duration_end: "2013-08-28T11:02:09"
+    period: 20
+    period_end: "2013-08-28T11:02:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:00"
+    avg: 0.0
+    sum: 196679966.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:09"
+    min: 196691325.0
+    max: 196691325.0
+    duration_end: "2013-08-28T11:03:09"
+    period: 20
+    period_end: "2013-08-28T11:03:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:00"
+    avg: 0.0
+    sum: 196691325.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:09"
+    min: 196692783.0
+    max: 196692783.0
+    duration_end: "2013-08-28T11:04:09"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 196692783.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:09"
+    min: 196694199.0
+    max: 196694199.0
+    duration_end: "2013-08-28T11:05:09"
+    period: 20
+    period_end: "2013-08-28T11:05:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:00"
+    avg: 0.0
+    sum: 196694199.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:09"
+    min: 196695615.0
+    max: 196695615.0
+    duration_end: "2013-08-28T11:06:09"
+    period: 20
+    period_end: "2013-08-28T11:06:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:00"
+    avg: 0.0
+    sum: 196695615.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:09"
+    min: 196706601.0
+    max: 196706601.0
+    duration_end: "2013-08-28T11:07:09"
+    period: 20
+    period_end: "2013-08-28T11:07:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:00"
+    avg: 0.0
+    sum: 196706601.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:09"
+    min: 196708017.0
+    max: 196708017.0
+    duration_end: "2013-08-28T11:08:09"
+    period: 20
+    period_end: "2013-08-28T11:08:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:00"
+    avg: 0.0
+    sum: 196708017.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:09"
+    min: 196709433.0
+    max: 196709433.0
+    duration_end: "2013-08-28T11:09:09"
+    period: 20
+    period_end: "2013-08-28T11:09:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:00"
+    avg: 0.0
+    sum: 196709433.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:09"
+    min: 196711321.0
+    max: 196711321.0
+    duration_end: "2013-08-28T11:10:09"
+    period: 20
+    period_end: "2013-08-28T11:10:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:00"
+    avg: 0.0
+    sum: 196711321.0
+  hardware.memory.buffer:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 196678550.0
+    max: 196678550.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:00"
+    avg: 0.0
+    sum: 196678550.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:09"
+    min: 196679966.0
+    max: 196679966.0
+    duration_end: "2013-08-28T11:02:09"
+    period: 20
+    period_end: "2013-08-28T11:02:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:00"
+    avg: 0.0
+    sum: 196679966.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:09"
+    min: 196691325.0
+    max: 196691325.0
+    duration_end: "2013-08-28T11:03:09"
+    period: 20
+    period_end: "2013-08-28T11:03:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:00"
+    avg: 0.0
+    sum: 196691325.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:09"
+    min: 196692783.0
+    max: 196692783.0
+    duration_end: "2013-08-28T11:04:09"
+    period: 20
+    period_end: "2013-08-28T11:04:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:00"
+    avg: 0.0
+    sum: 196692783.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:09"
+    min: 196694199.0
+    max: 196694199.0
+    duration_end: "2013-08-28T11:05:09"
+    period: 20
+    period_end: "2013-08-28T11:05:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:00"
+    avg: 0.0
+    sum: 196694199.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:09"
+    min: 196695615.0
+    max: 196695615.0
+    duration_end: "2013-08-28T11:06:09"
+    period: 20
+    period_end: "2013-08-28T11:06:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:00"
+    avg: 0.0
+    sum: 196695615.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:09"
+    min: 196706601.0
+    max: 196706601.0
+    duration_end: "2013-08-28T11:07:09"
+    period: 20
+    period_end: "2013-08-28T11:07:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:00"
+    avg: 0.0
+    sum: 196706601.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:09"
+    min: 196708017.0
+    max: 196708017.0
+    duration_end: "2013-08-28T11:08:09"
+    period: 20
+    period_end: "2013-08-28T11:08:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:00"
+    avg: 0.0
+    sum: 196708017.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:09"
+    min: 196709433.0
+    max: 196709433.0
+    duration_end: "2013-08-28T11:09:09"
+    period: 20
+    period_end: "2013-08-28T11:09:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:00"
+    avg: 0.0
+    sum: 196709433.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:09"
+    min: 196711321.0
+    max: 196711321.0
+    duration_end: "2013-08-28T11:10:09"
+    period: 20
+    period_end: "2013-08-28T11:10:20"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:00"
+    avg: 0.0
+    sum: 196711321.0
   hardware.memory.swap.avail:
   -
     count: 1


### PR DESCRIPTION
Ceilometer's hardware.memory.used is calculated by subtracting free
memory from total memory.

See https://review.openstack.org/#/c/157257

Cached and buffer memory should be subtracted from
hardware.memory.used to get a more accurate representation of
memory that is utilized and can't be freed if there is memory
pressure.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1425951