### PR TITLE
NetworkManager: SupportsFeatureMixin cleanup

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -17,7 +17,6 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
   include SupportsFeatureMixin
 
   supports :create
-  supports :create_network_router
 
   has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"


### PR DESCRIPTION
Removes `create_network_router` which is redundant with `create`.