### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -161,6 +161,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     %w(default amqp)
   end
 
+  def supported_catalog_types
+    %w(openstack)
+  end
+
   def supports_provider_id?
     true
   end

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -95,6 +95,10 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
     supported_auth_types.include?(authtype.to_s)
   end
 
+  def supported_catalog_types
+    %w(openstack)
+  end
+
   def self.event_monitor_class
     ManageIQ::Providers::Openstack::InfraManager::EventCatcher
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -207,4 +207,12 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     end
 
   end
+
+  context "catalog types" do
+    let(:ems) { FactoryGirl.create(:ems_openstack) }
+
+    it '#supported_catalog_types' do
+      expect(ems.supported_catalog_types).to eq(%w(openstack))
+    end
+  end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -141,4 +141,12 @@ describe ManageIQ::Providers::Openstack::InfraManager do
       expect(@cluster.cloud_object_storage_disk_usage).to eq(12 * 2)
     end
   end
+
+  context "catalog types" do
+    let(:ems) { FactoryGirl.create(:ems_openstack_infra_with_authentication) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(openstack))
+    end
+  end
 end


### PR DESCRIPTION
For Service catalog items each provider has to now list the supported catalog types.

Needed for PR https://github.com/ManageIQ/manageiq/pull/16559