### PR TITLE
Update client to use renamed NetworkDiscovery

### DIFF
--- a/app/models/manageiq/providers/openstack/discovery.rb
+++ b/app/models/manageiq/providers/openstack/discovery.rb
@@ -1,4 +1,4 @@
-require 'manageiq/network/port'
+require 'manageiq/network_discovery/port'
 
 module ManageIQ::Providers::Openstack
   class Discovery
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Openstack
 
     def self.probe(ost)
       # Openstack InfraManager (TripleO/Director) discovery
-      if ManageIQ::Network::Port.open?(ost, IRONIC_PORT)
+      if ManageIQ::NetworkDiscovery::Port.open?(ost, IRONIC_PORT)
         res = ""
         Socket.tcp(ost.ipaddr, 6385) do |s|
           s.print("GET / HTTP/1.0\r\n\r\n")

--- a/spec/models/manageiq/providers/openstack/discovery_spec.rb
+++ b/spec/models/manageiq/providers/openstack/discovery_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::Openstack::Discovery do
+  it ".probe" do
+    require 'ostruct'
+    allow(ManageIQ::NetworkDiscovery::Port).to receive(:open?).and_return(true)
+    allow(Socket).to receive(:tcp).and_yield(double(:print => nil, :close_write => nil, :read => "OpenStack Ironic API"))
+    ost = OpenStruct.new(:ipaddr => "172.168.0.1", :hypervisor => [])
+    described_class.probe(ost)
+    expect(ost.hypervisor).to eq [:openstack_infra]
+  end
+end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/16994

Add missing test for the probe method.