### PR TITLE
Add notifications for VM destroy, Cloud Volume and Cloud Volume Snapshot actions

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume/operations.rb
@@ -9,14 +9,26 @@ module ManageIQ::Providers::Openstack::CloudManager::CloudVolume::Operations
 
   def raw_attach_volume(server_ems_ref, device = nil)
     device = nil if device.try(:empty?)
-    ext_management_system.with_provider_connection(connection_options) do |service|
-      service.servers.get(server_ems_ref).attach_volume(ems_ref, device)
+    with_notification(:cloud_volume_attach,
+                      :options => {
+                        :subject =>       self,
+                        :instance_name => server_ems_ref,
+                      }) do
+      ext_management_system.with_provider_connection(connection_options) do |service|
+        service.servers.get(server_ems_ref).attach_volume(ems_ref, device)
+      end
     end
   end
 
   def raw_detach_volume(server_ems_ref)
-    ext_management_system.with_provider_connection(connection_options) do |service|
-      service.servers.get(server_ems_ref).detach_volume(ems_ref)
+    with_notification(:cloud_volume_detach,
+                      :options => {
+                        :subject =>       self,
+                        :instance_name => server_ems_ref,
+                      }) do
+      ext_management_system.with_provider_connection(connection_options) do |service|
+        service.servers.get(server_ems_ref).detach_volume(ems_ref)
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -5,6 +5,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   include_concern 'AssociateIp'
   include_concern 'ManageSecurityGroups'
 
+  include ManageIQ::Providers::Openstack::HelperMethods
+
   supports :smartstate_analysis do
     feature_supported, reason = check_feature_support('smartstate_analysis')
     unless feature_supported

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
@@ -8,7 +8,12 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations
 
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
-    with_provider_object(&:destroy)
+    with_notification(:vm_destroy,
+                      :options => {
+                        :subject => self,
+                      }) do
+      with_provider_object(&:destroy)
+    end
     self.update_attributes!(:raw_power_state => "DELETED")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -1,8 +1,6 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
   extend ActiveSupport::Concern
 
-  include ManageIQ::Providers::Openstack::HelperMethods
-
   included do
     supports :live_migrate do
       unsupported_reason_add(:live_migrate, unsupported_reason(:control)) unless supports_control?

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -9,6 +9,10 @@ module ManageIQ::Providers::Openstack::HelperMethods
     self.class.parse_error_message_from_neutron_response(exception)
   end
 
+  def with_notification(type, options: {}, &block)
+    self.class.with_notification(type, :options => options, &block)
+  end
+
   module ClassMethods
     def parse_error_message_from_fog_response(exception)
       exception_string = exception.to_s
@@ -18,6 +22,26 @@ module ManageIQ::Providers::Openstack::HelperMethods
 
     def parse_error_message_from_neutron_response(exception)
       JSON.parse(exception.response.body)["NeutronError"]["message"]
+    end
+
+    def with_notification(type, options: {})
+      # extract success and error options from options
+      # :success and :error keys respectively
+      # with all other keys common for both cases
+      success_options = options.delete(:success) || {}
+      error_options = options.delete(:error) || {}
+      success_options.merge!(options)
+      error_options.merge!(options)
+      begin
+        yield
+      rescue => ex
+        # Fog specific
+        error_message = parse_error_message_from_fog_response(ex.to_s)
+        Notification.create(:type => "#{type}_error".to_sym, :options => error_options.merge(:error_message => error_message))
+        raise
+      else
+        Notification.create(:type => "#{type}_success".to_sym, :options => success_options)
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -50,10 +50,6 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
 
   describe "vm actions" do
     context "#live_migrate" do
-      before do
-        NotificationType.seed
-      end
-
       it "live migrates with default options" do
         expect(handle).to receive(:live_migrate_server).with(vm.ems_ref, nil, false, false)
         vm.live_migrate
@@ -72,10 +68,6 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     end
 
     context "evacuate" do
-      before do
-        NotificationType.seed
-      end
-
       it "evacuates with default options" do
         expect(handle).to receive(:evacuate_server).with(vm.ems_ref, nil, true, nil)
         vm.evacuate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(ManageIQ::Providers::Openstack::Engine.root, 'spec/vcr_cassettes')
 end
 
+NotificationType.seed
+
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::Openstack::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
This adds generic with_notification method to be used to wrap call for fog-openstack actions.