### PR TITLE
Trim neutron error messages out of fog responses

### DIFF
--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -1,7 +1,23 @@
 module ManageIQ::Providers::Openstack::HelperMethods
+  extend ActiveSupport::Concern
+
   def parse_error_message_from_fog_response(exception)
-    exception_string = exception.to_s
-    matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)
-    matched_message ? matched_message[1] : exception_string
+    self.class.parse_error_message_from_fog_response(exception)
+  end
+
+  def parse_error_message_from_neutron_response(exception)
+    self.class.parse_error_message_from_neutron_response(exception)
+  end
+
+  module ClassMethods
+    def parse_error_message_from_fog_response(exception)
+      exception_string = exception.to_s
+      matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)
+      matched_message ? matched_message[1] : exception_string
+    end
+
+    def parse_error_message_from_neutron_response(exception)
+      JSON.parse(exception.response.body)["NeutronError"]["message"]
+    end
   end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetwork
+  include ManageIQ::Providers::Openstack::HelperMethods
   include SupportsFeatureMixin
 
   supports :create
@@ -49,7 +50,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     {:ems_ref => network.id, :name => options[:name]}
   rescue => e
     _log.error "network=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqNetworkCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_delete_cloud_network
@@ -58,7 +59,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     end
   rescue => e
     _log.error "network=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def delete_cloud_network_queue(userid)
@@ -84,7 +85,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     end
   rescue => e
     _log.error "network=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkUpdateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def update_cloud_network_queue(userid, options = {})

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubnet
+  include ManageIQ::Providers::Openstack::HelperMethods
   include ProviderObjectMixin
   include SupportsFeatureMixin
 
@@ -34,7 +35,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     {:ems_ref => subnet.id, :name => options[:name]}
   rescue => e
     _log.error "subnet=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqCloudSubnetCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqCloudSubnetCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_delete_cloud_subnet
@@ -43,7 +44,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     end
   rescue => e
     _log.error "subnet=[#{name}], error: #{e}"
-    raise MiqException::MiqCloudSubnetDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqCloudSubnetDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def delete_cloud_subnet_queue(userid)
@@ -69,7 +70,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     end
   rescue => e
     _log.error "subnet=[#{name}], error: #{e}"
-    raise MiqException::MiqCloudSubnetUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqCloudSubnetUpdateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def update_cloud_subnet_queue(userid, options = {})

--- a/app/models/manageiq/providers/openstack/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/floating_ip.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::FloatingIp < ::FloatingIp
+  include ManageIQ::Providers::Openstack::HelperMethods
   include ProviderObjectMixin
   include AsyncDeleteMixin
 
@@ -33,7 +34,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::FloatingIp < ::FloatingIp
     {:ems_ref => floating_ip['id'], :name => options[:floating_ip_address]}
   rescue => e
     _log.error "floating_ip=[#{options[:floating_ip_address]}], error: #{e}"
-    raise MiqException::MiqFloatingIpCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqFloatingIpCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def self.remapping(options)
@@ -54,7 +55,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::FloatingIp < ::FloatingIp
     end
   rescue => e
     _log.error "floating_ip=[#{name}], error: #{e}"
-    raise MiqException::MiqFloatingIpDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqFloatingIpDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def delete_floating_ip_queue(userid)
@@ -84,7 +85,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::FloatingIp < ::FloatingIp
     end
   rescue => e
     _log.error "floating_ip=[#{name}], error: #{e}"
-    raise MiqException::MiqFloatingIpUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqFloatingIpUpdateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def update_floating_ip_queue(userid, options = {})

--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkRouter
+  include ManageIQ::Providers::Openstack::HelperMethods
   include ProviderObjectMixin
   include AsyncDeleteMixin
 
@@ -35,7 +36,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     {:ems_ref => router['id'], :name => options[:name]}
   rescue => e
     _log.error "router=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqNetworkRouterCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkRouterCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_delete_network_router
@@ -44,7 +45,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     end
   rescue => e
     _log.error "router=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkRouterDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkRouterDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def delete_network_router_queue(userid)
