### PR TITLE
Add cloud refresher tests with stubbed out collector calls

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
@@ -1,0 +1,148 @@
+require_relative '../openstack_stubs'
+
+describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
+  include OpenstackStubs
+
+  describe "refresh" do
+    before do
+      @ems = FactoryGirl.create(:ems_openstack_with_authentication)
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+    end
+
+    it "refreshes twice, first creating all entities and then updating all entities" do
+      @data_scaling = 1
+      2.times do
+        setup_mocked_collector
+        assert_do_not_delete
+        refresh_spec
+      end
+    end
+
+    it "refreshes twice, first creating all entities and then updating existing and deleting missing entities" do
+      @data_scaling         = 2
+      @disconnect_inv_count = 0
+      2.times do
+        setup_mocked_collector
+        refresh_spec
+        @data_scaling         -= 1
+        @disconnect_inv_count += 1
+      end
+    end
+
+    it "refreshes twice, first creating all entities and then updating existing and creating new entities" do
+      @data_scaling = 1
+      2.times do
+        setup_mocked_collector
+        assert_do_not_delete
+        refresh_spec
+        @data_scaling += 1
+      end
+    end
+
+    it "refreshes twice, first creating all entities and then deleting all entities from the db" do
+      @data_scaling = 1
+      2.times do
+        setup_mocked_collector
+        refresh_spec do
+          VmOrTemplate.all.map(&:destroy) if @data_scaling == 0
+        end
+        @data_scaling -= 1
+      end
+    end
+
+    def refresh_spec
+      @ems.reload
+      # with_openstack_stubbed(stub_responses) do
+      EmsRefresh.refresh(@ems)
+      # end
+      @ems.reload
+
+      yield if block_given?
+
+      assert_table_counts
+      assert_ems
+    end
+
+    def expected_table_counts(disconnect = nil)
+      disconnect ||= disconnect_inv_factor
+
+      vm_count     = test_counts(@data_scaling)[:vms_count]
+      image_count  = test_counts(@data_scaling)[:miq_templates_count]
+
+      # Disconnect_inv count, when these objects are not found in the API, they are not deleted in DB, but just marked
+      # as disconnected
+      vm_count_plus_disconnect_inv    = vm_count + test_counts(disconnect)[:vms_count]
+      image_count_plus_disconnect_inv = image_count + test_counts(disconnect)[:miq_templates_count]
+      {
+        :auth_private_key              => test_counts(@data_scaling)[:key_pairs_count],
+        :ext_management_system         => 4,
+        :flavor                        => test_counts(@data_scaling)[:flavors_count],
+        :host_aggregate                => test_counts(@data_scaling)[:host_aggregates_count],
+        :availability_zone             => 2,
+        :vm_or_template                => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
+        :vm                            => vm_count_plus_disconnect_inv,
+        :miq_template                  => image_count_plus_disconnect_inv,
+        :disk                          => vm_count_plus_disconnect_inv,
+        :hardware                      => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
+        :network                       => vm_count_plus_disconnect_inv * 2,
+        :orchestration_template        => test_counts([@data_scaling, 1 + disconnect].max)[:orchestration_stacks_count],
+        :orchestration_stack           => test_counts(@data_scaling)[:orchestration_stacks_count],
+        :orchestration_stack_parameter => test_counts(@data_scaling)[:orchestration_stacks_count],
+        :orchestration_stack_output    => test_counts(@data_scaling)[:orchestration_stacks_count] + test_counts[:vnfs_count],
+        :orchestration_stack_resource  => test_counts(@data_scaling)[:orchestration_stacks_count],
+      }
+    end
+
+    def assert_table_counts
+      actual = {
+        :auth_private_key              => AuthPrivateKey.count,
+        :ext_management_system         => ExtManagementSystem.count,
+        :flavor                        => Flavor.count,
+        :host_aggregate                => HostAggregate.count,
+        :availability_zone             => AvailabilityZone.count,
+        :vm_or_template                => VmOrTemplate.count,
+        :vm                            => Vm.count,
+        :miq_template                  => MiqTemplate.count,
+        :disk                          => Disk.count,
+        :hardware                      => Hardware.count,
+        :network                       => Network.count,
+        :orchestration_template        => OrchestrationTemplate.count,
+        :orchestration_stack           => OrchestrationStack.count,
+        :orchestration_stack_parameter => OrchestrationStackParameter.count,
+        :orchestration_stack_output    => OrchestrationStackOutput.count,
+        :orchestration_stack_resource  => OrchestrationStackResource.count,
+      }
+      expect(actual).to eq expected_table_counts
+    end
+
+    def setup_mocked_collector
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:image_service).and_return(double(:name => "not-glance"))
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:availability_zones).and_return(mocked_availability_zones)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:cloud_services).and_return(mocked_cloud_services)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:flavors).and_return(mocked_flavors)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:host_aggregates).and_return(mocked_host_aggregates)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:images).and_return(mocked_miq_templates)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:key_pairs).and_return(mocked_key_pairs)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:quotas).and_return(mocked_quotas)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:quotas).and_return([])
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:quotas).and_return([])
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:orchestration_stacks).and_return(mocked_orchestration_stacks)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:servers).and_return(mocked_vms)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:vnfs).and_return(mocked_vnfs)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:vnfds).and_return(mocked_vnfds)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:tenants).and_return(mocked_cloud_tenants)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:private_flavor).and_return(nil)
+    end
+
+    def assert_ems
+      ems = @ems
+
+      # The disconnected entities should not be associated to ems, so we get counts as expected_table_counts(0)
+      expect(ems.flavors.size).to eql(expected_table_counts[:flavor])
+      expect(ems.availability_zones.size).to eql(expected_table_counts[:availability_zone])
+      expect(ems.vms_and_templates.size).to eql(expected_table_counts(0)[:vm_or_template])
+      expect(ems.miq_templates.size).to eq(expected_table_counts(0)[:miq_template])
+      expect(ems.orchestration_stacks.size).to eql(expected_table_counts[:orchestration_stack])
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openstack/openstack_stubs.rb
+++ b/spec/models/manageiq/providers/openstack/openstack_stubs.rb
@@ -1,0 +1,239 @@
+require 'ostruct'
+module OpenstackStubs
+  def scaling_factor
+    @data_scaling || try(:data_scaling) || 1
+  end
+
+  def disconnect_inv_factor
+    @disconnect_inv_count || 0
+  end
+
+  def test_counts(scaling = nil)
+    scaling ||= scaling_factor
+    {
+      :cloud_services_count       => scaling * 10,
+      :cloud_tenants_count        => scaling * 10,
+      :flavors_count              => scaling * 10,
+      :host_aggregates_count      => scaling * 10,
+      :key_pairs_count            => scaling * 5,
+      :quotas_count               => scaling * 10,
+      :miq_templates_count        => scaling * 10,
+      :orchestration_stacks_count => scaling * 10,
+      :vnfs_count                 => scaling * 10,
+      :vnfds_count                => scaling * 10,
+      :vms_count                  => scaling * 10
+    }
+  end
+
+  def assert_do_not_delete
+    allow_any_instance_of(ApplicationRecord).to(
+      receive(:delete).and_raise("Not allowed delete operation detected. The probable cause is a wrong manager_ref"\
+                                 " causing create&delete instead of update")
+    )
+    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to(
+      receive(:delete).and_raise("Not allowed delete operation detected. The probable cause is a wrong manager_ref"\
+                                 " causing create&delete instead of update")
+    )
+    allow_any_instance_of(ApplicationRecord).to(
+      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
+                                         " manager_ref causing create&disconnect_inv instead of update")
+    )
+    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to(
+      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
+                                         "manager_ref causing create&disconnect_inv instead of update")
+    )
+  end
+
+  def mocked_availability_zones
+    [OpenStruct.new(:zoneName => "nova")]
+  end
+
+  def mocked_cloud_services
+    mocked_cloud_services = []
+    test_counts[:cloud_services_count].times do |i|
+      mocked_cloud_services << OpenStruct.new(
+        :id              => i,
+        :binary          => "binary_#{i}",
+        :host            => "host_#{i}",
+        :state           => "state_#{i}",
+        :status          => "disabled",
+        :disabled_reason => "disabled_reason_#{i}",
+        :zone            => "nova"
+      )
+    end
+    mocked_cloud_services
+  end
+
+  def mocked_cloud_tenants
+    mocked_cloud_tenants = []
+    test_counts[:cloud_tenants_count].times do |i|
+      mocked_cloud_tenants << OpenStruct.new(
+        :id          => i,
+        :name        => "cloud_tenant_#{i}",
+        :description => "cloud_tenant_description_#{i}",
+        :enabled     => true
+      )
+    end
+    mocked_cloud_tenants
+  end
+
+  def mocked_flavors
+    mocked_flavors = []
+    test_counts[:flavors_count].times do |i|
+      mocked_flavors << OpenStruct.new(
+        :id        => i,
+        :name      => "flavor_#{i}",
+        :disabled  => false,
+        :vcpus     => i,
+        :ram       => i,
+        :is_public => i.even?,
+        :disk      => i,
+        :swap      => i,
+        :ephemeral => i
+      )
+    end
+    mocked_flavors
+  end
+
+  def mocked_host_aggregates
+    mocked_host_aggregates = []
+    test_counts[:host_aggregates_count].times do |i|
+      mocked_host_aggregates << OpenStruct.new(
+        :id       => i,
+        :name     => "host_aggregate_#{i}",
+        :ems_ref  => i,
+        :hosts    => [],
+        :metadata => "host_aggregate_metadata_#{i}"
+      )
+    end
+    mocked_host_aggregates
+  end
+
+  def mocked_key_pairs
+    mocked_key_pairs = []
+    test_counts[:key_pairs_count].times do |i|
+      mocked_key_pairs << OpenStruct.new(
+        :name        => "key_pair_#{i}",
+        :fingerprint => "key_pair_fingerprint_#{i}"
+      )
+    end
+    mocked_key_pairs
+  end
+
+  def mocked_quotas
+    mocked_quotas = []
+    test_counts[:quotas_count].times do |i|
+      mocked_quotas << {
+        :id           => i,
+        :tenant_id    => i,
+        :service_name => "compute",
+        :quota_key_1  => "quota_value_1",
+        :quota_key_2  => "quota_value_2"
+      }
+    end
+    mocked_quotas
+  end
+
+  def mocked_miq_templates
+    mocked_miq_templates = []
+    test_counts[:miq_templates_count].times do |i|
+      mocked_miq_templates << OpenStruct.new(
+        :id          => "image_#{i}",
+        :name        => "miq_template_#{i}",
+        :owner       => i,
+        :min_disk    => i,
+        :min_ram     => i,
+        :size        => i,
+        :disk_format => "ext2",
+        :is_public   => true,
+        :visibility  => "public",
+        :properties  => {'architecture' => '64'},
+        :attributes  => {}
+      )
+    end
+    mocked_miq_templates
+  end
+
+  def mocked_orchestration_stacks
+    mocked_orchestration_stacks = []
+    test_counts[:orchestration_stacks_count].times do |i|
+      mocked_orchestration_stacks << OpenStruct.new(
+        :id                  => i,
+        :stack_name          => "orchestration_stack_#{i}",
+        :description         => "orchestration_stack_description_#{i}",
+        :stack_status        => "orchestration_stack_status_#{i}",
+        :stack_status_reason => "orchestration_stack_status_reason_#{i}",
+        :parent              => nil,
+        :service             => OpenStruct.new(:current_tenant => {:id => i}),
+        :template            => OpenStruct.new(
+          :id          => i,
+          :description => "orchestration_template_description_#{i}",
+          :content     => "orchestration_template_content_#{i}",
+          :format      => "HOT"
+        ),
+        :outputs             => [{
+          'output_key'   => "output_key_#{i}",
+          'output_value' => "output_value_#{i}",
+          'description'  => "output_description_#{i}"
+        }],
+        :parameters          => [{
+          "parameter_#{i}" => "key_#{i}"
+        }],
+        :resources           => [OpenStruct.new(
+          :physical_resource_id   => "vm_#{i}",
+          :logical_resource_id    => "logical_resource_#{i}",
+          :resource_type          => "resource_type_#{i}",
+          :resource_Status        => "resource_status_#{i}",
+          :resource_status_reason => "resource_status_reason_#{i}",
+          :updated_time           => nil
+        )]
+      )
+    end
+    mocked_orchestration_stacks
+  end
+
+  def mocked_vnfs
+    mocked_vnfs = []
+    test_counts[:vnfs_count].times do |i|
+      mocked_vnfs << OpenStruct.new(
+        :id          => i,
+        :name        => "vnf_#{i}",
+        :description => "vnf_description_#{i}",
+        :status      => "vnf_status_#{i}",
+        :tenant_id   => i,
+        :mgmt_url    => "vnf_mgmt_url_#{i}"
+      )
+    end
+    mocked_vnfs
+  end
+
+  def mocked_vnfds
+    mocked_vnfds = []
+    test_counts[:vnfds_count].times do |i|
+      mocked_vnfds << OpenStruct.new(
+        :id             => i,
+        :name           => "vnfd_#{i}",
+        :description    => "vnfd_description_#{i}",
+        :vnf_attributes => {"vnfd" => "vnfd_content_#{i}"}
+      )
+    end
+    mocked_vnfds
+  end
+
+  def mocked_vms
+    mocked_vms = []
+    test_counts[:vms_count].times do |i|
+      mocked_vms << OpenStruct.new(
+        :id                 => "vm_#{i}",
+        :name               => "vm_#{i}",
+        :state              => "vm_state_#{i}",
+        :image              => {"id" => i},
+        :flavor             => {"id" => i},
+        :availability_zone  => "nova",
+        :private_ip_address => '10.10.10.1',
+        :public_ip_address  => '172.1.1.2'
+      )
+    end
+    mocked_vms
+  end
+end


### PR DESCRIPTION
This is a set of tests for the inventory refresher with stubbed out calls that do not rely on the presence of a VCR. This is able to catch some stuff the current refreshers specs don't catch, like incorrectly setup relationships between different objects.