### PR TITLE
Edit delete method for Cloud Subnet

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -53,7 +53,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'raw_delete_cloud_subnet',
+      :method_name => 'delete_cloud_subnet',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',


### PR DESCRIPTION
Changed `delete_cloud_subnet_queue` method's body to call `delete_cloud_subnet` directly instead of `raw_`.
https://github.com/ManageIQ/manageiq/pull/15087
https://github.com/ManageIQ/manageiq-ui-classic/pull/1347 