@@ -70,7 +71,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     end
   rescue => e
     _log.error "router=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkRouterUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkRouterUpdateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def update_network_router_queue(userid, options = {})
@@ -100,7 +101,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     end
   rescue => e
     _log.error "router=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkRouterAddInterfaceError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkRouterAddInterfaceError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def add_interface_queue(userid, cloud_subnet)
@@ -130,7 +131,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     end
   rescue => e
     _log.error "router=[#{name}], error: #{e}"
-    raise MiqException::MiqNetworkRouterRemoveInterfaceError, e.to_s, e.backtrace
+    raise MiqException::MiqNetworkRouterRemoveInterfaceError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def remove_interface_queue(userid, cloud_subnet)

--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::SecurityGroup
+  include ManageIQ::Providers::Openstack::HelperMethods
+
   supports :create
 
   supports :delete do
@@ -39,7 +41,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     end
   rescue => e
     _log.error "security_group=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqSecurityGroupCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqSecurityGroupCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_delete_security_group
@@ -48,7 +50,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     end
   rescue => e
     _log.error "security_group=[#{name}], error: #{e}"
-    raise MiqException::MiqSecurityGroupDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqSecurityGroupDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def create_security_group_rule_queue(userid, security_group_id, direction, options = {})
@@ -109,7 +111,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     end
   rescue => e
     _log.error "security_group=[#{name}], error: #{e}"
-    raise MiqException::MiqSecurityGroupCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqSecurityGroupCreateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_delete_security_group_rule(key)
@@ -118,7 +120,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     end
   rescue => e
     _log.error "security_group=[#{name}], error: #{e}"
-    raise MiqException::MiqSecurityGroupDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqSecurityGroupDeleteError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def raw_update_security_group(options)
@@ -127,7 +129,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     end
   rescue => e
     _log.error "security_group=[#{name}], error: #{e}"
-    raise MiqException::MiqSecurityGroupUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqSecurityGroupUpdateError, parse_error_message_from_neutron_response(e), e.backtrace
   end
 
   def update_security_group_queue(userid, options = {})

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork do
     response = Excon::Response.new
     response.status = 400
     response.body = '{"NeutronError": {"message": "bad request"}}'
-    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+    Excon::Errors.status_error({:expects => 200}, response)
   end
 
   before do
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork do
       it 'catches errors from provider' do
         expect(service).to receive_message_chain(:networks, :new).and_raise(bad_request)
         expect do
-          ems_network.create_cloud_network({:cloud_tenant => tenant})
+          ems_network.create_cloud_network(:cloud_tenant => tenant)
         end.to raise_error(MiqException::MiqNetworkCreateError)
       end
     end

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
@@ -1,0 +1,61 @@
+describe ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:ems_network) { ems.network_manager }
+  let(:cloud_network) do
+    FactoryGirl.create(:cloud_network_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test',
+                       :ems_ref               => 'one_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:service) do
+    service = double("Fog service")
+    service
+  end
+
+  let(:raw_cloud_networks) do
+    raw_cloud_networks = double("cloud networks")
+    allow(ExtManagementSystem).to receive(:find).with(ems_network.id).and_return(ems_network)
+    allow(ems_network.parent_manager).to receive(:connect)
+      .with(hash_including(:service => 'Network', :tenant_name => tenant.name)).and_return(service)
+    raw_cloud_networks
+  end
+
+  let(:bad_request) do
+    response = Excon::Response.new
+    response.status = 400
+    response.body = '{"NeutronError": {"message": "bad request"}}'
+    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+  end
+
+  before do
+    raw_cloud_networks
+  end
+
+  describe 'cloud network actions' do
+    context ".create" do
+      it 'catches errors from provider' do
+        expect(service).to receive_message_chain(:networks, :new).and_raise(bad_request)
+        expect do
+          ems_network.create_cloud_network({:cloud_tenant => tenant})
+        end.to raise_error(MiqException::MiqNetworkCreateError)
+      end
+    end
+
+    context "#update_cloud_network" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:update_network).and_raise(bad_request)
+        expect { cloud_network.raw_update_cloud_network({}) }.to raise_error(MiqException::MiqNetworkUpdateError)
+      end
+    end
+
+    context "#delete_cloud_network" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:delete_network).and_raise(bad_request)
+        expect { cloud_network.raw_delete_cloud_network }.to raise_error(MiqException::MiqNetworkDeleteError)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
     response = Excon::Response.new
     response.status = 400
     response.body = '{"NeutronError": {"message": "bad request"}}'
