### PR TITLE
Return empty AR relation instead of nil for ::InfraManager#cloud_tenants

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -31,6 +31,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   end
 
   def cloud_tenants
+    self.class.none
   end
 
   def host_aggregates

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -149,4 +149,10 @@ describe ManageIQ::Providers::Openstack::InfraManager do
       expect(ems.supported_catalog_types).to eq(%w(openstack))
     end
   end
+
+  let(:openstack_infra_manager) { FactoryGirl.create(:ems_openstack_infra_with_authentication) }
+
+  it 'returns empty relation instead of nil when cloud_tenants are requested on infra provider' do
+    expect(openstack_infra_manager.cloud_tenants).to eq(ManageIQ::Providers::Openstack::InfraManager.none)
+  end
 end


### PR DESCRIPTION
InfraProvider don't have relation to cloud_tenants - there was
created only empty method returning nil to preserve consitency - but on
some places is expected AR relation object.

For example screen add new subnet, there are listed network managers and
their parent manager's cloud_tenants but they can be infra manager whithout
cloud_tenants.

Such place, where was expected AR Relation object is here:
https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/subcollections/cloud_tenants.rb#L5

which was reached for example by this request:

http://localhost:3000/api/providers/:id/cloud_tenants but it fails later
when object has been infra manager and the method cloud_tenants_query_resource
was returning nil.

@miq-bot add_label graprindashvili/yes, bug


cc @gtanzillo 
@miq-bot assign @aufi 


### Reproducer
![zytkbnyvnw](https://user-images.githubusercontent.com/14937244/34523548-4032eb52-f098-11e7-9e94-e2e541623c2e.gif)


### Links
it was found during BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1463422

