### PR TITLE
[WIP] Fix destroy provider

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -170,4 +170,10 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   def validate_shutdown
     {:available => false,   :message => nil}
   end
+
+  # need override https://github.com/ManageIQ/manageiq/pull/16755 destroy method
+  def destroy
+    ar_destroy = ApplicationRecord.instance_method(:destroy)
+    ar_destroy.bind(self).call
+  end
 end

--- a/app/models/manageiq/providers/openstack/provider.rb
+++ b/app/models/manageiq/providers/openstack/provider.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Openstack::Provider < ::Provider
   has_many :cloud_ems,
            :foreign_key => "provider_id",
            :class_name  => "ManageIQ::Providers::Openstack::CloudManager",
+           :dependent   => :nullify,
            :autosave    => true
   has_many :network_managers,
            :foreign_key => "provider_id",

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bunny",                "~>2.1.0"
   s.add_runtime_dependency "excon",                "~>0.40"
   s.add_runtime_dependency "fog-openstack",        "=0.1.22"
-  s.add_runtime_dependency "more_core_extensions", "~>3.2"
+  s.add_runtime_dependency "more_core_extensions", "~>3.5"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Change introduced in ManageIQ/manageiq#16755 is not
compatible with OSP provider which uses cascade deletion of related providers.

Nullification introduced in #198
breaks tests and possibly affects Infra provider deletion.

Trying override destroy method with original from AR until we get better solution (preferably in main repo).