### PR TITLE
Add proper error message if network type not supported

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -50,7 +50,13 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     {:ems_ref => network.id, :name => options[:name]}
   rescue => e
     _log.error "network=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqNetworkCreateError, parse_error_message_from_neutron_response(e), e.backtrace
+    parsed_error = parse_error_message_from_neutron_response(e)
+    error_message = if parsed_error =~ /Invalid input for operation: network_type value '.*' not supported\./
+                      _("Network type '#{options[:provider_network_type]}' is not supported by the Provider")
+                    else
+                      parsed_error
+                    end
+    raise MiqException::MiqNetworkCreateError, error_message, e.backtrace
   end
 
   def raw_delete_cloud_network


### PR DESCRIPTION
When creating network, add proper error message if network type is not supported by provider.
Fixes [link](https://bugzilla.redhat.com/show_bug.cgi?id=1540692)
<img width="1152" alt="screen shot 2018-02-02 at 13 22 10" src="https://user-images.githubusercontent.com/20123872/35733049-1a686c80-081c-11e8-934b-6f48a1ec60d3.png">
