### PR TITLE
Change Openstack::InfraManager model to use real model for subclass

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
+class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraManager
   require_nested :AuthKeyPair
   require_nested :EmsCluster
   require_nested :EventCatcher


### PR DESCRIPTION
The Openstack::InfraManager model was using [alias EmsInfra](https://github.com/ManageIQ/manageiq/blob/master/app/models/aliases/ems_infra.rb) instead of the real subclass `ManageIQ::Providers::InfraManager`

Found while debugging issue https://github.com/ManageIQ/manageiq-automation_engine/issues/20 which is fixed by a similar change to the service model https://github.com/ManageIQ/manageiq-automation_engine/pull/22.