### PR TITLE
Trim error messages from fog responses for remaining models

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -3,7 +3,6 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   include_concern 'Operations'
 
   include SupportsFeatureMixin
-  include ManageIQ::Providers::Openstack::HelperMethods
 
   supports :create
   supports :backup_create

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot.rb
@@ -1,7 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
   include ManageIQ::Providers::Openstack::HelperMethods
   include SupportsFeatureMixin
-  include ManageIQ::Providers::Openstack::HelperMethods
 
   supports :create
   supports :update

--- a/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
@@ -1,11 +1,13 @@
 class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
+  include ManageIQ::Providers::Openstack::HelperMethods
+
   def self.raw_create_flavor(ext_management_system, create_options)
     ext_management_system.with_provider_connection({:service => 'Compute'}) do |service|
       service.flavors.create(create_options)
     end
   rescue => err
     _log.error "flavor=[#{name}], error=[#{err}]"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def self.validate_create_flavor(ext_management_system, _options = {})
@@ -24,7 +26,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
     end
   rescue => err
     _log.error "flavor=[#{name}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def validate_delete_flavor

--- a/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggregate
+  include ManageIQ::Providers::Openstack::HelperMethods
 
   supports :update_aggregate
   supports :delete_aggregate
@@ -53,7 +54,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
             :ext_management_system => ext_management_system)
   rescue => e
     _log.error "host_aggregate=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqHostAggregateCreateError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateCreateError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def external_aggregate
@@ -98,7 +99,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
     end
   rescue => e
     _log.error "host_aggregate=[#{name}], error: #{e}"
-    raise MiqException::MiqHostAggregateUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateUpdateError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def update_aggregate_metadata(new_metadata)
@@ -110,7 +111,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
     aggr.update_metadata(out_metadata)
   rescue => e
     _log.error "host_aggregate=[#{name}], error: #{e}"
-    raise MiqException::MiqHostAggregateUpdateError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateUpdateError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def delete_aggregate_queue(userid)
@@ -134,7 +135,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
     external_aggregate.destroy
   rescue => e
     _log.error "host_aggregate=[#{name}], error: #{e}"
-    raise MiqException::MiqHostAggregateDeleteError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateDeleteError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def external_host_list
@@ -176,7 +177,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
     end
   rescue => e
     _log.error "host_aggregate=[#{name}], error: #{e}"
-    raise MiqException::MiqHostAggregateAddHostError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateAddHostError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def remove_host_queue(userid, old_host)
@@ -206,6 +207,6 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
     end
   rescue => e
     _log.error "host_aggregate=[#{name}], error: #{e}"
-    raise MiqException::MiqHostAggregateRemoveHostError, e.to_s, e.backtrace
+    raise MiqException::MiqHostAggregateRemoveHostError, parse_error_message_from_fog_response(e), e.backtrace
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
+  include ManageIQ::Providers::Openstack::HelperMethods
   require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
@@ -10,7 +11,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
     end
   rescue => err
     _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationProvisionError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_update_stack(template, options)
@@ -23,7 +24,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationUpdateError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_delete_stack
@@ -34,7 +35,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationDeleteError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_status
@@ -51,7 +52,7 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
     raise
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationStatusError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def self.transform_parameters(template, deploy_parameters)

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
+  include ManageIQ::Providers::Openstack::HelperMethods
   belongs_to :cloud_tenant
 
   supports :smartstate_analysis do
@@ -79,7 +80,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
     end
   rescue => err
     _log.error("image=[#{name}], error=[#{err}]")
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def self.validate_create_image(ext_management_system, _options = {})
@@ -102,7 +103,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
     end
   rescue => err
     _log.error("image=[#{name}], error: #{err}")
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def update_image(options)
@@ -115,7 +116,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
     end
   rescue => err
     _log.error("image=[#{name}], error: #{err}")
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def validate_delete_image

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
     end
   rescue => err
     _log.error "vm=[#{name}], floating_ip=[#{floating_ip}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_disassociate_floating_ip(floating_ip)
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
     end
   rescue => err
     _log.error "vm=[#{name}], floating_ip=[#{floating_ip}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def compute_connection_options

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/manage_security_groups.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/manage_security_groups.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::ManageSecurityGroups
     end
   rescue => err
     _log.error "vm=[#{name}], security_group=[#{security_group}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_remove_security_group(security_group)
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::ManageSecurityGroups
     end
   rescue => err
     _log.error "vm=[#{name}], security_group=[#{security_group}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def compute_connection_options

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
                  :method_name => "raw_resize_finish")
   rescue => err
     _log.error "vm=[#{name}], flavor=[#{new_flavor.name}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def validate_resize_confirm
