### PR TITLE
Use an unscoped connection to Keystone to validate API creds

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -141,7 +141,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   end
 
   def verify_api_credentials(options = {})
-    options[:service] = "Compute"
+    options[:service] = "Identity"
     with_provider_connection(options) {}
     true
   rescue => err


### PR DESCRIPTION
`verify_api_credentials` was checking Openstack API credentials
against the Compute service without an explicit tenant name,
which lead to OpenstackHandle making a ton of connections to
decide on how to scope the request. As a result, verifying
Openstack credentials was extremely slow. Now it makes a single
request to Keystone, which is way faster.

This PR is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1469306

@tzumainn 