### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -385,4 +385,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   def object_storage_disk_usage(swift_replicas = 1)
     cloud_object_store_containers.sum(:bytes).to_f * swift_replicas
   end
+
+  def self.display_name(number = 1)
+    n_('Cloud Provider (OpenStack)', 'Cloud Providers (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -43,6 +43,10 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
     connection_options
   end
 
+  def self.display_name(number = 1)
+    n_('Cloud Tenant (OpenStack)', 'Cloud Tenants (OpenStack)', number)
+  end
+
   private
 
   def connection_options

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -68,4 +68,8 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageI
       end
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Orchestration Stack (OpenStack)', 'Orchestration Stacks (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb
@@ -83,6 +83,10 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate < ::Or
     content.strip.start_with?('{') ? 'json'.freeze : 'yaml'.freeze
   end
 
+  def self.display_name(number = 1)
+    n_('Heat Template', 'Heat Templates', number)
+  end
+
   private
 
   def parse

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -166,4 +166,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   def memory_mb_available?
     true
   end
+
+  def self.display_name(number = 1)
+    n_('Instance (OpenStack)', 'Instances (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vnfd_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vnfd_template.rb
@@ -66,4 +66,8 @@ class ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate < ::Orchestrati
     self.orderable = true
     save!
   end
+
+  def self.display_name(number = 1)
+    n_('VNF Template', 'VNF Templates', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -170,4 +170,8 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   def validate_shutdown
     {:available => false,   :message => nil}
   end
+
+  def self.display_name(number = 1)
+    n_('Infrastructure Provider (OpenStack)', 'Infrastructure Providers (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -424,4 +424,8 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     _log.warn("Error in refreshing network interfaces of host #{id}. Error: #{e.message}")
     _log.warn(e.backtrace.join("\n"))
   end
+
+  def self.display_name(number = 1)
+    n_('Host (OpenStack)', 'Hosts (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
@@ -139,6 +139,10 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
     log_and_raise_update_error(__method__, err)
   end
 
+  def self.display_name(number = 1)
+    n_('Orchestration Stack (OpenStack)', 'Orchestration Stacks (OpenStack)', number)
+  end
+
   private
 
   def scale_queue(method_name, userid, parameters)

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -194,4 +194,8 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
     }
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
+
+  def self.display_name(number = 1)
+    n_('Network Provider (OpenStack)', 'Network Providers (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -182,6 +182,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Cloud Network (OpenStack)', 'Cloud Networks (OpenStack)', number)
+  end
+
   private
 
   def connection_options(cloud_tenant = nil)

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (OpenStack)', 'Cloud Networks (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/public.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/public.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
+  def self.display_name(number = 1)
+    n_('External Cloud Network (OpenStack)', 'External Cloud Networks (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -96,6 +96,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     connection_options
   end
 
+  def self.display_name(number = 1)
+    n_('Cloud Subnet (OpenStack)', 'Cloud Subnets (OpenStack)', number)
+  end
+
   private
 
   def connection_options(cloud_tenant = nil)

--- a/app/models/manageiq/providers/openstack/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/floating_ip.rb
@@ -116,6 +116,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::FloatingIp < ::FloatingIp
     connection_options
   end
 
+  def self.display_name(number = 1)
+    n_('Floating IP (OpenStack)', 'Floating IPs (OpenStack)', number)
+  end
+
   private
 
   def connection_options(cloud_tenant = nil)

--- a/app/models/manageiq/providers/openstack/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_port.rb
@@ -8,4 +8,8 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkPort < ::NetworkPor
     end
     delete
   end
+
+  def self.display_name(number = 1)
+    n_('Network Port (OpenStack)', 'Network Ports (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -162,6 +162,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     connection_options
   end
 
+  def self.display_name(number = 1)
+    n_('Network Router (OpenStack)', 'Network Routers (OpenStack)', number)
+  end
+
   private
 
   def connection_options(cloud_tenant = nil)

--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -155,6 +155,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::Security
     connection_options
   end
 
+  def self.display_name(number = 1)
+    n_('Security Group (OpenStack)', 'Security Groups (OpenStack)', number)
+  end
+
   private
 
   def parse_direction(val)


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836