### PR TITLE
safe_call should catch Fog::Errors::NotFound

### DIFF
--- a/app/models/manageiq/providers/openstack/refresh_parser_common/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/helper_methods.rb
@@ -44,7 +44,7 @@ module ManageIQ::Providers
           _log.warn "Unauthorized response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")
           nil
-        rescue Excon::Errors::NotFound => err
+        rescue Excon::Errors::NotFound, Fog::Errors::NotFound => err
           # It can happen that some data do not exist anymore,, in that case log warning but continue refresh
           _log.warn "Not Found response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")


### PR DESCRIPTION
Some fog calls raise subclasses of `Fog::Errors::NotFound` instead of `Excon::Errors::NotFound`. This change allows `safe_call` (and by extension `safe_list`) to handle those cases.

This should fix issues with deleted flavors crashing refresh despite the catch, since `list_tenants_with_flavor_access` throws `Fog::Compute::OpenStack::NotFound`.