### PR TITLE
Event parser sets host id

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
@@ -16,6 +16,9 @@ module ManageIQ::Providers::Openstack::InfraManager::EventParser
     }
 
     payload = event[:content]["payload"]
+    if payload.key? "instance_id"
+      event_hash[:host_id] = Host.find_by("ems_ref_obj" => YAML.dump(payload["instance_id"])).try(:id)
+    end
     event_hash[:message]                   = payload["message"]           if payload.key? "message"
     event_hash[:host_ems_ref]              = payload["node"]              if payload.key? "node"
     event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"


### PR DESCRIPTION
Event parser now sets host_id attribute. It tries to find host by `ems_ref_obj` using `instance_id` attribute from event's payload.
[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=1377786)