### PR TITLE
add error message if FIP assigned to router

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -13,6 +13,11 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
         :table => ui_lookup(:table => "ext_management_systems")
       })
     end
+    if network_ports.any?
+      unsupported_reason_add(:delete, _("Unable to delete \"%{name}\" because it has associated ports.") % {
+        :name => name
+      })
+    end
   end
 
   supports :update do


### PR DESCRIPTION
Router can't be deleted if has assigned floating ips.
https://bugzilla.redhat.com/show_bug.cgi?id=1470754