### PR TITLE
manageiq-gems-pending is already from manageiq itself

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,5 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-# We are using 'miq-password' from gems-pending
-gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-
 # Load Gemfile with dependencies from manageiq
 eval_gemfile(File.expand_path("spec/manageiq/Gemfile", __dir__))


### PR DESCRIPTION
While this doesn't have a problem on master because the lines in both Gemfiles (this one and manageiq/manageiq's Gemfile) are identical, this causes an issue on release branches because manageiq's gemfile says the new branch name (e.g. gaprindashvili), but then this file has a different branch name (e.g. master), and that blows up.  While we *could* just change it on the branch to the new release branch name, we don't want to have to remember to maintain that.

@simaishi Please review.
cc @aufi