### PR TITLE
BZ 1520565: Track guest OS for openstack images and VMs

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -311,6 +311,7 @@ module ManageIQ::Providers
       end
 
       parent_image_uid = server.image["id"]
+      parent_image = @data_index.fetch_path(:vms, parent_image_uid)
 
       new_result = {
         :type                => "ManageIQ::Providers::Openstack::CloudManager::Vm",
@@ -352,6 +353,18 @@ module ManageIQ::Providers
 
       disks = new_result[:hardware][:disks]
       dev = "vda"
+
+      if parent_image
+        guest_os = parent_image.fetch_path(:hardware, :guest_os)
+        os_distro = parent_image.fetch_path(:operating_system, :distribution)
+        os_version = parent_image.fetch_path(:operating_system, :version)
+        new_result.store_path(:operating_system, :distribution, os_distro)
+        new_result.store_path(:operating_system, :version, os_version)
+      else
+        guest_os = "unknown"
+      end
+      new_result.store_path(:hardware, :guest_os, guest_os)
+      new_result.store_path(:operating_system, :product_name, guest_os)
 
       if flavor
         if (sz = flavor[:root_disk_size]) == 0

--- a/app/models/manageiq/providers/openstack/inventory/persister/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/cloud_manager.rb
@@ -28,6 +28,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::CloudManager < Manag
       cloud,
       %i(
         hardwares
+        operating_systems
         disks
         networks
         orchestration_templates

--- a/app/models/manageiq/providers/openstack/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/target_collection.rb
@@ -17,8 +17,8 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::TargetCollection < M
     # Child models with references in the Parent InventoryCollections for Cloud
     add_inventory_collections(
       cloud,
-      %i(hardwares networks disks orchestration_stacks_resources orchestration_stacks_outputs
-         orchestration_stacks_parameters),
+      %i(hardwares operating_systems networks disks orchestration_stacks_resources
+         orchestration_stacks_outputs orchestration_stacks_parameters),
       :strategy => strategy,
       :targeted => true
     )

--- a/app/models/manageiq/providers/openstack/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory_collection_default/cloud_manager.rb
@@ -107,6 +107,7 @@ class ManageIQ::Providers::Openstack::InventoryCollectionDefault::CloudManager <
           :memory_mb,
           :disk_capacity,
           :bitness,
+          :guest_os,
           :disk_size_minimum,
           :memory_mb_minimum,
           :root_device_type,
@@ -114,6 +115,19 @@ class ManageIQ::Providers::Openstack::InventoryCollectionDefault::CloudManager <
           :virtualization_type
         ]
       }
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def operating_systems(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => [
+          :vm_or_template,
+          :product_name,
+          :distribution,
+          :version,
+        ]
+      }
+
       super(attributes.merge!(extra_attributes))
     end
 

--- a/app/models/manageiq/providers/openstack/refresh_parser_common/images.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/images.rb
@@ -15,6 +15,7 @@ module ManageIQ::Providers::Openstack
       def parse_image(image)
         uid               = image.id
         parent_server_uid = parse_image_parent_id(image)
+        guest_os = OperatingSystem.normalize_os_name(image.try(:os_distro) || 'unknown')
 
         new_result = {
           :type               => self.class.miq_template_type,
@@ -26,7 +27,13 @@ module ManageIQ::Providers::Openstack
           :template           => true,
           :publicly_available => public?(image),
           :cloud_tenants      => image_tenants(image),
+          :operating_system   => {
+            :product_name => guest_os,
+            :distribution => image.try(:os_distro),
+            :version      => image.try(:os_version)
+          },
           :hardware           => {
+            :guest_os            => guest_os,
             :bitness             => architecture(image),
             :disk_size_minimum   => (image.min_disk * 1.gigabyte),
             :memory_mb_minimum   => image.min_ram,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -81,7 +81,7 @@ module Openstack
       expect(Disk.count).to                              eq disks_count
       expect(Hardware.count).to                          eq vms_count + images_count
       expect(Vm.count).to                                eq vms_count
-      expect(OperatingSystem.count).to                   eq 0
+      expect(OperatingSystem.count).to                   eq vms_count + images_count
       expect(Snapshot.count).to                          eq 0
       expect(SystemService.count).to                     eq 0
       expect(GuestDevice.count).to                       eq 0
@@ -265,7 +265,7 @@ module Openstack
       # TODO(lsmola) 2 networks per each floatingip assigned, it's kinda weird now, will replace with
       # neutron models, then the number of networks will fit the number of neutron networks
       # expect(Network.count).to           eq vms_count * 2
-      expect(OperatingSystem.count).to                   eq 0
+      expect(OperatingSystem.count).to                   eq vms_count + images_count
       expect(Snapshot.count).to                          eq 0
       expect(SystemService.count).to                     eq 0
       expect(GuestDevice.count).to                       eq 0
@@ -697,7 +697,7 @@ module Openstack
         expect(template.ems_ref).to be_guid
 
         expect(template.ext_management_system).to  eq @ems
-        expect(template.operating_system).to       be_nil # TODO: This should probably not be nil
+        expect(template.operating_system).not_to   be_nil
         expect(template.custom_attributes.size).to eq 0
         expect(template.snapshots.size).to         eq 0
         expect(template.hardware).not_to           be_nil
@@ -787,7 +787,7 @@ module Openstack
       expect(vm.flavor.name).to            eq vm_expected[:__flavor_name]
       expect(vm.key_pairs.map(&:name)).to  eq [vm_expected[:key_name]]
       expect(vm.genealogy_parent.name).to  eq vm_expected[:__image_name]
-      expect(vm.operating_system).to       be_nil # TODO: This should probably not be nil
+      expect(vm.operating_system).not_to   be_nil
       expect(vm.custom_attributes.size).to eq 0
       expect(vm.snapshots.size).to         eq 0
 
@@ -950,7 +950,7 @@ module Openstack
       expect(vm.flavor.name).to            eq "m1.ems_refresh_spec"
       expect(vm.key_pairs.map(&:name)).to  eq ["EmsRefreshSpec-KeyPair"]
       expect(vm.genealogy_parent.name).to  eq "EmsRefreshSpec-Image"
-      expect(vm.operating_system).to       be_nil # TODO: This should probably not be nil
+      expect(vm.operating_system).not_to   be_nil
       expect(vm.custom_attributes.size).to eq 0
       expect(vm.snapshots.size).to         eq 0
 

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -228,7 +228,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     expect(template.ems_ref).to be_guid
 
     expect(template.ext_management_system).to eq @ems
-    expect(template.operating_system).to be_nil # TODO: This should probably not be nil
+    expect(template.operating_system).not_to be_nil
     expect(template.custom_attributes.size).to eq 0
     expect(template.snapshots.size).to         eq 0
     expect(template.hardware).not_to               be_nil


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1520565

Use os_distro and os_version properties on glance images to track operating system
information on templates and VMs.