### PR TITLE
Implement Openstack Swift/Cinder Graph Refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/cinder_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::CinderManager < ManageIQ::Providers::StorageManager::CinderManager
+end

--- a/app/models/manageiq/providers/openstack/cinder_manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/cinder_manager_mixin.rb
@@ -1,0 +1,20 @@
+module ManageIQ::Providers::Openstack::CinderManagerMixin
+  extend ActiveSupport::Concern
+  include ::CinderManagerMixin
+
+  included do
+    # TODO: how about many storage managers???
+    # Should use has_many :storage_managers,
+    has_one  :cinder_manager,
+             :foreign_key => :parent_ems_id,
+             :class_name  => "ManageIQ::Providers::Openstack::CinderManager",
+             :autosave    => true,
+             :dependent   => :destroy
+
+    delegate :cloud_volumes,
+             :cloud_volume_snapshots,
+             :cloud_volume_backups,
+             :to        => :cinder_manager,
+             :allow_nil => true
+  end
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -29,8 +29,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
            :autosave    => true,
            :dependent   => :destroy
 
-  include CinderManagerMixin
-  include SwiftManagerMixin
+  include ManageIQ::Providers::Openstack::CinderManagerMixin
+  include ManageIQ::Providers::Openstack::SwiftManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
 
   supports :provisioning
@@ -75,13 +75,13 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def ensure_cinder_manager
     return false if cinder_manager
-    build_cinder_manager(:type => 'ManageIQ::Providers::StorageManager::CinderManager')
+    build_cinder_manager(:type => 'ManageIQ::Providers::Openstack::CinderManager')
     true
   end
 
   def ensure_swift_manager
     return false if swift_manager