-    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+    Excon::Errors.status_error({:expects => 200}, response)
   end
 
   before do
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
       it 'catches errors from provider' do
         expect(service).to receive_message_chain(:subnets, :new).and_raise(bad_request)
         expect do
-          ems_network.create_cloud_subnet({:cloud_tenant => tenant})
+          ems_network.create_cloud_subnet(:cloud_tenant => tenant)
         end.to raise_error(MiqException::MiqCloudSubnetCreateError)
       end
     end

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
@@ -1,0 +1,61 @@
+describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:ems_network) { ems.network_manager }
+  let(:cloud_subnet) do
+    FactoryGirl.create(:cloud_subnet_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test',
+                       :ems_ref               => 'one_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:service) do
+    service = double("Fog service")
+    service
+  end
+
+  let(:raw_cloud_subnets) do
+    raw_cloud_subnets = double("cloud subnets")
+    allow(ExtManagementSystem).to receive(:find).with(ems_network.id).and_return(ems_network)
+    allow(ems_network.parent_manager).to receive(:connect)
+      .with(hash_including(:service => 'Network', :tenant_name => tenant.name)).and_return(service)
+    raw_cloud_subnets
+  end
+
+  let(:bad_request) do
+    response = Excon::Response.new
+    response.status = 400
+    response.body = '{"NeutronError": {"message": "bad request"}}'
+    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+  end
+
+  before do
+    raw_cloud_subnets
+  end
+
+  describe 'cloud subnet actions' do
+    context ".create" do
+      it 'catches errors from provider' do
+        expect(service).to receive_message_chain(:subnets, :new).and_raise(bad_request)
+        expect do
+          ems_network.create_cloud_subnet({:cloud_tenant => tenant})
+        end.to raise_error(MiqException::MiqCloudSubnetCreateError)
+      end
+    end
+
+    context "#update_cloud_subnet" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:update_subnet).and_raise(bad_request)
+        expect { cloud_subnet.raw_update_cloud_subnet({}) }.to raise_error(MiqException::MiqCloudSubnetUpdateError)
+      end
+    end
+
+    context "#delete_cloud_subnet" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:delete_subnet).and_raise(bad_request)
+        expect { cloud_subnet.raw_delete_cloud_subnet }.to raise_error(MiqException::MiqCloudSubnetDeleteError)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openstack/network_manager/floating_ip_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/floating_ip_spec.rb
@@ -1,0 +1,70 @@
+describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:ems_network) { ems.network_manager }
+  let(:cloud_network) do
+    FactoryGirl.create(:cloud_network_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test_network',
+                       :ems_ref               => 'network_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:floating_ip) do
+    FactoryGirl.create(:floating_ip_openstack,
+                       :ext_management_system => ems_network,
+                       :address               => '10.10.10.10',
+                       :ems_ref               => 'one_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:service) do
+    service = double("Fog service")
+    service
+  end
+
+  let(:raw_floating_ips) do
+    raw_floating_ips = double("floating ips")
+    allow(CloudNetwork).to receive(:find).with(cloud_network.id).and_return(cloud_network)
+    allow(ExtManagementSystem).to receive(:find).with(ems_network.id).and_return(ems_network)
+    allow(ems_network.parent_manager).to receive(:connect)
+      .with(hash_including(:service => 'Network', :tenant_name => tenant.name)).and_return(service)
+    raw_floating_ips
+  end
+
+  let(:bad_request) do
+    response = Excon::Response.new
+    response.status = 400
+    response.body = '{"NeutronError": {"message": "bad request"}}'
+    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+  end
+
+  before do
+    raw_floating_ips
+  end
+
+  describe 'floating ip actions' do
+    context ".create" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:create_floating_ip).and_raise(bad_request)
+        expect do
+          ems_network.create_floating_ip({:cloud_tenant => tenant, :cloud_network_id => cloud_network.id})
+        end.to raise_error(MiqException::MiqFloatingIpCreateError)
+      end
+    end
+
+    context "#update_floating_ip" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:disassociate_floating_ip).and_raise(bad_request)
+        expect { floating_ip.raw_update_floating_ip({:network_port_ems_ref => ""}) }.to raise_error(MiqException::MiqFloatingIpUpdateError)
+      end
+    end
+
+    context "#delete_floating_ip" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:delete_floating_ip).and_raise(bad_request)
+        expect { floating_ip.raw_delete_floating_ip }.to raise_error(MiqException::MiqFloatingIpDeleteError)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openstack/network_manager/floating_ip_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/floating_ip_spec.rb
@@ -36,7 +36,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
     response = Excon::Response.new
     response.status = 400
     response.body = '{"NeutronError": {"message": "bad request"}}'
