### PR TITLE
Assign Infra host hostname as hypervisor_hostname

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -172,7 +172,7 @@ module ManageIQ
         host_name           = identify_host_name(indexed_resources, host.instance_uuid, uid)
         hypervisor_hostname = identify_hypervisor_hostname(host, indexed_servers)
         ip_address          = identify_primary_ip_address(host, indexed_servers)
-        hostname            = ip_address
+        hostname            = hypervisor_hostname
 
         introspection_details = get_introspection_details(host)
         extra_attributes = get_extra_attributes(introspection_details)


### PR DESCRIPTION
Instead of having the hostname for infrastructure managers show up as an
IP address, have it appear as the hostname as it does for other
providers like RHEV/OVirt.