### PR TITLE
Fix missing quota calculations

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
@@ -75,4 +75,46 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota < ::Cloud
   def subnet_quota_used
     CloudSubnet.joins(:cloud_network).where("cloud_networks.cloud_tenant_id" => cloud_tenant_id).count
   end
+
+  def port_quota_used
+    NetworkPort.where(:cloud_tenant_id => cloud_tenant_id).count
+  end
+
+  def volumes_quota_used
+    CloudVolume.where(:cloud_tenant_id => cloud_tenant_id).count
+  end
+
+  def gigabytes_quota_used
+    CloudVolume.where(:cloud_tenant_id => cloud_tenant_id)
+               .sum(:size) / 1_073_741_824
+  end
+
+  def backups_quota_used
+    CloudVolumeBackup.joins(:cloud_volume)
+                     .where("cloud_volumes.cloud_tenant_id" => cloud_tenant_id).count
+  end
+
+  def backup_gigabytes_quota_used
+    CloudVolumeBackup.joins(:cloud_volume)
+                     .where("cloud_volumes.cloud_tenant_id" => cloud_tenant_id)
+                     .sum(:size) / 1_073_741_824
+  end
+
+  def snapshots_quota_used
+    CloudVolumeSnapshot.where(:cloud_tenant_id => cloud_tenant_id).count
+  end
+
+  def ems
+    CloudTenant.find(cloud_tenant_id).ext_management_system
+  end
+
+  def key_pairs_quota_used
+    Authentication.where(:resource_id   => ems.id,
+                         :resource_type => 'ExtManagementSystem',
+                         :type          => ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.name).count
+  end
+
+  def router_quota_used
+    NetworkRouter.where(:cloud_tenant_id => cloud_tenant_id).count
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -245,7 +245,11 @@ module ManageIQ::Providers
       # The array of hashes returned from this block is the same as what would
       # be produced by parse_quota ... so, parse_quota just returns the same
       # hash with a compound key.
-      quota.except("id", "tenant_id", "service_name").collect do |key, value|
+      # Metadata items, injected files, server groups, and rbac policies are not modeled.
+      # Skip them for now.
+      quota.except("id", "tenant_id", "service_name", "metadata_items", "injected_file_content_bytes",
+                   "injected_files", "injected_file_path_bytes", "server_groups", "server_group_members",
+                   "rbac_policy").collect do |key, value|
         begin
           value = value.to_i
         rescue


### PR DESCRIPTION
Add missing quota information that were being displayed as unknown.

Disabled collection of metadata items, injected files, server groups,
and rbac policies quotas because we don't model them.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1504576