### PR TITLE
Assign only compact and unique list of hosts

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -106,7 +106,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManagerR
       host_aggregate.ems_ref = ha.id.to_s
       host_aggregate.name = ha.name
       host_aggregate.metadata = ha.metadata
-      host_aggregate.hosts = hosts
+      host_aggregate.hosts = hosts.compact.uniq
     end
   end
 


### PR DESCRIPTION
Assign only compact and unique list of hosts, to avoid rails
failures or duplication of the data.

Fixes:
https://github.com/ManageIQ/manageiq-providers-openstack/issues/70