### PR TITLE
Return true instead of connection object for creds validation

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -12,6 +12,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   #
   module ClassMethods
     def raw_connect(password, params, service = "Compute")
+      # TODO: this method seems to be used only for Provider credentials validation
       ems = new
       ems.name                   = params[:name].strip
       ems.provider_region        = params[:provider_region]
@@ -28,6 +29,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
 
       begin
         ems.connect(:service => service)
+        true
       rescue => err
         miq_exception = translate_exception(err)
         raise unless miq_exception


### PR DESCRIPTION
A validate credentials action on Cloud Provider uses raw_connect method on ManagerMixin via MiqQueue,
that leads to exposing credentials to log entry related to MiqQueue handling.

Changed to return true instead of connection object from the method.

Related github issue: https://github.com/ManageIQ/manageiq-providers-openstack/issues/174