### PR TITLE
Added keystone_v3_domain_id to api_allowed_attributes method

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -129,6 +129,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     )
   end
 
+  def self.api_allowed_attributes
+    %w[keystone_v3_domain_id].freeze
+  end
+
   def hostname_uniqueness_valid?
     return unless hostname_required?
     return unless hostname.present? # Presence is checked elsewhere


### PR DESCRIPTION
This is a follow on PR from ManageIQ/manageiq#16802/
and ManageIQ/manageiq-api#279