### PR TITLE
Fix spec helper AMQP stub method

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,11 @@ VCR.configure do |config|
 end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
+
+module EvmSpecHelper
+  def self.stub_amqp_support
+    require 'openstack/events/openstack_rabbit_event_monitor'
+    allow(OpenstackRabbitEventMonitor).to receive(:available?).and_return(true)
+    allow(OpenstackRabbitEventMonitor).to receive(:test_connection).and_return(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 
 module EvmSpecHelper
   def self.stub_amqp_support
-    require 'openstack/events/openstack_rabbit_event_monitor'
+    require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
     allow(OpenstackRabbitEventMonitor).to receive(:available?).and_return(true)
     allow(OpenstackRabbitEventMonitor).to receive(:test_connection).and_return(true)
   end


### PR DESCRIPTION
Spec helper from main repo contain code for AMQP stub, which is Openstack specific.

Moving to openstack provider repo and updating require path.