-    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+    Excon::Errors.status_error({:expects => 200}, response)
   end
 
   before do
@@ -48,7 +48,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
       it 'catches errors from provider' do
         expect(service).to receive(:create_floating_ip).and_raise(bad_request)
         expect do
-          ems_network.create_floating_ip({:cloud_tenant => tenant, :cloud_network_id => cloud_network.id})
+          ems_network.create_floating_ip(:cloud_tenant => tenant, :cloud_network_id => cloud_network.id)
         end.to raise_error(MiqException::MiqFloatingIpCreateError)
       end
     end
@@ -56,7 +56,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
     context "#update_floating_ip" do
       it 'catches errors from provider' do
         expect(service).to receive(:disassociate_floating_ip).and_raise(bad_request)
-        expect { floating_ip.raw_update_floating_ip({:network_port_ems_ref => ""}) }.to raise_error(MiqException::MiqFloatingIpUpdateError)
+        expect { floating_ip.raw_update_floating_ip(:network_port_ems_ref => "") }.to raise_error(MiqException::MiqFloatingIpUpdateError)
       end
     end
 

--- a/spec/models/manageiq/providers/openstack/network_manager/network_router_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/network_router_spec.rb
@@ -1,0 +1,84 @@
+describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:ems_network) { ems.network_manager }
+  let(:cloud_subnet) do
+    FactoryGirl.create(:cloud_subnet_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test_subnet',
+                       :ems_ref               => 'network_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:network_router) do
+    FactoryGirl.create(:network_router_openstack,
+                       :ext_management_system => ems_network,
+                       :name                  => 'test',
+                       :ems_ref               => 'one_id',
+                       :cloud_tenant          => tenant)
+  end
+
+  let(:service) do
+    service = double("Fog service")
+    service
+  end
+
+  let(:raw_network_routers) do
+    raw_network_routers = double("network routers")
+    allow(CloudSubnet).to receive(:find).with(cloud_subnet.id).and_return(cloud_subnet)
+    allow(ExtManagementSystem).to receive(:find).with(ems_network.id).and_return(ems_network)
+    allow(ems_network.parent_manager).to receive(:connect)
+      .with(hash_including(:service => 'Network', :tenant_name => tenant.name)).and_return(service)
+    raw_network_routers
+  end
+
+  let(:bad_request) do
+    response = Excon::Response.new
+    response.status = 400
+    response.body = '{"NeutronError": {"message": "bad request"}}'
+    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+  end
+
+  before do
+    raw_network_routers
+  end
+
+  describe 'network router actions' do
+    context ".create" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:create_router).and_raise(bad_request)
+        expect do
+          ems_network.create_network_router({:cloud_tenant => tenant, :name => "network"})
+        end.to raise_error(MiqException::MiqNetworkRouterCreateError)
+      end
+    end
+
+    context "#update_network_router" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:update_router).and_raise(bad_request)
+        expect { network_router.raw_update_network_router({}) }.to raise_error(MiqException::MiqNetworkRouterUpdateError)
+      end
+    end
+
+    context "#delete_network_router" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:delete_router).and_raise(bad_request)
+        expect { network_router.raw_delete_network_router }.to raise_error(MiqException::MiqNetworkRouterDeleteError)
+      end
+    end
+
+    context "#raw_add_interface" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:add_router_interface).and_raise(bad_request)
+        expect { network_router.raw_add_interface(cloud_subnet.id) }.to raise_error(MiqException::MiqNetworkRouterAddInterfaceError)
+      end
+    end
+
+    context "#raw_remove_interface" do
+      it 'catches errors from provider' do
+        expect(service).to receive(:remove_router_interface).and_raise(bad_request)
+        expect { network_router.raw_remove_interface(cloud_subnet.id) }.to raise_error(MiqException::MiqNetworkRouterRemoveInterfaceError)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openstack/network_manager/network_router_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/network_router_spec.rb
@@ -36,7 +36,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
     response = Excon::Response.new
     response.status = 400
     response.body = '{"NeutronError": {"message": "bad request"}}'
