### PR TITLE
Add configurable vhost to AMQP monitor

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -139,6 +139,7 @@
         :amqp_port: 5672
         :amqp_heartbeat: 30
         :amqp_recovery_attempts: 4
+        :amqp_vhost: '/'
         :ceilometer:
           :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
       :event_catcher_openstack_infra:
@@ -154,6 +155,7 @@
         :amqp_port: 5672
         :amqp_heartbeat: 30
         :amqp_recovery_attempts: 4
+        :amqp_vhost: '/'
         :ceilometer:
           :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
       :event_catcher_openstack_network:
@@ -165,6 +167,7 @@
         :amqp_port: 5672
         :amqp_heartbeat: 30
         :amqp_recovery_attempts: 4
+        :amqp_vhost: '/'
         :ceilometer:
           :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
       :event_catcher_openstack_service: "auto"

--- a/lib/manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor.rb
@@ -6,6 +6,7 @@ require 'thread'
 class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   DEFAULT_AMQP_PORT = 5672
   DEFAULT_AMQP_HEARTBEAT = 30
+  DEFAULT_AMQP_VHOST = '/'
 
   # The rabbit event monitor is available if a connection can be established.
   # This ensures that the amqp server is indeed rabbit (and not another amqp
@@ -26,6 +27,7 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
     connection_options[:heartbeat]          = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
     connection_options[:automatic_recovery] = options[:automatic_recovery] if options.key? :automatic_recovery
     connection_options[:recovery_attempts]  = options[:recovery_attempts] if options.key? :recovery_attempts
+    connection_options[:vhost]              = options[:vhost] || DEFAULT_AMQP_VHOST
 
     if options.key? :recover_from_connection_close
       connection_options[:recover_from_connection_close] = options[:recover_from_connection_close]


### PR DESCRIPTION
We need to provide different vhost that default '/'. This commit adds the functionality to set it via Settings. 
It was already discussed @aufi. 