### PR TITLE
Don't break refresh if a flavor couldn't be found

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -78,7 +78,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
 
   def tenant_ids_with_flavor_access(flavor_id)
     unparsed_tenants = safe_get { connection.list_tenants_with_flavor_access(flavor_id) }
-    flavor_access = unparsed_tenants.data[:body]["flavor_access"]
+    flavor_access = unparsed_tenants.try(:data).try(:[], :body).try(:[], "flavor_access") || []
     flavor_access.map! { |t| t['tenant_id'] }
   rescue
     []

--- a/app/models/manageiq/providers/openstack/refresh_parser_common/flavors.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/flavors.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Openstack
           tenants = []
           # Add tenants with access to the private flavor
           unparsed_tenants = safe_list { @connection.list_tenants_with_flavor_access(flavor.id) }
-          flavor_access = unparsed_tenants.data[:body]["flavor_access"]
+          flavor_access = unparsed_tenants.try(:data).try(:[], :body).try(:[], "flavor_access") || []
           unless flavor_access.blank?
             tenants += flavor_access.map { |x| @data_index.fetch_path(:cloud_tenants, x['tenant_id']) }
           end


### PR DESCRIPTION
This PR prevents refresh from failing when a flavor's access list couldn't be retrieved due to a network issue or a nonexistent flavor. Fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1460683