### PR TITLE
Vcr recorder rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ See the section on pluggable providers in the [ManageIQ Developer Setup](http://
 
 For quick local setup run `bin/setup`, which will clone the core ManageIQ repository under the *spec* directory and setup necessary config files. If you have already cloned it, you can run `bin/update` to bring the core ManageIQ code up to date.
 
+### VCR cassettes re-recording
+
+You will need testing OpenStack environment(s) and `openstack_environments.yml` file with credentials in format like:
+```yml
+---
+- test_env_1:
+    ip: 11.22.33.44
+    password: long_password_1
+    user: admin_1
+- test_env_2:
+    ip: 11.22.33.55
+    password: long_password_2
+    user: admin_2
+```
+
+Then you can run `bundle exec rake app:manageiq:providers:openstack:vcr:rerecord` and following will happen:
+* Current VCR cassettes files will be deleted
+* Credentials from `openstack_environments.yml` file will be injected into spec files
+* Specs needed for re-recording of VCR cassettes will be run. During this step manageiq will call OpenStack APIs at specified endpoints
+* Credentials present in spec files and VCR cassettes will be changed to dummy data so tests can run from VCR cassettes
+
 ## License
 
 The gem is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/lib/tasks/openstack.rake
+++ b/lib/tasks/openstack.rake
@@ -1,10 +1,20 @@
-#namespace :manageiq do
-#  namespace :providers do
-#    namespace :openstack do
-#      desc "Explaining what the task does"
-#      task :your_task do
-#        # Task goes here
-#      end
-#    end
-#  end
-#end
+require 'vcr_recorder'
+
+namespace :manageiq do
+  namespace :providers do
+    namespace :openstack do
+      namespace :vcr do
+        namespace :credentials do
+          desc 'Load credentials from openstack_environments.yml'
+          task :load do
+            VcrRecorder.new.load_credentials
+          end
+          desc 'Obfuscate real credentials from specs and cassettes'
+          task :obfuscate do
+            VcrRecorder.new.obfuscate_credentials
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/openstack.rake
+++ b/lib/tasks/openstack.rake
@@ -29,6 +29,14 @@ namespace :manageiq do
             Rake::Task['spec'].invoke
           end
         end
+
+        desc 'Rerecord all of VCR cassettes'
+        task :rerecord => [] do
+          Rake::Task['app:manageiq:providers:openstack:vcr:cassettes:delete'].invoke
+          Rake::Task['app:manageiq:providers:openstack:vcr:credentials:load'].invoke
+          Rake::Task['app:manageiq:providers:openstack:vcr:spec:run'].invoke
+          Rake::Task['app:manageiq:providers:openstack:vcr:credentials:obfuscate'].invoke
+        end
       end
     end
   end

--- a/lib/tasks/openstack.rake
+++ b/lib/tasks/openstack.rake
@@ -14,6 +14,13 @@ namespace :manageiq do
             VcrRecorder.new.obfuscate_credentials
           end
         end
+
+        namespace :cassettes do
+          desc 'Deletes VCR cassettes for OpenStack Cloud Provider'
+          task :delete do
+            VcrRecorder.new.delete_cassettes
+          end
+        end
       end
     end
   end

--- a/lib/tasks/openstack.rake
+++ b/lib/tasks/openstack.rake
@@ -21,6 +21,14 @@ namespace :manageiq do
             VcrRecorder.new.delete_cassettes
           end
         end
+
+        namespace :spec do
+          desc 'Run specs needed for rerecording of VCRs'
+          task :run do
+            ENV['SPEC'] = VcrRecorder.new.test_files.join(' ')
+            Rake::Task['spec'].invoke
+          end
+        end
       end
     end
   end

--- a/lib/vcr_recorder.rb
+++ b/lib/vcr_recorder.rb
@@ -18,6 +18,10 @@ class VcrRecorder
     File.join(base_dir, 'spec/models/manageiq/providers/openstack/cloud_manager')
   end
 
+  def test_files
+    Dir.glob(File.join(test_base_dir, 'refresher_*_spec.rb'))
+  end
+
   def openstack_environment_file
     File.join(base_dir, "openstack_environments.yml")
   end

--- a/lib/vcr_recorder.rb
+++ b/lib/vcr_recorder.rb
@@ -10,6 +10,10 @@ class VcrRecorder
     File.join(base_dir, 'spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager')
   end
 
+  def vcr_files
+    Dir.glob(File.join(vcr_base_dir, 'refresher_rhos_*.yml'))
+  end
+
   def test_base_dir
     File.join(base_dir, 'spec/models/manageiq/providers/openstack/cloud_manager')
   end
@@ -69,4 +73,11 @@ class VcrRecorder
       out << file
     end
   end
+
+  def delete_cassettes
+    vcr_files.each do |file|
+      File.delete(file)
+    end
+  end
+
 end

--- a/lib/vcr_recorder.rb
+++ b/lib/vcr_recorder.rb
@@ -1,0 +1,72 @@
+class VcrRecorder
+  OBFUSCATED_PASSWORD = "password_2WpEraURh"
+  OBFUSCATED_IP = "11.22.33.44"
+
+  def base_dir
+    Rake.application.original_dir
+  end
+
+  def vcr_base_dir
+    File.join(base_dir, 'spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager')
+  end
+
+  def test_base_dir
+    File.join(base_dir, 'spec/models/manageiq/providers/openstack/cloud_manager')
+  end
+
+  def openstack_environment_file
+    File.join(base_dir, "openstack_environments.yml")
+  end
+
+  def openstack_environments
+    @openstack_environments ||= YAML.load_file(openstack_environment_file)
+  end
+
+  def load_credentials
+    openstack_environments.each do |env|
+      env_name = env.keys.first
+      env      = env[env_name]
+
+      puts "-------------------------------------------------------------------------------------------------------------"
+      puts "Loading enviroment credentials for #{env_name}"
+      file_name = File.join(test_base_dir, "refresher_rhos_#{env_name}_spec.rb")
+      change_file(file_name, OBFUSCATED_PASSWORD, env["password"], OBFUSCATED_IP, env["ip"])
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_with_errors.yml")
+      change_file(file_name, OBFUSCATED_PASSWORD, env["password"], OBFUSCATED_IP, env["ip"])
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}.yml")
+      change_file(file_name, OBFUSCATED_PASSWORD, env["password"], OBFUSCATED_IP, env["ip"])
+    end
+  end
+
+  def obfuscate_credentials
+    openstack_environments.each do |env|
+      env_name = env.keys.first
+      env      = env[env_name]
+
+      puts "-------------------------------------------------------------------------------------------------------------"
+      puts "Obfuscating enviroment credentials for #{env_name}"
+      file_name = File.join(test_base_dir, "refresher_rhos_#{env_name}_spec.rb")
+      change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_with_errors.yml")
+      change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}.yml")
+      change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
+    end
+  end
+
+  def change_file(file_name, from_password, to_password, from_ip, to_ip)
+    return unless File.exist?(file_name)
+
+    file = File.read(file_name)
+    file.gsub!(from_password, to_password)
+    file.gsub!(from_ip, to_ip)
+
+    File.open(file_name, 'w') do |out|
+      out << file
+    end
+  end
+end


### PR DESCRIPTION
This allows developers to use one rake task `bundle exec rake app:manageiq:providers:openstack:vcr:rerecord` to re-record VCR cassettes.