### PR TITLE
Don't pass nil ssl_options to try_connection

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -48,7 +48,7 @@ module OpenstackHandle
 
     def self.raw_connect_try_ssl(username, password, address, port, service = "Compute", opts = nil, api_version = nil,
                                  security_protocol = nil)
-      ssl_options = opts.delete(:ssl_options)
+      ssl_options = opts.delete(:ssl_options) || {}
       try_connection(security_protocol, ssl_options) do |scheme, connection_options|
         auth_url = auth_url(address, port, scheme, api_version)
         opts[:connection_options] = (opts[:connection_options] || {}).merge(connection_options)


### PR DESCRIPTION
Should fix the bug reported in https://bugzilla.redhat.com/show_bug.cgi?id=1518182 by ensuring that `ssl_options` is always a hash when it gets passed into `try_connection`, so that the attempt to `merge` it doesn't fail.