### PR TITLE
Fix Ceilometer Event Monitor sync calls

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Openstack::CloudManager::EventCatcher < ::MiqEventCat
   def self.all_valid_ems_in_zone
     require 'openstack/openstack_event_monitor'
     super.select do |ems|
-      ems.event_monitor_available?.tap do |available|
+      ems.sync_event_monitor_available?.tap do |available|
         _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
       end
     end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCat
   def self.all_valid_ems_in_zone
     require 'openstack/openstack_event_monitor'
     super.select do |ems|
-      ems.event_monitor_available?.tap do |available|
+      ems.sync_event_monitor_available?.tap do |available|
         _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
       end
     end

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -104,6 +104,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     false
   end
 
+  def sync_event_monitor_available?
+    event_monitor_options[:events_monitor] == :ceilometer ? authentication_status_ok? : event_monitor_available?
+  end
+
   def stop_event_monitor_queue_on_change
     if event_monitor_class && !self.new_record? && (authentications.detect{ |x| x.previous_changes.present? } ||
                                                     endpoints.detect{ |x| x.previous_changes.present? })

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher < ::MiqEventC
   def self.all_valid_ems_in_zone
     require 'openstack/openstack_event_monitor'
     super.select do |ems|
-      ems.event_monitor_available?.tap do |available|
+      ems.sync_event_monitor_available?.tap do |available|
         _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
       end
     end


### PR DESCRIPTION
MiqServer syncs processes each 15 seconds by default. This results into calling
available? method on event monitor. This was useful for AMQP subscriptions, but
it is not needed for Ceilometer and causes creating a lot of Keystone Auth tokens
on Openstack side.

This commit changes a method which is used for syncing event workers to verify
auth status on provider for Ceilometer and keeps original behavior for AMQP.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1451122