-    build_swift_manager(:type => 'ManageIQ::Providers::StorageManager::SwiftManager')
+    build_swift_manager(:type => 'ManageIQ::Providers::Openstack::SwiftManager')
     true
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/collector/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cinder_manager.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Openstack::Inventory::Collector::CinderManager < ManagerRefresh::Inventory::Collector
+  def cinder_service
+    @os_handle ||= manager.parent_manager.openstack_handle
+    @cinder_service ||= manager.parent_manager.cinder_service
+  end
+
+  def volumes
+    @volumes ||= cinder_service.handled_list(:volumes)
+  end
+
+  def snapshots
+    @snapshots ||= cinder_service.handled_list(:list_snapshots_detailed, :__request_body_index => "snapshots")
+  end
+
+  def backups
+    @backups ||= cinder_service.list_backups_detailed.body["backups"]
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/collector/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/swift_manager.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Openstack::Inventory::Collector::SwiftManager < ManagerRefresh::Inventory::Collector
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::HelperMethods
+  include Vmdb::Logging
+
+  def swift_service
+    @os_handle ||= manager.parent_manager.openstack_handle
+    @swift_service ||= manager.parent_manager.swift_service
+  end
+
+  def object_store_containers
+    @object_store_containers ||= swift_service.handled_list(:directories)
+  end
+
+  def object_store_objects(container)
+    safe_list { container.files }
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cinder_manager.rb
@@ -1,0 +1,94 @@
+class ManageIQ::Providers::Openstack::Inventory::Parser::CinderManager < ManagerRefresh::Inventory::Parser
+  def parse
+    volumes
+    snapshots
+    backups
+  end
+
+  def volumes
+    collector.volumes.each do |v|
+      volume = persister.cloud_volumes.find_or_build(v.id)
+      volume.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+      volume.name = volume_name(v)
+      volume.status = v.status
+      volume.bootable = v.attributes['bootable']
+      volume.creation_time = v.created_at
+      volume.description = volume_description(v)
+      volume.volume_type = v.volume_type
+      volume.size = v.size.to_i.gigabytes
+      volume.base_snapshot = persister.cloud_volume_snapshots.lazy_find(v.snapshot_id)
+      volume.cloud_tenant = persister.cloud_tenants.lazy_find(v.tenant_id)
+      volume.availability_zone = persister.availability_zones.lazy_find(v.availability_zone || "null_az")
+
+      volume_attachments(volume, v.attachments)
+    end
+  end
+
+  def snapshots
+    collector.snapshots.each do |s|
+      snapshot = persister.cloud_volume_snapshots.find_or_build(s['id'])
+      snapshot.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
+      snapshot.creation_time = s['created_at']
+      snapshot.status = s['status']
+      snapshot.size = s['size'].to_i.gigabytes
+      # Supporting both Cinder v1 and Cinder v2
+      snapshot.name = s['display_name'] || s['name']
+      snapshot.description = s['display_description'] || s['description']
+      snapshot.cloud_volume = persister.cloud_volumes.lazy_find(s['volume_id'])
+      snapshot.cloud_tenant = persister.cloud_tenants.lazy_find(s['os-extended-snapshot-attributes:project_id'])
+    end
+  end
+
+  def backups
+    collector.backups.each do |b|
+      backup = persister.cloud_volume_backups.find_or_build(b['id'])
+      backup.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+      backup.status = b['status']
+      backup.creation_time = b['create_at']
+      backup.size = b['size'].to_i.gigabytes
+      backup.object_count = b['object_count'].to_i
+      backup.is_incremental = b['is_incremental']
+      backup.has_dependent_backups = b['has_dependent_backups']
+      # Supporting both Cinder v1 and Cinder v2
+      backup.name = b['display_name'] || b['name']
+      backup.description = b['display_description'] || b['description']
+      backup.cloud_volume = persister.cloud_volumes.lazy_find(b['volume_id'])
+      backup.availability_zone = persister.availability_zones.lazy_find(b['availability_zone'] || "null_az")
+    end
+  end
+
+  def volume_attachments(persister_volume, attachments)
+    (attachments || []).each do |a|
+      if a['device'].blank?
+        log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{ems.name}] id: [#{ems.id}]"
+        _log.warn "#{log_header}: Volume: #{persister_volume.ems_ref}, is missing a mountpoint, skipping the volume processing"
+        _log.warn "#{log_header}: EMS: #{ems.name}, Instance: #{a['server_id']}"
+        next
+      end
+
+      dev = File.basename(a['device'])
+
+      persister.disks.find_or_build_by(
+        # FIXME: find works here, but lazy_find doesn't... I don't understand why
+        :hardware    => persister.hardwares.find(a["server_id"]),
+        :device_name => dev
+      ).assign_attributes(
+        :location        => dev,
+        :size            => persister_volume.size,
+        :device_type     => "disk",
+        :controller_type => "openstack",
+        :backing         => persister_volume
+      )
+    end
+  end
+
+  def volume_name(volume)
+    # Cinder v1 : Cinder v2
+    volume.respond_to?(:display_name) ? volume.display_name : volume.name
+  end
+
+  def volume_description(volume)
+    # Cinder v1 : Cinder v2
+    volume.respond_to?(:display_description) ? volume.display_description : volume.description
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -310,14 +310,14 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManagerR
       if (root_size = flavor.try(:disk).to_i.gigabytes).zero?
         root_size = 1.gigabytes
       end
-      make_instance_disk(hardware, root_size, disk_location.dup, "Root disk")
+      make_instance_disk(hardware, root_size, disk_location.dup)
       ephemeral_size = flavor.try(:ephemeral).to_i.gigabytes
       unless ephemeral_size.zero?
-        make_instance_disk(hardware, ephemeral_size, disk_location.succ!.dup, "Ephemeral disk")
+        make_instance_disk(hardware, ephemeral_size, disk_location.succ!.dup)
       end
       swap_size = flavor.try(:swap).to_i.megabytes
       unless swap_size.zero?
-        make_instance_disk(hardware, swap_size, disk_location.succ!.dup, "Swap disk")
+        make_instance_disk(hardware, swap_size, disk_location.succ!.dup)
       end
     end
   end
@@ -349,12 +349,12 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManagerR
     end
   end
 
-  def make_instance_disk(hardware, size, location, name)
+  def make_instance_disk(hardware, size, location)
     disk = persister.disks.find_or_build_by(
       :hardware    => hardware,
-      :device_name => name
+      :device_name => location
     )
-    disk.device_name = name
+    disk.device_name = location
     disk.device_type = "disk"
     disk.controller_type = "openstack"
     disk.size = size

--- a/app/models/manageiq/providers/openstack/inventory/parser/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/swift_manager.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Openstack::Inventory::Parser::SwiftManager < ManagerRefresh::Inventory::Parser
+  def parse
+    containers
+  end
+
+  def containers
+    collector.object_store_containers.each do |c|
+      container = persister.cloud_object_store_containers.find_or_build("#{c.project.id}/#{c.key}")
+      container.key = c.key
+      container.object_count = c.count
+      container.bytes = c.bytes
+      container.cloud_tenant = persister.cloud_tenants.lazy_find(c.project.id)
+
+      collector.object_store_objects(c).each do |o|
+        object = persister.cloud_object_store_objects.find_or_build(o.key)
+        object.etag = o.etag
+        object.last_modified = o.last_modified
+        object.content_length = o.content_length
+        object.key = o.key
+        object.content_type = o.content_type
+        object.cloud_object_store_container = container
+        object.cloud_tenant = persister.cloud_tenants.lazy_find(c.project.id)
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/cinder_manager.rb
@@ -1,0 +1,35 @@
+class ManageIQ::Providers::Openstack::Inventory::Persister::CinderManager < ManagerRefresh::Inventory::Persister
+  def cinder
+    ManageIQ::Providers::Openstack::InventoryCollectionDefault::CinderManager
+  end
+
+  def cloud
+    ManageIQ::Providers::Openstack::InventoryCollectionDefault::CloudManager
+  end
+
+  def initialize_inventory_collections
+    add_inventory_collections(cinder,
+                              %i(
+                                cloud_volumes
+                                cloud_volume_snapshots
+                                cloud_volume_backups
+                              ),
+                              :builder_params => {:ext_management_system => manager})
+
+    add_inventory_collections(cloud,
+                              %i(
+                                availability_zones
+                                hardwares
+                                cloud_tenants
+                              ),
+                              :parent   => manager.parent_manager,
+                              :strategy => :local_db_find_references)
+
+    add_inventory_collections(cloud,
+                              %i(
+                                disks
+                              ),
+                              :parent   => manager.parent_manager,
+                              :complete => false)
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/swift_manager.rb
@@ -1,0 +1,25 @@
+class ManageIQ::Providers::Openstack::Inventory::Persister::SwiftManager < ManagerRefresh::Inventory::Persister
+  def swift
+    ManageIQ::Providers::Openstack::InventoryCollectionDefault::SwiftManager
+  end
+
+  def cloud
+    ManageIQ::Providers::Openstack::InventoryCollectionDefault::CloudManager
+  end
+
+  def initialize_inventory_collections
+    add_inventory_collections(swift,
+                              %i(
+                                cloud_object_store_containers
+                                cloud_object_store_objects
+                              ),
+                              :builder_params => {:ext_management_system => manager})
+
+    add_inventory_collections(cloud,
+                              %i(
+                                cloud_tenants
+                              ),
+                              :parent   => manager.parent_manager,
+                              :strategy => :local_db_cache_all)
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory_collection_default/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory_collection_default/cinder_manager.rb
@@ -1,0 +1,65 @@
+class ManageIQ::Providers::Openstack::InventoryCollectionDefault::CinderManager < ManagerRefresh::InventoryCollectionDefault::StorageManager
+  class << self
+    def cloud_volume_backups(extra_attributes = {})
+      attributes = {
+        :model_class                 => ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup,
+        :association                 => :cloud_volume_backups,
+        :inventory_object_attributes => [
+          :type,
+          :ems_ref,
+          :status,
+          :creation_time,
+          :size,
+          :object_count,
+          :is_incremental,
+          :has_dependent_backups,
+          :name,
+          :description,
+          :cloud_volume,
+          :availability_zone
+        ]
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def cloud_volume_snapshots(extra_attributes = {})
+      attributes = {
+        :model_class                 => ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot,
+        :inventory_object_attributes => [
+          :type,
+          :ems_ref,
+          :status,
+          :creation_time,
+          :size,
+          :name,
+          :description,
+          :cloud_volume,
+          :cloud_tenant
+        ]
+      }
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def cloud_volumes(extra_attributes = {})
+      attributes = {
+        :model_class                 => ManageIQ::Providers::Openstack::CloudManager::CloudVolume,
+        :inventory_object_attributes => [
+          :type,
+          :ems_ref,
+          :status,
+          :bootable,
+          :volume_type,
+          :creation_time,
+          :size,
+          :name,
+          :description,
+          :base_snapshot,
+          :availability_zone,
+          :cloud_tenant
+        ]
+      }
+      super(attributes.merge!(extra_attributes))
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory_collection_default/cloud_manager.rb
@@ -71,7 +71,9 @@ class ManageIQ::Providers::Openstack::InventoryCollectionDefault::CloudManager <
           :device_type,
           :controller_type,
           :size,
-          :location
+          :location,
+          :backing,
+          :hardware
         ]
       }
       super(attributes.merge!(extra_attributes))

