### PR TITLE
Fix Service Provisioning cloud_tenant issue

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
@@ -2,4 +2,5 @@ class ManageIQ::Providers::Openstack::CloudManager::Provision < ::MiqProvisionCl
   include_concern 'Cloning'
   include_concern 'Configuration'
   include_concern 'VolumeAttachment'
+  include_concern 'OptionsHelper'
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
   end
 
   def do_clone_task_check(clone_task_ref)
-    connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of?(Array)
+    connection_options = {:tenant_name => cloud_tenant.name}
     source.with_provider_connection(connection_options) do |openstack|
       instance = if connection_options
                    openstack.servers.get(clone_task_ref)
@@ -55,7 +55,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
   end
 
   def start_clone(clone_options)
-    connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of?(Array)
+    connection_options = {:tenant_name => cloud_tenant.name}
     if source.kind_of?(ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate)
       # remove the image_ref parameter from the options since it actually refers
       # to a volume, and then overwrite the default root volume with the volume

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/options_helper.rb
@@ -1,0 +1,5 @@
+module ManageIQ::Providers::Openstack::CloudManager::Provision::OptionsHelper
+  def cloud_tenant
+    @cloud_tenant ||= CloudTenant.find_by(:id => get_option(:cloud_tenant))
+  end
+end


### PR DESCRIPTION
Call new cloud_tenant helper method to avoid provision error.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532244

Provision error:  
[----] I, [2018-01-31T13:04:42.560968 #4325:f61134]  INFO -- : Q-task_id([miq_provision_1000000000024]) Starting Phase <provision_error>
[----] E, [2018-01-31T13:04:42.629955 #4325:f61134] ERROR -- : Q-task_id([miq_provision_1000000000024]) MIQ(ManageIQ::Providers::Openstack::CloudManager::Provision#provision_error) [[NoMethodError]: undefined method `[]' for nil:NilClass] encountered during phase [start_clone_task]
[----] E, [2018-01-31T13:04:42.630183 #4325:f61134] ERROR -- : Q-task_id([miq_provision_1000000000024]) /var/www/miq/vmdb/app/models/mixins/provider_object_mixin.rb:29:in `connection_source'
/var/www/miq/vmdb/app/models/mixins/provider_object_mixin.rb:5:in `with_provider_connection'
/var/www/miq/vmdb/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb:45:in `start_clone'
/var/www/miq/vmdb/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb:37:in `start_clone_task'
/var/www/miq/vmdb/app/models/miq_request_task/state_machine.rb:21:in `signal'
/var/www/miq/vmdb/app/models/miq_provision/state_machine.rb:18:in `prepare_provision'
/var/www/miq/vmdb/app/models/miq_request_task/state_machine.rb:21:in `signal'
/var/www/miq/vmdb/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb:28:in `poll_volumes_complete'
/var/www/miq/vmdb/app/models/miq_request_task/state_machine.rb:21:in `signal'
/var/www/miq/vmdb/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb:15:in `prepare_volumes'
/var/www/miq/vmdb/app/models/miq_request_task/state_machine.rb:21:in `signal'

Service Dialog populates cloud_tenant as a string, code is expecting it to be an array.
----] I, [2018-01-31T13:04:42.543243 #4325:f61134]  INFO -- :
Q-task_id([miq_provision_1000000000024])
MIQ(ManageIQ::Providers::Openstack::CloudManager::Provision#log_clone_options)
Prov Options:  [:cloud_tenant](String) = "1000000000001"

Although these code changes resolves the issue,  I think further investigation is necessary because the hash key :tenant_name isn't used in the connection_source method, the method works just because it's being passed a hash, when previously it wasn't.
