### PR TITLE
Change vms state map deleted to 'terminated' instead of 'archived'

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -26,7 +26,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
     "ERROR"             => "non_operational",
     "BUILD"             => "wait_for_launch",
     "REBUILD"           => "wait_for_launch",
-    "DELETED"           => "archived",
+    "DELETED"           => "terminated",
     "MIGRATING"         => "migrating",
   }.freeze
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
                        :cloud_tenant          => tenant)
   end
 
-  let(:archived_vm) { FactoryGirl.create(:vm_openstack) }
+  let(:terminated_vm) { FactoryGirl.create(:vm_openstack) }
 
   let(:handle) do
     double.tap do |handle|
@@ -142,8 +142,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
         expect(vm.supports_snapshot_create?).to eq true
       end
 
-      it "does not support snapshot_create on archived VM" do
-        expect(archived_vm.supports_snapshot_create?).to be_falsy
+      it "does not support snapshot_create on terminated VM" do
+        expect(terminated_vm.supports_snapshot_create?).to be_falsy
       end
 
       it "checks remove_snapshot is_available? when snapshots are associated with the instance" do
@@ -224,7 +224,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       expect(vm).to receive(:with_provider_object).and_yield(provider_object)
       vm.raw_destroy
       expect(vm.raw_power_state).to eq("DELETED")
-      expect(vm.state).to eq("archived")
+      expect(vm.state).to eq("terminated")
     end
   end
 


### PR DESCRIPTION
Use `terminated` as other providers, so that vm that is deleted won't continue to show on provider current active vms page, but in `archived` vms page

manageiq should be a tool of unification but not creating new divergences

Examples of `terminated` usage in other providers 
* https://github.com/ManageIQ/manageiq-providers-amazon/blob/7835e02d792216e7c380a49f7af609945c150618/app/models/manageiq/providers/amazon/cloud_manager/vm.rb#L12
* https://github.com/ManageIQ/manageiq-providers-vmware/blob/ba1583e269620784bdbe5e367e80fed61fc95f5d/app/models/manageiq/providers/vmware/cloud_manager/vm.rb#L13

Usage of `terminated`  in manageiq
* https://github.com/ManageIQ/manageiq/blob/c1549f0067bbdbcd6a3f9cfd89b8d0631744e57e/app/models/vm_or_template.rb#L309

