### PR TITLE
Don't dependent => destroy child_managers

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -28,8 +28,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   has_many :storage_managers,
            :foreign_key => :parent_ems_id,
            :class_name  => "ManageIQ::Providers::StorageManager",
-           :autosave    => true,
-           :dependent   => :destroy
+           :autosave    => true
 
   include CinderManagerMixin
   include SwiftManagerMixin

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -103,10 +103,10 @@ describe ManageIQ::Providers::Openstack::InfraManager do
       # compare they both use the same provider
       expect(@ems_cloud.provider).to eq(@ems.provider)
 
-      # destroy ems and see the relation of ems_cloud to provider nullified
+      # destroy ems and see the ems_cloud removed as well
       @ems.destroy
-      expect(ManageIQ::Providers::Openstack::Provider.count).to eq 0
-      expect(@ems_cloud.reload.provider).to be_nil
+      expect(ManageIQ::Providers::Openstack::Provider.count).to     eq 0
+      expect(ManageIQ::Providers::Openstack::CloudManager.count).to eq 0
     end
   end
 


### PR DESCRIPTION
Destroying child_managers is orchestrated by the parent and destroying
them prematurely leads to issues when the endpoints are shared between
the two managers.

Example failure: https://travis-ci.org/ManageIQ/manageiq-providers-openstack/jobs/332446792#L2079-L2091

Depends: https://github.com/ManageIQ/manageiq/pull/16871

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1538232