### PR TITLE
Set VolumeTemplate name to ID if empty

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       next if vt.attributes["bootable"].to_s != "true"
       volume_template = persister.miq_templates.find_or_build(vt.id)
       volume_template.type = "ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate"
-      volume_template.name = vt.name.blank? ? "N/A" : vt.name
+      volume_template.name = vt.name.blank? ? vt.id : vt.name
       volume_template.cloud_tenant = persister.cloud_tenants.lazy_find(vt.tenant_id) if vt.tenant_id
       volume_template.location = "N/A"
       volume_template.vendor = "openstack"
@@ -36,7 +36,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       # next if vt["attributes"].["bootable"].to_s != "true"
       volume_template = persister.miq_templates.find_or_build(vt["id"])
       volume_template.type = "ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate"
-      volume_template.name = (vt['display_name'] || vt['name']).blank? ? "N/A" : (vt['display_name'] || vt['name'])
+      volume_template.name = (vt['display_name'] || vt['name']).blank? ? vt.id : (vt['display_name'] || vt['name'])
       volume_template.cloud_tenant = persister.cloud_tenants.lazy_find(vt["tenant_id"]) if vt["tenant_id"]
       volume_template.location = "N/A"
       volume_template.vendor = "openstack"


### PR DESCRIPTION
OpenStack volume can have empty name. This PR set name = id when name was empty
in order to allow user identify volume in Instance provisioning form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518637