### PR TITLE
update raw connect method to accomodate OpenStack complexity

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   #
   module ClassMethods
     def raw_connect(password, params, service = "Compute")
-      ems = self.new
+      ems = new
       ems.name                   = params[:name].strip
       ems.provider_region        = params[:provider_region]
       ems.api_version            = params[:api_version].strip
@@ -24,7 +24,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
       authentication = {:userid => user, :password => password, :save => false, :role => 'default', :authtype => 'default'}
       ems.connection_configurations = [{:endpoint       => endpoint,
-                                        :authentication => authentication}]      
+                                        :authentication => authentication}]
       ems.connect(:service => service)
     end
   end

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].strip
 
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
-      authentication = {:userid => user, :password => password, :save => false, :role => 'default', :authtype => 'default'}
+      authentication = {:userid => user, :password => MiqPassword.decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
       ems.connection_configurations = [{:endpoint       => endpoint,
                                         :authentication => authentication}]
       ems.connect(:service => service)

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].strip
 
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
-      authentication = {:userid => user, :password => MiqPassword.decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
+      authentication = {:userid => user, :password => MiqPassword.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
       ems.connection_configurations = [{:endpoint       => endpoint,
                                         :authentication => authentication}]
       ems.connect(:service => service)

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -60,13 +60,13 @@ describe ManageIQ::Providers::Openstack::CloudManager do
 
     it "accepts and decrypts encrypted passwords" do
       params = {
-        :name => 'dummy',
-        :provider_region => '',
-        :api_version => 'v2.0',
+        :name                      => 'dummy',
+        :provider_region           => '',
+        :api_version               => 'v2.0',
         :default_security_protocol => 'non-ssl',
-        :default_userid => 'admin',
-        :default_hostname => 'address',
-        :default_api_port => '5000'
+        :default_userid            => 'admin',
+        :default_hostname          => 'address',
+        :default_api_port          => '5000'
       }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "admin",
@@ -81,13 +81,13 @@ describe ManageIQ::Providers::Openstack::CloudManager do
 
     it "works with unencrypted passwords" do
       params = {
-        :name => 'dummy',
-        :provider_region => '',
-        :api_version => 'v2.0',
+        :name                      => 'dummy',
+        :provider_region           => '',
+        :api_version               => 'v2.0',
         :default_security_protocol => 'non-ssl',
-        :default_userid => 'admin',
-        :default_hostname => 'address',
-        :default_api_port => '5000'
+        :default_userid            => 'admin',
+        :default_hostname          => 'address',
+        :default_api_port          => '5000'
       }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "admin",

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Openstack::CloudManager do
   context "Class Methods" do
-    it("from mixin") { expect(described_class.methods).to include(:auth_url, :raw_connect) }
+    it("from mixin") { expect(described_class.methods).to include(:raw_connect) }
   end
 
   it ".ems_type" do
@@ -59,25 +59,45 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     end
 
     it "accepts and decrypts encrypted passwords" do
+      params = {
+        :name => 'dummy',
+        :provider_region => '',
+        :api_version => 'v2.0',
+        :default_security_protocol => 'non-ssl',
+        :default_userid => 'admin',
+        :default_hostname => 'address',
+        :default_api_port => '5000'
+      }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
+        "admin",
         "dummy",
-        "dummy",
-        "http://address:5000/v2.0/tokens",
-        "Compute"
+        "http://address:5000",
+        "Compute",
+        instance_of(Hash)
       )
 
-      described_class.raw_connect("dummy", MiqPassword.encrypt("dummy"), "http://address:5000/v2.0/tokens", "Compute")
+      described_class.raw_connect(MiqPassword.encrypt("dummy"), params, "Compute")
     end
 
     it "works with unencrypted passwords" do
+      params = {
+        :name => 'dummy',
+        :provider_region => '',
+        :api_version => 'v2.0',
+        :default_security_protocol => 'non-ssl',
+        :default_userid => 'admin',
+        :default_hostname => 'address',
+        :default_api_port => '5000'
+      }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
+        "admin",
         "dummy",
-        "dummy",
-        "http://address:5000/v2.0/tokens",
-        "Compute"
+        "http://address:5000",
+        "Compute",
+        instance_of(Hash)
       )
 
-      described_class.raw_connect("dummy", "dummy", "http://address:5000/v2.0/tokens", "Compute")
+      described_class.raw_connect("dummy", params, "Compute")
     end
   end
 


### PR DESCRIPTION
The raw_connect method is used in provider validation; this change allows us to validate complex cases such as keystone v3 and ssl

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/2394

https://bugzilla.redhat.com/show_bug.cgi?id=1500379