### PR TITLE
Use proper nested references in parser

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -190,7 +190,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
 
       guest_os = OperatingSystem.normalize_os_name(i.try(:os_distro) || 'unknown')
 
-      hardware = persister.hardwares.find_or_build(i.id)
+      hardware = persister.hardwares.find_or_build(image)
       hardware.vm_or_template = image
       hardware.guest_os = guest_os
       hardware.bitness = image_architecture(i)
@@ -326,7 +326,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       make_flavor(flavor) unless flavor.nil?
       server.flavor = persister.flavors.lazy_find(s.flavor["id"].to_s)
 
-      hardware = persister.hardwares.find_or_build(s.id)
+      hardware = persister.hardwares.find_or_build(server)
       hardware.vm_or_template = server
       hardware.cpu_sockets = flavor.try(:vcpus)
       hardware.cpu_total_cores = flavor.try(:vcpus)
@@ -345,7 +345,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
 
       unless s.private_ip_address.blank?
         private_network = persister.networks.find_or_build_by(
-          :hardware    => persister.hardwares.lazy_find(s.id),
+          :hardware    => hardware,
           :description => "private"
         )
         private_network.description = "private"
@@ -353,7 +353,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       end
       unless s.public_ip_address.blank?
         public_network = persister.networks.find_or_build_by(
-          :hardware    => persister.hardwares.lazy_find(s.id),
+          :hardware    => hardware,
           :description => "public"
         )
         public_network.description = "public"

--- a/app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb
@@ -29,7 +29,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager < Manage
       network.vlan_transparent = n.attributes["vlan_transparent"]
       network.maximum_transmission_unit = n.attributes["mtu"]
       network.cloud_tenant = persister.cloud_tenants.lazy_find(n.tenant_id)
-      network.orchestration_stack = persister.orchestration_stacks.lazy_find(collector.orchestration_stack_by_resource_id(n.id))
+      network.orchestration_stack = persister.orchestration_stacks_resources.lazy_find(
+        collector.orchestration_stack_by_resource_id(n.id).try(:physical_resource_id), :key => :stack
+      )
       n.subnets.each do |s|
         subnet = persister.cloud_subnets.find_or_build(s.id)
         subnet.type = "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet"
@@ -127,7 +129,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager < Manage
       security_group.name = s.name
       security_group.description = s.description.try(:truncate, 255)
       security_group.cloud_tenant = persister.cloud_tenants.lazy_find(s.tenant_id)
-      security_group.orchestration_stack = persister.orchestration_stacks.lazy_find(collector.orchestration_stack_by_resource_id(s.id))
+      security_group.orchestration_stack = persister.orchestration_stacks_resources.lazy_find(
+        collector.orchestration_stack_by_resource_id(s.id).try(:physical_resource_id), :key => :stack
+      )
 
       s.security_group_rules.each do |r|
         case collector.network_service.name

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
 
       attachment_names = {'vda' => 'Root disk', 'vdb' => 'Ephemeral disk', 'vdc' => 'Swap disk'}
       persister.disks.find_or_build_by(
-        :hardware    => persister.hardwares.lazy_find(a["server_id"]),
+        :hardware    => persister.hardwares.lazy_find(persister.vms.lazy_find(a["server_id"])),
         :device_name => attachment_names.fetch(dev, dev)
       ).assign_attributes(
         :location        => dev,

--- a/app/models/manageiq/providers/openstack/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/network_manager.rb
@@ -26,6 +26,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::NetworkManager < Man
       %i(
         vms
         orchestration_stacks
+        orchestration_stacks_resources
         availability_zones
         cloud_tenants
       ),

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -31,6 +31,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       assert_table_counts
       assert_ems
       assert_specific_host
+      assert_mapped_stacks
       assert_specific_public_template
     end
   end
@@ -234,5 +235,29 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     expect(template.hardware).not_to               be_nil
     expect(template.parent).to                     be_nil
     template
+  end
+
+  def assert_mapped_stacks
+    expect(CloudNetwork.all.map { |x| "#{x.name}___#{x.orchestration_stack.try(:name)}" }).to(
+      match_array(
+        %w(
+          storage___overcloud-Networks-pbb77pcdo5vf-StorageNetwork-alynjx5sbihk
+          internal_api___overcloud-Networks-pbb77pcdo5vf-InternalNetwork-m6gf3fnrmv2o
+          external___overcloud-Networks-pbb77pcdo5vf-ExternalNetwork-t35bvwrbnmml
+          storage_mgmt___overcloud-Networks-pbb77pcdo5vf-StorageMgmtNetwork-4hapfhdgyuxk
+          ctlplane___
+          tenant___overcloud-Networks-pbb77pcdo5vf-TenantNetwork-6ls6x5prvhle
+        )
+      )
+    )
+
+    expect(SecurityGroup.all.map { |x| "#{x.name}___#{x.orchestration_stack.try(:name)}" }).to(
+      match_array(
+        %w(
+          default___
+          default___
+        )
+      )
+    )
   end
 end


### PR DESCRIPTION
Use proper nested references in parser. Adding nested
lazy_finds to correctly model a complex link.
  
Fixes  https://github.com/ManageIQ/manageiq-providers-openstack/issues/164