### PR TITLE
Change Compute service to Image in delete action

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -74,7 +74,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
   end
 
   def raw_delete_image
-    ext_management_system.with_provider_connection(:service => 'Compute') do |service|
+    ext_management_system.with_provider_connection(:service => 'Image') do |service|
       service.delete_image(ems_ref)
     end
   rescue => err

--- a/spec/models/manageiq/providers/openstack/cloud_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/template_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Template do
   context 'when raw_delete_image' do
     before do
       allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-      allow(ems).to receive(:with_provider_connection).with(:service => 'Compute').and_yield(service)
+      allow(ems).to receive(:with_provider_connection).with(:service => 'Image').and_yield(service)
     end
 
     subject { template_openstack }


### PR DESCRIPTION
Fixed wrong service in [`delete`](https://github.com/ManageIQ/manageiq-providers-openstack/pull/88/files#diff-dc700e83d755312bb00d3e67ab440984R77) action for Image