### PR TITLE
Add i18n string placeholders test

### DIFF
--- a/spec/i18n/placeholders_spec.rb
+++ b/spec/i18n/placeholders_spec.rb
@@ -1,0 +1,3 @@
+describe :placeholders do
+  include_examples :placeholders, ManageIQ::Providers::Openstack::Engine.root.join('locale').to_s
+end


### PR DESCRIPTION
This is just invocation of standard i18n placeholder test, included from main ManageIQ
repository. It's the same thing that we do in ui-classic to test that the provided translations
honor placeholders in the original (English) strings.