### PR TITLE
Ensure update of more_core_extensions gem

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bunny",                "~>2.1.0"
   s.add_runtime_dependency "excon",                "~>0.40"
   s.add_runtime_dependency "fog-openstack",        "=0.1.22"
-  s.add_runtime_dependency "more_core_extensions", "~>3.2"
+  s.add_runtime_dependency "more_core_extensions", "~>3.5"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Hostname validation was added to newest version, updating gemspec to include it.