### PR TITLE
Adds vm_snapshot_success Notification creation

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -266,6 +266,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
     miq_openstack_instance = MiqOpenStackInstance.new(vm.ems_ref, openstack_handle)
     miq_openstack_instance.delete_evm_snapshot(snapshot_uid)
+    Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'remove'})
 
     # Remove from the snapshots table.
     ar_snapshot = vm.snapshots.find_by(:ems_ref  => snapshot_uid)

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -239,6 +239,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
     miq_openstack_instance = MiqOpenStackInstance.new(vm.ems_ref, openstack_handle)
     snapshot = miq_openstack_instance.create_snapshot(options)
+    Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'create'})
     snapshot_id = snapshot["id"]
 
     # Add new snapshot to the snapshots table.


### PR DESCRIPTION
Creates notification with `vm_snapshot_success` type with Vm as `subject` for `create` and `remove` as `snapshot_op`.

Notification Type is defined in https://github.com/ManageIQ/manageiq/pull/16286 which is needed for this one.

Partially solves https://bugzilla.redhat.com/show_bug.cgi?id=1429313