### PR TITLE
Enhance orchestration template parameter type support

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     create_options = {:stack_name => stack_name, :template => template.content}.merge(options).except(:tenant_name)
+    transform_parameters(template, create_options[:parameters]) if create_options[:parameters]
     connection_options = {:service => "Orchestration"}.merge(options.slice(:tenant_name))
     orchestration_manager.with_provider_connection(connection_options) do |service|
       service.stacks.new.save(create_options)["id"]
@@ -14,6 +15,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
 
   def raw_update_stack(template, options)
     update_options = {:template => template.content}.merge(options.except(:disable_rollback, :timeout_mins))
+    self.class.transform_parameters(template, update_options[:parameters]) if update_options[:parameters]
     connection_options = {:service => "Orchestration"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
     ext_management_system.with_provider_connection(connection_options) do |service|
@@ -50,5 +52,19 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
+
+  def self.transform_parameters(template, deploy_parameters)
+    list_re = /^(comma_delimited_list)|(CommaDelimitedList)|(List<.+>)$/
+    # convert multiline text to comma delimited string
+    template.parameter_groups.each do |group|
+      group.parameters.each do |para_def|
+        next unless para_def.data_type =~ list_re
+        parameter = deploy_parameters[para_def.name]
+        next if parameter.nil? || !parameter.kind_of?(String)
+        parameter.chomp!('')
+        parameter.tr!("\n", ",")
+      end
+    end
   end
 end

--- a/spec/fixtures/orchestration_templates/heat_parameters.json
+++ b/spec/fixtures/orchestration_templates/heat_parameters.json
@@ -1,1 +1,88 @@
-{"heat_template_version":"2013-05-23","description":"Incomplete sample template for testing parsing of various parameters","parameter_groups":[{"label":"General parameters","description":"General parameters","parameters":["flavor","image_id","cartridges"]},{"parameters":["admin_pass","db_port","metadata"]}],"parameters":{"admin_pass":{"type":"string","description":"Admin password","hidden":true,"constraints":[{"length":{"min":6,"max":8},"description":"Admin password must be between 6 and 8 characters long.\n"},{"allowed_pattern":"[a-zA-Z0-9]+","description":"Password must consist of characters and numbers only"},{"allowed_pattern":"[A-Z]+[a-zA-Z0-9]*","description":"Password must start with an uppercase character"}]},"flavor":{"type":"string","description":"Flavor for the instances to be created","default":"m1.small","constraints":[{"custom_constraint":"nova.flavor","description":"Must be a flavor known to Nova"}]},"cartridges":{"description":"Cartridges to install. \"all\" for all cartridges; \"standard\" for all cartridges except for JBossEWS or JBossEAP\n","type":"string","default":"cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby"},"db_port":{"type":"number","label":"Port Number","description":"Database port number","default":50000,"constraints":[{"range":{"min":40000,"max":60000},"description":"Port number must be between 40000 and 60000"}]},"image_id":{"type":"string","description":"ID of the image to use for the instance to be created.","default":"F18-x86_64-cfntools","constraints":[{"allowed_values":["F18-i386-cfntools","F18-x86_64-cfntools"],"description":"Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools."}]},"metadata":{"type":"json"}}}
+{
+  "heat_template_version": "2013-05-23",
+  "description": "Incomplete sample template for testing parsing of various parameters",
+  "parameter_groups": [
+    {
+      "label": "General parameters",
+      "description": "General parameters",
+      "parameters": [
+        "flavor",
+        "image_id",
+        "cartridges"
+      ]
+    },
+    {
+      "parameters": [
+        "admin_pass",
+        "db_port",
+        "metadata",
+        "skip_failed",
+        "subnets",
+        "my_key_pair"
+      ]
+    }
+  ],
+  "parameters": {
+    "admin_pass": {
+      "Type": "String",
+      "Description": "Admin password",
+      "NoEcho": true,
+      "MinLength": "6",
+      "MaxLength": "8",
+      "AllowedPattern": "[a-zA-Z0-9]+",
+      "ConstraintDescription": "Admin password must be between 6 and 8 characters long. Password must consist of characters and numbers only."
+    },
+    "flavor": {
+      "type": "string",
+      "description": "Flavor for the instances to be created",
+      "default": "m1.small",
+      "constraints": [
+        {
+          "custom_constraint": "nova.flavor",
+          "description": "Must be a flavor known to Nova"
+        }
+      ]
+    },
+    "cartridges": {
+      "Description": "Cartridges to install. \"all\" for all cartridges; \"standard\" for all cartridges except for JBossEWS or JBossEAP\n",
+      "Type": "CommaDelimitedList",
+      "Default": "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby"
+    },
+    "db_port": {
+      "Type": "Number",
+      "label": "Port Number",
+      "Description": "Database port number",
+      "Default": "50000",
+      "MinValue": "40000",
+      "MaxValue": "60000",
+      "ConstraintDescription": "Port number must be between 40000 and 60000"
+    },
+    "image_id": {
+      "Type": "string",
+      "Description": "ID of the image to use for the instance to be created.",
+      "Default": "F18-x86_64-cfntools",
+      "AllowedValues": ["F18-i386-cfntools", "F18-x86_64-cfntools"],
+      "ConstraintDescription": "Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools."
+    },
+    "metadata": {
+      "type": "json",
+      "default": {
+        "ver": "test"
+      }
+    },
+    "skip_failed": {
+      "type": "boolean",
+      "default": "t"
+    },
+    "subnets": {
+      "Description": "Subnet IDs",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+      "Default": ["subnet-123a351e", "subnet-123a351f"]
+    },
+    "my_key_pair": {
+      "Description": "Amazon EC2 key pair",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "Default": "my-key"
+    }
+  }
+}

--- a/spec/fixtures/orchestration_templates/heat_parameters.yml
+++ b/spec/fixtures/orchestration_templates/heat_parameters.yml
@@ -13,6 +13,9 @@ parameter_groups:
   - admin_pass
   - db_port
   - metadata
+  - skip_failed
+  - subnets
+  - my_key_pair
 
 parameters:
   admin_pass:
@@ -20,45 +23,69 @@ parameters:
     description: Admin password
     hidden: true
     constraints:
-      - length: { min: 6, max: 8 }
-        description: >
-          Admin password must be between 6 and 8 characters long.
-      - allowed_pattern: "[a-zA-Z0-9]+"
-        description: Password must consist of characters and numbers only
-      - allowed_pattern: "[A-Z]+[a-zA-Z0-9]*"
-        description: Password must start with an uppercase character
+    - length: { min: 6, max: 8 }
+      description: >
+        Admin password must be between 6 and 8 characters long.
+    - allowed_pattern: "[a-zA-Z0-9]+"
+      description: Password must consist of characters and numbers only
 
   flavor:
     type: string
     description: Flavor for the instances to be created
     default: m1.small
     constraints:
-      - custom_constraint: nova.flavor
-        description: Must be a flavor known to Nova
+    - custom_constraint: nova.flavor
+      description: Must be a flavor known to Nova
 
   cartridges:
     description: >
       Cartridges to install. "all" for all cartridges; "standard" for all cartridges except for JBossEWS or JBossEAP
-    type: string
-    default: "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby"
+    type: comma_delimited_list
+    default:
+    - cron
+    - diy
+    - haproxy
+    - mysql
+    - nodejs
+    - perl
+    - php
+    - postgresql
+    - python
+    - ruby
 
   db_port:
     type: number
     label: Port Number
     description: Database port number
-    default: 50000
+    default: "50000"
     constraints:
-      - range: { min: 40000, max: 60000 }
-        description: Port number must be between 40000 and 60000
+    - range: { min: 40000, max: 60000 }
+      description: Port number must be between 40000 and 60000
 
   image_id:
     type: string
     description: ID of the image to use for the instance to be created.
     default: F18-x86_64-cfntools
     constraints:
-      - allowed_values: [ F18-i386-cfntools, F18-x86_64-cfntools ]
-        description:
-          Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools.
+    - allowed_values: [ F18-i386-cfntools, F18-x86_64-cfntools ]
+      description:
+        Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools.
 
   metadata:
     type: json
+    default:
+      ver: test
+
+  skip_failed:
+    type: boolean
+    default: t
+
+  subnets:
+    Description: Subnet IDs
+    Type: List<AWS::EC2::Subnet::Id>
+    Default: [subnet-123a351e, subnet-123a351f]
+
+  my_key_pair:
+    Description: Amazon EC2 key pair
+    Type: AWS::EC2::KeyPair::KeyName
+    Default: my-key

--- a/spec/fixtures/orchestration_templates/vnfd_parameters.yml
+++ b/spec/fixtures/orchestration_templates/vnfd_parameters.yml
@@ -1,0 +1,31 @@
+template_name: sample-vnfd
+description: demo-example
+
+service_properties:
+  Id: sample-vnfd
+  vendor: tacker
+  version: 1
+
+vdus:
+  vdu1:
+    id: vdu1
+    vm_image: centos7-image
+    instance_type: m1.medium
+
+    network_interfaces:
+      management:
+        network: net_mgmt
+        management: true
+      pkt_in:
+        network: net0
+      pkt_out:
+        network: net1
+
+    placement_policy:
+      availability_zone: nova
+
+    auto-scaling: noop
+
+    config:
+      param0: key0
+      param1: key1

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
@@ -107,4 +107,14 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
       end
     end
   end
+
+  describe '.transform_parameters' do
+    let(:template) { FactoryGirl.create(:orchestration_template_openstack_in_yaml) }
+    it 'converts multiline text into one comma delimitered string' do
+      parameters = {'cartridges' => "test1\ntest2\n\n"}
+
+      described_class.transform_parameters(template, parameters)
+      expect(parameters).to eq('cartridges' => "test1,test2")
+    end
+  end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vnfd_template_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vnfd_template_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate do
     end
   end
 
-  let(:valid_template) { FactoryGirl.create(:orchestration_template_vnfd_with_content) }
+  let(:valid_template) { FactoryGirl.create(:vnfd_template_openstack_in_yaml) }
 
   describe '#validate_format' do
     it 'passes validation if no content' do


### PR DESCRIPTION
Better support non-string parameter types including comma-delimited-list, number, boolean
    
https://bugzilla.redhat.com/show_bug.cgi?id=1489908

depends on ~~https://github.com/ManageIQ/manageiq/pull/16047~~

Update:
The work now also include better support Cloudformation template. So it is able to accept both HOT and Cloudformation templates in either JSON or YAML format.

The last commit fixed an error in spec test that references to a factory that has been removed from manageiq repo.