### PR TITLE
autoload move

### DIFF
--- a/lib/manageiq-providers-openstack.rb
+++ b/lib/manageiq-providers-openstack.rb
@@ -1,2 +1,10 @@
 require "manageiq/providers/openstack/engine"
 require "manageiq/providers/openstack/version"
+
+module ManageIQ
+  module Providers
+    module Openstack
+      autoload :InfraDiscovery, 'manageiq/providers/openstack/infra_discovery'
+    end
+  end
+end


### PR DESCRIPTION
The network discovery probe's class is declared with `autoload`. The autoload belongs to the provider too.

This is part of https://github.com/ManageIQ/manageiq-network_discovery/issues/8
