### PR TITLE
Adds security group tests

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -34,7 +34,6 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     ext_management_system.with_provider_connection(connection_options(cloud_tenant)) do |service|
       security_group = service.create_security_group(options).body
     end
-    {:ems_ref => security_group['id'], :name => options[:name]}
   rescue => e
     _log.error "security_group=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqSecurityGroupCreateError, e.to_s, e.backtrace

--- a/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
@@ -1,0 +1,100 @@
+describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:ems_network) { ems.network_manager }
+  let(:security_group) do
+    FactoryGirl.create(:security_group_with_firewall_rules_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test',
+                       :ems_ref               => 'one_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:service) do
+    service = double("Fog service")
+    service
+  end
+
+  let(:raw_security_group) do
+    raw_security_group = double("security group")
+    allow(raw_security_group).to receive(:id).and_return('one_id')
+    allow(raw_security_group).to receive(:status).and_return('available')
+    allow(raw_security_group).to receive(:attributes).and_return({})
+    raw_security_group
+  end
+
+  let(:raw_security_groups) do
+    raw_security_groups = double("security groups")
+    allow(ExtManagementSystem).to receive(:find).with(ems_network.id).and_return(ems_network)
+    allow(ems_network.parent_manager).to receive(:connect)
+      .with(hash_including(:service => 'Network', :tenant_name => tenant.name)).and_return(service)
+    raw_security_groups
+  end
+
+  before do
+    raw_security_groups
+  end
+
+  describe 'security group actions' do
+    context ".create" do
+      let(:the_new_security_group) { {:name => "test", :description => "Test" } }
+      let(:security_group_options) { {:cloud_tenant => tenant, :name => "test", :description => "Test"} }
+
+      it 'creates a security group' do
+        expect(service).to receive_message_chain(:create_security_group, :body).and_return(the_new_security_group)
+
+        sg = ems_network.create_security_group(security_group_options)
+        expect(sg.class).to         eq Hash
+        expect(sg[:name]).to        eq 'test'
+        expect(sg[:description]).to eq 'Test'
+      end
+
+      it "raises an error when the ems is missing" do
+        expect { ems_network.create_security_group(nil) }.to raise_error(NoMethodError)
+      end
+
+      it 'catches errors from provider' do
+        expect(service).to receive(:create_security_group).and_raise('bad request')
+        expect do
+          ems_network.create_security_group(security_group_options)
+        end.to raise_error(MiqException::MiqSecurityGroupCreateError)
+      end
+    end
+
+    context "#update_security_group" do
+      it 'updates the security_group' do
+        security_group_options = {:description => "Test 2"}
+
+        expect(service).to receive(:update_security_group).with(security_group[:ems_ref], security_group_options)
+        security_group.raw_update_security_group(security_group_options)
+      end
+
+      it 'catches errors from provider' do
+        expect(service).to receive(:update_security_group).and_raise('bad request')
+        expect { security_group.raw_update_security_group({}) }.to raise_error(MiqException::MiqSecurityGroupUpdateError)
+      end
+
+      it 'updates the security_group_rule' do
+        sg_rule_options = { "host_protocol" => "TCP" }
+
+        expect(service).to receive(:delete_security_group_rule).with("security_group_rule_id")
+        expect(service).to receive(:create_security_group_rule).with(security_group.id, "egress", sg_rule_options)
+
+        security_group.raw_delete_security_group_rule("security_group_rule_id")
+        security_group.raw_create_security_group_rule(security_group.id, "outbound", sg_rule_options)
+      end
+    end
+
+    context "#delete_security_group" do
+      it 'deletes the security_group' do
+        expect(service).to receive(:delete_security_group)
+        security_group.raw_delete_security_group
+      end
+
+      it 'catches errors from provider' do
+        expect(service).to receive(:delete_security_group).and_raise('bad request')
+        expect { security_group.raw_delete_security_group }.to raise_error(MiqException::MiqSecurityGroupDeleteError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `spec/models/manageiq/providers/openstack/network_manager/`
Adds security groups spec file with security group and firewall rules CRUD.