@@ -33,7 +33,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
     end
   rescue => err
     _log.error "vm=[#{name}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_resize_finish
@@ -52,7 +52,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
     end
   rescue => err
     _log.error "vm=[#{name}], error: #{err}"
-    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def compute_connection_options

--- a/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::CloudManager::OrchestrationStack
+  include ManageIQ::Providers::Openstack::HelperMethods
   require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
@@ -11,14 +12,14 @@ class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::C
     end
   rescue => err
     _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationProvisionError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_update_stack(_template, _options)
     # TODO(lsmola) implement updates
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationUpdateError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_delete_stack
@@ -29,7 +30,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::C
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationDeleteError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_status
@@ -46,6 +47,6 @@ class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::C
     raise
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationStatusError, parse_error_message_from_fog_response(err), err.backtrace
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -1,6 +1,7 @@
 require 'manageiq/providers/openstack/legacy/openstack_configuration_parser'
 
 class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
+  include ManageIQ::Providers::Openstack::HelperMethods
   belongs_to :availability_zone
 
   has_many :host_service_group_openstacks, :foreign_key => :host_id, :dependent => :destroy,
@@ -232,7 +233,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
   rescue => e
     _log.error "host=[#{name}], error: #{e}"
-    raise MiqException::MiqOpenstackInfraHostSetManageableError, e.to_s, e.backtrace
+    raise MiqException::MiqOpenstackInfraHostSetManageableError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def introspect_queue(userid = "system", _options = {})
@@ -272,7 +273,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
   rescue => e
     _log.error "host=[#{name}], error: #{e}"
-    raise MiqException::MiqOpenstackInfraHostIntrospectError, e.to_s, e.backtrace
+    raise MiqException::MiqOpenstackInfraHostIntrospectError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def provide_queue(userid = "system", _options = {})
@@ -311,7 +312,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
   rescue => e
     _log.error "host=[#{name}], error: #{e}"
-    raise MiqException::MiqOpenstackInfraHostProvideError, e.to_s, e.backtrace
+    raise MiqException::MiqOpenstackInfraHostProvideError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def validate_start
@@ -378,7 +379,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
   rescue => e
     _log.error "ironic node=[#{uid_ems}], error: #{e}"
-    raise MiqException::MiqOpenstackInfraHostDestroyError, e.to_s, e.backtrace
+    raise MiqException::MiqOpenstackInfraHostDestroyError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
   def refresh_network_interfaces(ssu)

--- a/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
@@ -81,6 +81,6 @@ module ManageIQ::Providers::Openstack::InfraManager::Host::Operations
     end
   rescue => e
     _log.error "node=[#{name}], error: #{e}"
-    raise MiqException::MiqOpenstackInfraHostSetPowerStateError, e.to_s, e.backtrace
+    raise MiqException::MiqOpenstackInfraHostSetPowerStateError, parse_error_message_from_fog_response(e), e.backtrace
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::OrchestrationStack
+  include ManageIQ::Providers::Openstack::HelperMethods
+
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::InfraManager"
   belongs_to :orchestration_template
   belongs_to :cloud_tenant
@@ -25,7 +27,7 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationUpdateError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def update_ready?
@@ -41,7 +43,7 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationDeleteError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def raw_status
@@ -57,7 +59,7 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
     raise
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationStatusError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   def queue_post_scaledown_task(services, task_id = nil)
@@ -135,7 +137,7 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
 
   def log_and_raise_update_error(method_name, err)
     _log.error "MIQ(#{self}.#{method_name}) stack=[#{name}], error: #{err}"
-    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+    raise MiqException::MiqOrchestrationUpdateError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
   private :log_and_raise_update_error


### PR DESCRIPTION
Should make the UI prettier when things go wrong, instead of spraying poorly formatted JSON everywhere.