### PR TITLE
Filter out resources with blank physical_resource_id

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -170,7 +170,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
     raw_resources = collector.orchestration_resources(stack)
     # reject resources that don't have a physical resource id, because that
     # means they failed to be successfully created
-    raw_resources.reject! { |r| r.physical_resource_id.nil? }
+    raw_resources.reject! { |r| r.physical_resource_id.blank? }
     raw_resources.each do |resource|
       uid = resource.physical_resource_id
       o = persister.orchestration_stacks_resources.find_or_build(uid)


### PR DESCRIPTION
Filter out resources with blank physical_resource_id.
Before we were ignoring those with:
https://github.com/Ladas/manageiq-providers-openstack/blob/d0799c4a5766650f2d3d149875c1b58f8a16040f/app/models/manageiq/providers/openstack/refresh_parser_common/orchestration_stacks.rb#L165

Without ignoring thise results in error :
[NoMethodError]: undefined method `ems_ref=' for nil:NilClass  Method:[block in method_missing]