### PR TITLE
Fix disable CloudTenant Vm targeted refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -124,7 +124,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
   def memoized_get_tenant(tenant_id)
     return nil if tenant_id.blank?
     @tenant_memo ||= Hash.new do |h, key|
-      h[key] = safe_get { identity_service.tenants.find_by_id(key) }
+      h[key] = safe_get { identity_service.respond_to?(:projects) ? identity_service.projects_get_by_id(key) : identity_service.tenants.find_by_id(key) }
     end
     @tenant_memo[tenant_id]
   end
@@ -254,7 +254,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
 
   def infer_related_cloud_tenant_ems_refs_api!
     tenants.each do |tenant|
-      add_simple_target(:cloud_tenants, tenant.try(:parent_id)) unless tenant.try(:parent_id).blank?
+      add_simple_target!(:cloud_tenants, tenant.try(:parent_id)) unless tenant.try(:parent_id).blank?
     end
   end
 

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -144,5 +144,11 @@ module OpenstackHandle
         list_roles_for_user_on_tenant(project_id, user_id).body["roles"]
       end
     end
+
+    # Remove this method once fog/openstack allows get_project correctly
+    def projects_get_by_id(id)
+      @all_projects ||= projects.all
+      @all_projects.find { |project| project.id == id }
+    end
   end
 end


### PR DESCRIPTION
Vm targeted refresh queued related Cloud Tenant refresh, that could fail due to
keystone v3 backend in fog or an issue in fog/openstack method get_project_by_id.

Queueing CloudTenant doesn't seem to be actually needed - disabled now and we should
make a cleanup in ongoing PR.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538741