### PR TITLE
BZ 1396218: don't attempt cloning of OpenStack infra templates

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/template.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Template < ManageIQ::Provide
       unsupported_reason_add(:smartstate_analysis, reason)
     end
   end
+  supports_not :clone
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1396218

OpenStack infra template cloning is not supported. With this fix
a flash message tells the user this is unsupported rather than
trying (and failing) to render the clone form.