--- a/app/models/manageiq/providers/openstack/inventory_collection_default/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory_collection_default/swift_manager.rb
@@ -1,0 +1,34 @@
+class ManageIQ::Providers::Openstack::InventoryCollectionDefault::SwiftManager < ManagerRefresh::InventoryCollectionDefault::StorageManager
+  class << self
+    def cloud_object_store_containers(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::CloudObjectStoreContainer,
+        :inventory_object_attributes => [
+          :key,
+          :object_count,
+          :bytes,
+          :cloud_tenant
+        ]
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def cloud_object_store_objects(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::CloudObjectStoreObject,
+        :inventory_object_attributes => [
+          :etag,
+          :last_modified,
+          :content_length,
+          :key,
+          :content_type,
+          :cloud_object_store_container,
+          :cloud_tenant
+        ]
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/swift_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::SwiftManager < ManageIQ::Providers::StorageManager::SwiftManager
+end

--- a/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::Openstack::SwiftManagerMixin
+  extend ActiveSupport::Concern
+  include ::SwiftManagerMixin
+
+  included do
+    has_one  :swift_manager,
+             :foreign_key => :parent_ems_id,
+             :class_name  => "ManageIQ::Providers::Openstack::SwiftManager",
+             :autosave    => true,
+             :dependent   => :destroy
+
+    delegate :cloud_object_store_containers,
+             :cloud_object_store_objects,
+             :to        => :swift_manager,
+             :allow_nil => true
+  end
+end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -787,21 +787,24 @@ module Openstack
       # TODO(lsmola) the flavor disk data should be stored in Flavor model, getting it from test data now
       flavor_expected = compute_data.flavors.detect { |x| x[:name] == vm.flavor.name }
 
-      disk = vm.hardware.disks.find_by_device_name("Root disk")
+      disk = vm.hardware.disks.find_by(:device_name => "vda")
       expect(disk).to have_attributes(
-        :device_name => "Root disk",
+        :device_name => "vda",
+        :location    => "vda",
         :device_type => "disk",
         :size        => flavor_expected[:disk].gigabyte
       )
-      disk = vm.hardware.disks.find_by_device_name("Ephemeral disk")
+      disk = vm.hardware.disks.find_by(:device_name => "vdb")
       expect(disk).to have_attributes(
-        :device_name => "Ephemeral disk",
+        :device_name => "vdb",
+        :location    => "vdb",
         :device_type => "disk",
         :size        => flavor_expected[:ephemeral].gigabyte
       )
-      disk = vm.hardware.disks.find_by_device_name("Swap disk")
+      disk = vm.hardware.disks.find_by(:device_name => "vdc")
       expect(disk).to have_attributes(
-        :device_name => "Swap disk",
+        :device_name => "vdc",
+        :location    => "vdc",
         :device_type => "disk",
         :size        => flavor_expected[:swap].megabytes
       )


### PR DESCRIPTION
This PR implements graph refresh for Swift and Cinder. It sidesteps the issue of Cinder and Swift living in the core repo but needing Openstack specific refresher implementation by subclassing those managers.