### PR TITLE
Don't require CinderManager in inventory classes

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -4,7 +4,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManagerRefresh::Inv
 
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
   require_nested :TargetCollection
 
   attr_reader :availability_zones

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManagerRefresh::Inventory::Parser
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,7 +1,6 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
   require_nested :TargetCollection
 
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below


### PR DESCRIPTION
This require shouldn't be necessary and causes an exception.