-    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+    Excon::Errors.status_error({:expects => 200}, response)
   end
 
   before do
@@ -48,7 +48,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
       it 'catches errors from provider' do
         expect(service).to receive(:create_router).and_raise(bad_request)
         expect do
-          ems_network.create_network_router({:cloud_tenant => tenant, :name => "network"})
+          ems_network.create_network_router(:cloud_tenant => tenant, :name => "network")
         end.to raise_error(MiqException::MiqNetworkRouterCreateError)
       end
     end

--- a/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
@@ -31,6 +31,13 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
     raw_security_groups
   end
 
+  let(:bad_request) do
+    response = Excon::Response.new
+    response.status = 400
+    response.body = '{"NeutronError": {"message": "bad request"}}'
+    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+  end
+
   before do
     raw_security_groups
   end
@@ -54,7 +61,8 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
       end
 
       it 'catches errors from provider' do
-        expect(service).to receive(:create_security_group).and_raise('bad request')
+
+        expect(service).to receive(:create_security_group).and_raise(bad_request)
         expect do
           ems_network.create_security_group(security_group_options)
         end.to raise_error(MiqException::MiqSecurityGroupCreateError)
@@ -70,7 +78,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
       end
 
       it 'catches errors from provider' do
-        expect(service).to receive(:update_security_group).and_raise('bad request')
+        expect(service).to receive(:update_security_group).and_raise(bad_request)
         expect { security_group.raw_update_security_group({}) }.to raise_error(MiqException::MiqSecurityGroupUpdateError)
       end
 
@@ -92,7 +100,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
       end
 
       it 'catches errors from provider' do
-        expect(service).to receive(:delete_security_group).and_raise('bad request')
+        expect(service).to receive(:delete_security_group).and_raise(bad_request)
         expect { security_group.raw_delete_security_group }.to raise_error(MiqException::MiqSecurityGroupDeleteError)
       end
     end

--- a/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/security_group_spec.rb
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
     response = Excon::Response.new
     response.status = 400
     response.body = '{"NeutronError": {"message": "bad request"}}'
-    bad_request = Excon::Errors.status_error({:expects => 200}, response)
+    Excon::Errors.status_error({:expects => 200}, response)
   end
 
   before do
@@ -61,7 +61,6 @@ describe ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup do
       end
 
       it 'catches errors from provider' do
-
         expect(service).to receive(:create_security_group).and_raise(bad_request)
         expect do
           ems_network.create_security_group(security_group_options)


### PR DESCRIPTION
This PR trims Neutron error messages out of fog responses, so that the UI can display readable messages instead of the mess of json and header info that currently appears. This is related to the problem described in https://bugzilla.redhat.com/show_bug.cgi?id=1476666, which will eventually be addressed as I go through the rest of the provider.