### PR TITLE
Update miq-module dependency to more_core_extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-# We are using 'miq-module' and 'miq-password' from gems-pending
+# We are using 'miq-password' from gems-pending
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
 # Load Gemfile with dependencies from manageiq

--- a/lib/manageiq/providers/openstack/legacy/openstack_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_event_monitor.rb
@@ -2,7 +2,7 @@
 # subclass as a plugin based on the #available? class method implemented in each
 # subclass
 require 'more_core_extensions/core_ext/hash'
-require 'util/extensions/miq-module'
+require 'more_core_extensions/core_ext/module'
 require 'active_support/core_ext/class/subclasses'
 
 class OpenstackEventMonitor


### PR DESCRIPTION
Miq-module was moved from gems-pending repo to more_core_extensions
repo, updating require loading.