### PR TITLE
Edit update method for cloud subnet

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -53,7 +53,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'raw_delete_cloud_subnet',
+      :method_name => 'delete_cloud_subnet',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -79,7 +79,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'raw_update_cloud_subnet',
+      :method_name => 'update_cloud_subnet',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',


### PR DESCRIPTION
Changed `update_cloud_subnet_queue` method's body to call `update_cloud_subnet` directly instead of `raw_`
Depends on https://github.com/ManageIQ/manageiq/pull/15192
