### PR TITLE
Skip disabled tenants when connecting to OpenStack

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -373,7 +373,8 @@ module OpenstackHandle
         # the "services" tenant is a special tenant in openstack reserved
         # specifically for the various services
         next if t.name == "services"
-        tenant_accessible?(t.name)
+        # disabled and non-accessible tenants are skipped
+        t.enabled && tenant_accessible?(t.name)
       end
     end
 


### PR DESCRIPTION
Attempts to connect with disabled tenants generated misleading error messages,
skipping disabled tenants when obtaining connection to OpenStack.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518625