### PR TITLE
Handle attempts to delete volumes that have already been deleted

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -56,15 +56,8 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def validate_delete_volume
     msg = validate_volume
     return {:available => msg[:available], :message => msg[:message]} unless msg[:available]
-    begin
-      if with_provider_object(&:status) == "in-use"
-        return validation_failed("Delete Volume", "Can't delete volume that is in use.")
-      end
-    # NoMethodError here usually means the above block got a nil while checking the volume
-    # status, probably because the user already deleted the volume. Assume that's the case
-    # and show a reassuring message.
-    rescue NoMethodError
-      return validation_failed("Delete Volume", "Volume already queued for deletion.")
+    if status == "in-use"
+      return validation_failed("Delete Volume", "Can't delete volume that is in use.")
     end
     {:available => true, :message => nil}
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -56,8 +56,15 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def validate_delete_volume
     msg = validate_volume
     return {:available => msg[:available], :message => msg[:message]} unless msg[:available]
-    if with_provider_object(&:status) == "in-use"
-      return validation_failed("Create Volume", "Can't delete volume that is in use.")
+    begin
+      if with_provider_object(&:status) == "in-use"
+        return validation_failed("Delete Volume", "Can't delete volume that is in use.")
+      end
+    # NoMethodError here usually means the above block got a nil while checking the volume
+    # status, probably because the user already deleted the volume. Assume that's the case
+    # and show a reassuring message.
+    rescue NoMethodError
+      return validation_failed("Delete Volume", "Volume already queued for deletion.")
     end
     {:available => true, :message => nil}
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -100,19 +100,19 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
 
     context "#delete_volume" do
       it "validates the volume delete operation when status is in-use" do
-        expect(the_raw_volume).to receive(:status).and_return("in-use")
+        expect(cloud_volume).to receive(:status).and_return("in-use")
         validation = cloud_volume.validate_delete_volume
         expect(validation[:available]).to be false
       end
 
       it "validates the volume delete operation when status is available" do
-        expect(the_raw_volume).to receive(:status).and_return("available")
+        expect(cloud_volume).to receive(:status).and_return("available")
         validation = cloud_volume.validate_delete_volume
         expect(validation[:available]).to be true
       end
 
       it "validates the volume delete operation when status is error" do
-        expect(the_raw_volume).to receive(:status).and_return("error")
+        expect(cloud_volume).to receive(:status).and_return("error")
         validation = cloud_volume.validate_delete_volume
         expect(validation[:available]).to be true
       end


### PR DESCRIPTION
This handles an exception that would occur when attempting to delete
a volume that was already deleted from the provider, but the deletion
was not yet reflected in ManageIQ. The exception is now caught and
a nice error message is shown.

https://bugzilla.redhat.com/show_bug.cgi?id=1487234
