### PR TITLE
allow raw_connect to accept encrypted passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-# We are using 'miq-module' from gems-pending
+# We are using 'miq-module' and 'miq-password' from gems-pending
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
 # Load Gemfile with dependencies from manageiq

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -13,7 +13,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   module ClassMethods
     def raw_connect(username, password, auth_url, service = "Compute")
       require 'manageiq/providers/openstack/legacy/openstack_handle'
-      OpenstackHandle::Handle.raw_connect(username, password, auth_url, service)
+      OpenstackHandle::Handle.raw_connect(username, MiqPassword.try_decrypt(password), auth_url, service)
     end
 
     def auth_url(address, port = nil)

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -53,6 +53,34 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     end
   end
 
+  describe ".raw_connect" do
+    before do
+      require 'manageiq/providers/openstack/legacy/openstack_handle/handle'
+    end
+
+    it "accepts and decrypts encrypted passwords" do
+      expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
+        "dummy",
+        "dummy",
+        "http://address:5000/v2.0/tokens",
+        "Compute"
+      )
+
+      described_class.raw_connect("dummy", MiqPassword.encrypt("dummy"), "http://address:5000/v2.0/tokens", "Compute")
+    end
+
+    it "works with unencrypted passwords" do
+      expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
+        "dummy",
+        "dummy",
+        "http://address:5000/v2.0/tokens",
+        "Compute"
+      )
+
+      described_class.raw_connect("dummy", "dummy", "http://address:5000/v2.0/tokens", "Compute")
+    end
+  end
+
   context "validation" do
     before :each do
       @ems = FactoryGirl.create(:ems_openstack_with_authentication)


### PR DESCRIPTION
Working on switching credential validation onto the queue using `raw_connect`. This will require passwords to be encrypted / decrypted.

See https://github.com/ManageIQ/manageiq-ui-classic/pull/1580 for related info / BZ 