### PR TITLE
Check provisioning status with the correct tenant scoping

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
@@ -1,7 +1,12 @@
 module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
   def do_clone_task_check(clone_task_ref)
-    source.with_provider_connection do |openstack|
-      instance = openstack.handled_list(:servers).detect { |s| s.id == clone_task_ref }
+    connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of?(Array)
+    source.with_provider_connection(connection_options) do |openstack|
+      instance = if connection_options
+                   openstack.servers.get(clone_task_ref)
+                 else
+                   openstack.handled_list(:servers).detect { |s| s.id == clone_task_ref }
+                 end
       status   = instance.state.downcase.to_sym
 
       if status == :error
@@ -20,9 +25,9 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
     clone_options[:flavor_ref]        = instance_type.ems_ref
     clone_options[:availability_zone] = nil if dest_availability_zone.kind_of?(ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull)
     clone_options[:security_groups]   = security_groups.collect(&:ems_ref)
-    clone_options[:nics]              = configure_network_adapters unless configure_network_adapters.blank?
+    clone_options[:nics]              = configure_network_adapters if configure_network_adapters.present?
 
-    clone_options[:block_device_mapping_v2] = configure_volumes unless configure_volumes.blank?
+    clone_options[:block_device_mapping_v2] = configure_volumes if configure_volumes.present?
 
     clone_options
   end
@@ -41,7 +46,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
   end
 
   def start_clone(clone_options)
-    connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of? Array
+    connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of?(Array)
     source.with_provider_connection(connection_options) do |openstack|
       instance = openstack.servers.create(clone_options)
       return instance.id

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
                  else
                    openstack.handled_list(:servers).detect { |s| s.id == clone_task_ref }
                  end
-      status   = instance.state.downcase.to_sym
+      status   = instance.state.downcase.to_sym if instance.present?
 
       if status == :error
         raise MiqException::MiqProvisionError, "An error occurred while provisioning Instance #{instance.name}"

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
     volumes_attrs_list = [default_volume_attributes]
 
     connection_options = {:service => "volume"}
-    connection_options[:tenant_name] = options[:cloud_tenant][1] if options[:cloud_tenant].kind_of? Array
+    connection_options[:tenant_name] = options[:cloud_tenant][1] if options[:cloud_tenant].kind_of?(Array)
     source.ext_management_system.with_provider_connection(connection_options) do |service|
       requested_volumes.each do |volume_attrs|
         new_volume_id = service.volumes.create(volume_attrs).id
@@ -22,7 +22,9 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
   end
 
   def do_volume_creation_check(volumes_refs)
-    source.ext_management_system.with_provider_connection(:service => "volume") do |service|
+    connection_options = {:service => "volume"}
+    connection_options[:tenant_name] = options[:cloud_tenant][1] if options[:cloud_tenant].kind_of?(Array)
+    source.ext_management_system.with_provider_connection(connection_options) do |service|
       volumes_refs.each do |volume_attrs|
         next unless volume_attrs[:source_type] == "volume"
         status = service.volumes.get(volume_attrs[:uuid]).try(:status)


### PR DESCRIPTION
If a volume or VM is provisioned in a tenant other than the default, then using `<collection>.get()` may fail to find them during the provisioning status check because the request is scoped to the wrong tenant. This PR scopes the request to use the tenant name from the provisioning request if it is a available.

This also fixes a performance problem with the cloning check, where in order to work around the scoping problem it was listing every server from every tenant. If the tenant name is available, then it will use `servers.get()` instead.

(Also some minor co-located lint fixes)