### PR TITLE
Prepare to move OrchestrationTemplate to each provider

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -15,6 +15,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationServiceOptionConverter
   require_nested :OrchestrationStack
+  require_nested :OrchestrationTemplate
+  require_nested :VnfdTemplate
   require_nested :Provision
   require_nested :ProvisionWorkflow
   require_nested :Refresher

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb
@@ -1,0 +1,131 @@
+class ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate < ::OrchestrationTemplate
+  def parameter_groups
+    content_hash = YAML.load(content)
+    raw_groups = content_hash["parameter_groups"]
+
+    if raw_groups
+      indexed_parameters = parameters(content_hash).index_by(&:name)
+      raw_groups.collect do |raw|
+        OrchestrationTemplate::OrchestrationParameterGroup.new(
+          :label       => raw["label"],
+          :description => raw["description"],
+          # Map each parameter name to its corresponding object
+          :parameters  => raw["parameters"].collect { |name| indexed_parameters[name] }
+        )
+      end
+    else
+      # Create a single group to include all parameters
+      [OrchestrationTemplate::OrchestrationParameterGroup.new(
+        :label      => "Parameters",
+        :parameters => parameters(content_hash)
+      )]
+    end
+  end
+
+  def parameters(content_hash = nil)
+    content_hash = YAML.load(content) unless content_hash
+    (content_hash["parameters"] || {}).collect do |key, val|
+      OrchestrationTemplate::OrchestrationParameter.new(
+        :name          => key,
+        :label         => val.key?('label') ? val['label'] : key.titleize,
+        :data_type     => val['type'],
+        :default_value => val['default'],
+        :description   => val['description'],
+        :hidden        => val['hidden'] == true,
+        :constraints   => val.key?('constraints') ? parse_constraints(val['constraints']) : nil,
+        :required      => true
+      )
+    end
+  end
+
+  def deployment_options(_manager_class = nil)
+    onfailure_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "stack_onfailure",
+      :label       => "On Failure",
+      :data_type   => "string",
+      :description => "Select what to do if stack creation failed",
+      :constraints => [
+        OrchestrationTemplate::OrchestrationParameterAllowed.new(
+          :allowed_values => {'ROLLBACK' => 'Rollback', 'DO_NOTHING' => 'Do nothing'}
+        )
+      ]
+    )
+
+    timeout_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "stack_timeout",
+      :label       => "Timeout(minutes, optional)",
+      :data_type   => "integer",
+      :description => "Abort the creation if it does not complete in a proper time window",
+    )
+
+    super << onfailure_opt << timeout_opt
+  end
+
+  def self.eligible_manager_types
+    [ManageIQ::Providers::Openstack::CloudManager]
+  end
+
+  # return the parsing error message if not valid JSON; otherwise nil
+  def validate_format
+    YAML.parse(content) && nil if content
+  rescue Psych::SyntaxError => err
+    err.message
+  end
+
+  private
+
+  def parse_constraints(raw_constraints)
+    raw_constraints.collect do |raw_constraint|
+      if raw_constraint.key?('allowed_values')
+        parse_allowed_values(raw_constraint)
+      elsif raw_constraint.key?('allowed_pattern')
+        parse_pattern(raw_constraint)
+      elsif raw_constraint.key?('length')
+        parse_length_constraint(raw_constraint)
+      elsif raw_constraint.key?('range')
+        parse_value_constraint(raw_constraint)
+      elsif raw_constraint.key?('custom_constraint')
+        parse_custom_constraint(raw_constraint)
+      else
+        raise MiqException::MiqParsingError, _("Unknown constraint %{constraint}") % {:constraint => raw_constraint}
+      end
+    end
+  end
+
+  def parse_allowed_values(hash)
+    OrchestrationTemplate::OrchestrationParameterAllowed.new(
+      :allowed_values => hash['allowed_values'],
+      :description    => hash['description']
+    )
+  end
+
+  def parse_pattern(hash)
+    OrchestrationTemplate::OrchestrationParameterPattern.new(
+      :pattern     => hash['allowed_pattern'],
+      :description => hash['description']
+    )
+  end
+
+  def parse_length_constraint(hash)
+    OrchestrationTemplate::OrchestrationParameterLength.new(
+      :min_length  => hash['length']['min'],
+      :max_length  => hash['length']['max'],
+      :description => hash['description']
+    )
+  end
+
+  def parse_value_constraint(hash)
+    OrchestrationTemplate::OrchestrationParameterRange.new(
+      :min_value   => hash['range']['min'],
+      :max_value   => hash['range']['max'],
+      :description => hash['description']
+    )
+  end
+
+  def parse_custom_constraint(hash)
+    OrchestrationTemplate::OrchestrationParameterCustom.new(
+      :custom_constraint => hash['custom_constraint'],
+      :description       => hash['description']
+    )
+  end
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vnfd_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vnfd_template.rb
@@ -1,0 +1,69 @@
+class ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate < ::OrchestrationTemplate
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
+
+  before_create :raw_create, :if => :remote_proxy?
+  before_update :raw_update, :if => :remote_proxy?
+  before_destroy :raw_destroy, :if => :remote_proxy?
+
+  def raw_create
+    vnfd_data = {:attributes    => {:vnfd => content},
+                 :service_types => [{:service_type => "vnfd"}],
+                 :mgmt_driver   => "noop",
+                 :infra_driver  => "heat"}
+
+    vnfd_data[:name] = name unless name.blank?
+    vnfd_data[:description] = description unless description.blank?
+
+    connection_options = {:service => "NFV"}
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      self.ems_ref = service.vnfds.create(:vnfd => vnfd_data, :auth => {}).id
+    end
+  end
+
+  def raw_update
+    # Tacker does not have an update call
+    raw_destroy && raw_create
+  end
+
+  def raw_destroy
+    connection_options = {:service => "NFV"}
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      service.vnfds.get(ems_ref).try(:destroy)
+    end
+  end
+
+  def parameter_groups
+    []
+  end
+
+  def parameters
+    []
+  end
+
+  def self.eligible_manager_types
+    [ManageIQ::Providers::Openstack::CloudManager]
+  end
+
+  def self.stack_type
+    "Vnf"
+  end
+
+  # return the parsing error message if not valid YAML; otherwise nil
+  def validate_format
+    YAML.parse(content) && nil if content
+  rescue Psych::SyntaxError => err
+    err.message
+  end
+
+  def unique_md5?
+    false
+  end
+
+  def save_as_orderable!
+    error_msg = validate_format unless draft
+    raise MiqException::MiqParsingError, error_msg if error_msg
+
+    self.orderable = true
+    save!
+  end
+end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_template_spec.rb
@@ -1,0 +1,194 @@
+describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate do
+  describe ".eligible_manager_types" do
+    it "lists the classes of eligible managers" do
+      described_class.eligible_manager_types.each do |klass|
+        expect(klass <= ManageIQ::Providers::Openstack::CloudManager).to be_truthy
+      end
+    end
+  end
+
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_hot_with_content) }
+
+  context "when a raw template in YAML format is given" do
+    it "parses parameters from a template" do
+      groups = valid_template.parameter_groups
+      expect(groups.size).to eq(2)
+
+      assert_general_group(groups[0])
+      assert_db_group(groups[1])
+    end
+  end
+
+  def assert_general_group(group)
+    expect(group.label).to eq("General parameters")
+    expect(group.description).to eq("General parameters")
+
+    assert_custom_constraint(group.parameters[0])
+    assert_allowed_values(group.parameters[1])
+    assert_list_string_type(group.parameters[2])
+  end
+
+  def assert_db_group(group)
+    expect(group.label).to be_nil
+    expect(group.description).to be_nil
+
+    assert_hidden_length_patterns(group.parameters[0])
+    assert_min_max_value(group.parameters[1])
+    assert_json_type(group.parameters[2])
+  end
+
+  def assert_custom_constraint(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "flavor",
+      :label         => "Flavor",
+      :description   => "Flavor for the instances to be created",
+      :data_type     => "string",
+      :default_value => "m1.small",
+      :hidden        => false,
+      :required      => true
+    )
+    constraints = parameter.constraints
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a ::OrchestrationTemplate::OrchestrationParameterCustom
+    expect(constraints[0]).to be_kind_of ::OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
+      :description       => "Must be a flavor known to Nova",
+      :custom_constraint => "nova.flavor"
+    )
+  end
+
+  def assert_list_string_type(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "cartridges",
+      :label         => "Cartridges",
+      :description   => "Cartridges to install. \"all\" for all cartridges; \"standard\" for all cartridges except for JBossEWS or JBossEAP\n",
+      :data_type     => "string",  # HOT has type comma_delimited_list, but all examples use type string. Why?
+      :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby",
+      :hidden        => false,
+      :required      => true,
+      :constraints   => [],
+    )
+  end
+
+  def assert_allowed_values(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "image_id",
+      :label         => "Image", # String#titleize removes trailing id
+      :description   => "ID of the image to use for the instance to be created.",
+      :data_type     => "string",
+      :default_value => "F18-x86_64-cfntools",
+      :hidden        => false,
+      :required      => true
+    )
+    constraints = parameter.constraints
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a ::OrchestrationTemplate::OrchestrationParameterAllowed
+    expect(constraints[0]).to be_kind_of ::OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
+      :description    => "Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools.",
+      :allowed_values => ["F18-i386-cfntools", "F18-x86_64-cfntools"]
+    )
+  end
+
+  def assert_min_max_value(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "db_port",
+      :label         => "Port Number",  # provided by template
+      :description   => "Database port number",
+      :data_type     => "number",
+      :default_value => 50_000,
+      :hidden        => false,
+      :required      => true
+    )
+    constraints = parameter.constraints
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a ::OrchestrationTemplate::OrchestrationParameterRange
+    expect(constraints[0]).to be_kind_of ::OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
+      :description => "Port number must be between 40000 and 60000",
+      :min_value   => 40_000,
+      :max_value   => 60_000
+    )
+  end
+
+  def assert_hidden_length_patterns(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "admin_pass",
+      :label         => "Admin Pass",
+      :description   => "Admin password",
+      :data_type     => "string",
+      :default_value => nil,
+      :hidden        => true,
+      :required      => true
+    )
+    constraints = parameter.constraints
+    expect(constraints.size).to eq(3)
+
+    expect(constraints[0]).to be_a ::OrchestrationTemplate::OrchestrationParameterLength
+    expect(constraints[0]).to be_kind_of ::OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
+      :description => "Admin password must be between 6 and 8 characters long.\n",
+      :min_length  => 6,
+      :max_length  => 8
+    )
+
+    expect(constraints[1]).to be_a ::OrchestrationTemplate::OrchestrationParameterPattern
+    expect(constraints[1]).to be_kind_of ::OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[1]).to have_attributes(
+      :description => "Password must consist of characters and numbers only",
+      :pattern     => "[a-zA-Z0-9]+"
+    )
+
+    expect(constraints[2]).to be_a ::OrchestrationTemplate::OrchestrationParameterPattern
+    expect(constraints[2]).to have_attributes(
+      :description => "Password must start with an uppercase character",
+      :pattern     => "[A-Z]+[a-zA-Z0-9]*"
+    )
+  end
+
+  def assert_json_type(parameter)
+    expect(parameter).to have_attributes(
+      :name          => "metadata",
+      :label         => "Metadata",
+      :description   => nil,
+      :data_type     => "json",
+      :default_value => nil,
+      :hidden        => false,
+      :required      => true,
+      :constraints   => [],
+    )
+  end
+
+  describe '#validate_format' do
+    it 'passes validation if no content' do
+      template = described_class.new
+      expect(template.validate_format).to be_nil
+    end
+
+    it 'passes validation with correct YAML content' do
+      expect(valid_template.validate_format).to be_nil
+    end
+
+    it 'fails validations with incorrect YAML content' do
+      template = described_class.new(:content => ":-Invalid:\n-String")
+      expect(template.validate_format).not_to be_nil
+    end
+  end
+
+  describe '#deployment_options' do
+    it do
+      options = subject.deployment_options
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
+    end
+  end
+
+  def assert_deployment_option(option, name, constraint_type, required, data_type = 'string')
+    expect(option.name).to eq(name)
+    expect(option.data_type).to eq(data_type)
+    expect(option.required?).to eq(required)
+    expect(option.constraints[0]).to be_kind_of("::OrchestrationTemplate::#{constraint_type}".constantize) if constraint_type
+  end
+end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vnfd_template_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vnfd_template_spec.rb
@@ -1,0 +1,27 @@
+describe ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate do
+  describe ".eligible_manager_types" do
+    it "lists the classes of eligible managers" do
+      described_class.eligible_manager_types.each do |klass|
+        expect(klass <= ManageIQ::Providers::Openstack::CloudManager).to be_truthy
+      end
+    end
+  end
+
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_vnfd_with_content) }
+
+  describe '#validate_format' do
+    it 'passes validation if no content' do
+      template = described_class.new
+      expect(template.validate_format).to be_nil
+    end
+
+    it 'passes validation with correct YAML content' do
+      expect(valid_template.validate_format).to be_nil
+    end
+
+    it 'fails validations with incorrect YAML content' do
+      template = described_class.new(:content => ":-Invalid:\n-String")
+      expect(template.validate_format).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Move the template classes to the corresponding provider repository.
This is a step before the migration.

https://bugzilla.redhat.com/show_bug.cgi?id=1417021

This is a refactor work but a step planned to fix above bugzilla issue.