### PR TITLE
Use only hypervisor hostname to match infra host with cloud vm

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -286,7 +286,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
 
     collector.vms.each do |s|
       if hosts && !s.os_ext_srv_attr_host.blank?
-        parent_host = hosts.find_by('lower(hypervisor_hostname) = ?', s.os_ext_srv_attr_host.downcase)
+        parent_host = hosts.find_by('lower(hypervisor_hostname) = ? OR lower(hypervisor_hostname) = ?', s.os_ext_srv_attr_host.split('.').first.downcase, s.os_ext_srv_attr_host.downcase)
         parent_cluster = parent_host.try(:ems_cluster)
       else
         parent_host = nil


### PR DESCRIPTION
Hosts are stored in db with only hostname part of hostname.domain which
we can see in OpenStack.
That caused issue with matching VMs with Hosts when Cloud OpenStack had
Infra OpenStack related to it.

Solves https://bugzilla.redhat.com/show_bug.cgi?id=1528162

![screenshot-2018-1-4 manageiq infrastructure providers](https://user-images.githubusercontent.com/122827/34583650-d6fb0fa0-f198-11e7-8765-d6a1000454d1.png)
![screenshot-2018-1-4 manageiq nodes](https://user-images.githubusercontent.com/122827/34583678-f0f4cac2-f198-11e7-8d29-85d6b95c94f2.png)

