### PR TITLE
Fix snapshot of VM without an EMS being supported

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/snapshot.rb
@@ -2,7 +2,11 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Snapshot
   extend ActiveSupport::Concern
 
   included do
-    supports :snapshot_create
+    supports :snapshot_create do
+      unless supports_control?
+        unsupported_reason_add(:snapshot_create, unsupported_reason(:control))
+      end
+    end
 
     supports :remove_snapshot do
       if supports_snapshots?

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -9,6 +9,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
                        :cloud_tenant          => tenant)
   end
 
+  let(:archived_vm) { FactoryGirl.create(:vm_openstack) }
+
   let(:handle) do
     double.tap do |handle|
       allow(ems).to receive(:connect).with(:service => 'Compute', :tenant_name => tenant.name).and_return(handle)
@@ -138,6 +140,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     context "snapshot actions" do
       it "supports snapshot_create" do
         expect(vm.supports_snapshot_create?).to eq true
+      end
+
+      it "does not support snapshot_create on archived VM" do
+        expect(archived_vm.supports_snapshot_create?).to be_falsy
       end
 
       it "checks remove_snapshot is_available? when snapshots are associated with the instance" do


### PR DESCRIPTION
`supports_control?` catches a number of cases where we do not want to support snapshots:
https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template/operations.rb#L90-L104
This was causing travis failures on `ManageIQ/manageiq`: https://travis-ci.org/ManageIQ/manageiq/jobs/225161421#L639-L648

https://bugzilla.redhat.com/show_bug.cgi?id=1443446