### PR TITLE
Test az_to_cn method from super

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -254,6 +254,18 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         end
       end
 
+      context "availability_zone_to_cloud_network" do
+        it "has one when it should" do
+          FactoryGirl.create(:cloud_network_google, :ext_management_system => provider.network_manager)
+
+          expect(workflow.allowed_cloud_networks.size).to eq(1)
+        end
+
+        it "has none when it should" do
+          expect(workflow.allowed_cloud_networks.size).to eq(0)
+        end
+      end
+
       context "#display_name_for_name_description" do
         let(:flavor) { FactoryGirl.create(:flavor_openstack) }
 


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16811 adds RBAC filtering to allowed_cloud_network base class and openstack needed specs around the fact that the cloud network list is NOT dependent on availability zone choice unlike azure and amazon. (Per https://github.com/ManageIQ/manageiq/pull/16824#discussion_r161679886)

Related bz links: 
https://bugzilla.redhat.com/show_bug.cgi?id=1533277
 https://bugzilla.redhat.com/show_bug.cgi?id=1535189