### PR TITLE
Handle case where do_volume_creation_check gets a nil from Fog

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
     source.ext_management_system.with_provider_connection(:service => "volume") do |service|
       volumes_refs.each do |volume_attrs|
         next unless volume_attrs[:source_type] == "volume"
-        status = service.volumes.get(volume_attrs[:uuid]).status
+        status = service.volumes.get(volume_attrs[:uuid]).try(:status)
         return false, status unless status == "available"
       end
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -55,5 +55,15 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
 
       expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq true
     end
+
+    it "check creation status - not found" do
+      pending_volume_attrs = {:source_type => "volume"}
+      service = double
+      allow(service).to receive_message_chain('volumes.get').and_return nil
+      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+        .with(:service => 'volume').and_yield(service)
+
+      expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq [false, nil]
+    end
   end
 end


### PR DESCRIPTION
`do_volume_creation_check` assumes it will always get the requested volume object back from Fog, resulting in a thrown exception and an errored-out provisioning attempt if that assumption is violated due to the requested volume not being found. This fixes the assumption, allowing the provisioning workflow to continue and retry as normal.

This fixes the surface level issue in https://bugzilla.redhat.com/show_bug.cgi?id=1475260, though it doesn't explain why a 404 would be reported for an ID that came from Fog in the first place.