### PR TITLE
Add missing deps from gems-pending repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,8 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
+# We are using 'miq-module' from gems-pending
+gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
+
 # Load Gemfile with dependencies from manageiq
 eval_gemfile(File.expand_path("spec/manageiq/Gemfile", __dir__))

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,9 +13,11 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "excon",         "~>0.40"
-  s.add_runtime_dependency "fog-openstack", "=0.1.20"
-  s.add_runtime_dependency "bunny",         "~>2.1.0"
+  s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.1"
+  s.add_runtime_dependency "bunny",                "~>2.1.0"
+  s.add_runtime_dependency "excon",                "~>0.40"
+  s.add_runtime_dependency "fog-openstack",        "=0.1.20"
+  s.add_runtime_dependency "more_core_extensions", "~>3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Adding runtime dependencies forgotten in import code from manageiq-gems-pending repo.

Required to get https://github.com/ManageIQ/manageiq-gems-pending/pull/119 in.