### PR TITLE
Extend allowed_cloud_network for providers that don't support allowed_ci

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -20,6 +20,14 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     end
   end
 
+  def allowed_cloud_networks(_options = {})
+    return {} unless (src_obj = provider_or_tenant_object)
+
+    src_obj.all_cloud_networks.each_with_object({}) do |cn, hash|
+      hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
+    end
+  end
+
   def allowed_cloud_tenants(_options = {})
     source = load_ar_obj(get_source_vm)
     ems = get_targets_for_ems(source, :cloud_filter, CloudTenant, 'cloud_tenants')

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -216,6 +216,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           expect(workflow.allowed_availability_zones).to eq({})
         end
 
+        it "#allowed_cloud_networks" do
+          expect(workflow.allowed_cloud_networks).to eq({})
+        end
+
         it "#allowed_guest_access_key_pairs" do
           expect(workflow.allowed_guest_access_key_pairs).to eq({})
         end
@@ -239,6 +243,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           azs = workflow.allowed_availability_zones
           expect(azs.length).to eq(1)
           expect(azs.first).to eq([az.id, az.name])
+        end
+
+        it "#allowed_cloud_networks" do
+          cn = FactoryGirl.create(:cloud_network)
+          provider.cloud_networks << cn
+          expect(workflow.allowed_cloud_networks).to eq(cn.id => cn.name)
         end
 
         it "#allowed_guest_access_key_pairs" do


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16811 and https://github.com/ManageIQ/manageiq/pull/16688 adds RBAC filtering to allowed_cloud_network base class but two of the providers don't support the allowed_ci method so for them we need to overwrite the allowed_cloud_networks, to just return allowed_cloud_networks. Which this does! (Per https://github.com/ManageIQ/manageiq/pull/16824#discussion_r161679886)

Fixes issue caused by fix of https://bugzilla.redhat.com/show_bug.cgi?id=1533277
(Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535189)

## Related to:
https://github.com/ManageIQ/manageiq-providers-google/pull/41