### PR TITLE
Override az_zone_to_cloud_network in openstack prov

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -26,6 +26,12 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     ems.each_with_object({}) { |f, h| h[f.id] = f.name }
   end
 
+  def availability_zone_to_cloud_network(src)
+    load_ar_obj(src[:ems]).all_cloud_networks.each_with_object({}) do |cn, hash|
+      hash[cn.id] = cn.name
+    end
+  end
+
   def set_request_values(values)
     values[:volumes] = prepare_volumes_fields(values)
     super

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -20,14 +20,6 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     end
   end
 
-  def allowed_cloud_networks(_options = {})
-    return {} unless (src_obj = provider_or_tenant_object)
-
-    src_obj.all_cloud_networks.each_with_object({}) do |cn, hash|
-      hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
-    end
-  end
-
   def allowed_cloud_tenants(_options = {})
     source = load_ar_obj(get_source_vm)
     ems = get_targets_for_ems(source, :cloud_filter, CloudTenant, 'cloud_tenants')

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -216,10 +216,6 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           expect(workflow.allowed_availability_zones).to eq({})
         end
 
-        it "#allowed_cloud_networks" do
-          expect(workflow.allowed_cloud_networks).to eq({})
-        end
-
         it "#allowed_guest_access_key_pairs" do
           expect(workflow.allowed_guest_access_key_pairs).to eq({})
         end
@@ -243,12 +239,6 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           azs = workflow.allowed_availability_zones
           expect(azs.length).to eq(1)
           expect(azs.first).to eq([az.id, az.name])
-        end
-
-        it "#allowed_cloud_networks" do
-          cn = FactoryGirl.create(:cloud_network)
-          provider.cloud_networks << cn
-          expect(workflow.allowed_cloud_networks).to eq(cn.id => cn.name)
         end
 
         it "#allowed_guest_access_key_pairs" do


### PR DESCRIPTION
I messed up [here](https://github.com/ManageIQ/manageiq-providers-openstack/pull/197) should be reverted because the [logic in main](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/cloud_manager/provision_workflow.rb#L98) is wrong. That else case should not include cloud_subnets: fixed in https://github.com/ManageIQ/manageiq/pull/16824. Per [comment](https://github.com/ManageIQ/manageiq/pull/16824/files#r161679886) we need to override this method in google and openstack because the availability zone to subnet relationship isn't set up yet. 

Fixes issue caused by fix of https://bugzilla.redhat.com/show_bug.cgi?id=1533277
(Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535189)

## Depends on:
https://github.com/ManageIQ/manageiq/pull/16824

## Related to:
https://github.com/ManageIQ/manageiq-providers-google/pull/43