### PR TITLE
Optimize Openstack Event Monitor code

### DIFF
--- a/spec/legacy/events/openstack_ceilometer_event_monitor_spec.rb
+++ b/spec/legacy/events/openstack_ceilometer_event_monitor_spec.rb
@@ -1,6 +1,10 @@
 require 'manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor'
 
+class Fog::Event::OpenStack::Event; end
+
 describe OpenstackCeilometerEventMonitor do
+  subject { OpenstackCeilometerEventMonitor.new(:ems => double(:connect => double)) }
+
   context "collecting events" do
     it 'query ceilometer nothing new' do
       connection = double


### PR DESCRIPTION
Refactor Openstack Event Monitor to have better code with less
duplication and create slightly less connections to OpenStack.

This PR was moved from manageiq-gems-pending repo PR https://github.com/ManageIQ/manageiq-gems-pending/pull/160.

Related to BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1442422