### PR TITLE
Add flavors info in instance provisioning

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
@@ -30,4 +30,10 @@ class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
   def validate_delete_flavor
     {:available => true, :message => nil}
   end
+
+  def description
+    ram = ActionController::Base.helpers.number_to_human_size(memory)
+    disk_size = ActionController::Base.helpers.number_to_human_size(root_disk_size)
+    _("#{cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk")
+  end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -186,7 +186,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
             provider.flavors << FactoryGirl.create(:flavor_openstack, :memory => 1.gigabyte, :root_disk_size => 1.megabyte) # Disk too small
             provider.flavors << FactoryGirl.create(:flavor_openstack, :memory => 1.megabyte, :root_disk_size => 1.terabyte) # Memory too small
 
-            expect(workflow.allowed_instance_types).to eq(flavor.id => flavor.name)
+            ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+            disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+            descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+
+            expect(workflow.allowed_instance_types).to eq(flavor.id => "#{flavor.name}: #{descr}")
           end
         end
 
@@ -198,7 +202,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
             provider.flavors << flavor
             provider.flavors << FactoryGirl.create(:flavor_openstack, :memory => 1.megabyte, :root_disk_size => 1.terabyte) # Memory too small
 
-            expect(workflow.allowed_instance_types).to eq(flavor.id => flavor.name)
+            ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+            disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+            descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+
+            expect(workflow.allowed_instance_types).to eq(flavor.id => "#{flavor.name}: #{descr}")
           end
         end
       end
@@ -249,13 +257,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       context "#display_name_for_name_description" do
         let(:flavor) { FactoryGirl.create(:flavor_openstack) }
 
-        it "with name only" do
-          expect(workflow.display_name_for_name_description(flavor)).to eq(flavor.name)
-        end
-
         it "with name and description" do
-          flavor.description = "Small"
-          expect(workflow.display_name_for_name_description(flavor)).to eq("#{flavor.name}: Small")
+          ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+          disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+          descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+          expect(workflow.display_name_for_name_description(flavor)).to eq("#{flavor.name}: #{descr}")
         end
       end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -333,10 +333,14 @@ module Openstack
             0
           end
 
+        ram = ActionController::Base.helpers.number_to_human_size(flavor.memory)
+        disk_size = ActionController::Base.helpers.number_to_human_size(flavor.root_disk_size)
+        descr = "#{flavor.cpus} CPUs, #{ram} RAM, #{disk_size} Root Disk"
+
         expect(flavor.ext_management_system).to eq @ems
         expect(flavor.enabled).to               eq true
         expect(flavor.cpu_cores).to             eq nil
-        expect(flavor.description).to           eq nil
+        expect(flavor.description).to           eq descr
         expect(flavor.ephemeral_disk_count).to  eq expected_ephemeral_disk_count
       end
     end


### PR DESCRIPTION
Flavors info when selecting flavor in instance provisioning.


<img width="1359" alt="screen shot 2017-09-06 at 14 39 44" src="https://user-images.githubusercontent.com/20123872/30113248-5a612444-9314-11e7-8b1c-345d5a2c6c5d.png">
