### PR TITLE
Only update tenant mapping for the network manager if it's present

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -91,8 +91,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def save_on_other_managers
     storage_managers.update_all(:tenant_mapping_enabled => tenant_mapping_enabled)
-    network_manager.tenant_mapping_enabled = tenant_mapping_enabled
-    network_manager.save!
+    if network_manager
+      network_manager.tenant_mapping_enabled = tenant_mapping_enabled
+      network_manager.save!
+    end
   end
 
   def supports_cloud_tenants?


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1471146 by checking for the presence of the network manager before attempting to modify it.