### PR TITLE
Collect all tenants during vm targeted refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -123,9 +123,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
 
   def memoized_get_tenant(tenant_id)
     return nil if tenant_id.blank?
-    @tenant_memo ||= Hash.new do |h, key|
-      h[key] = safe_get { identity_service.respond_to?(:projects) ? identity_service.projects_get_by_id(key) : identity_service.tenants.find_by_id(key) }
-    end
+    @tenant_memo ||= identity_service.visible_tenants.index_by(&:id)
     @tenant_memo[tenant_id]
   end
 


### PR DESCRIPTION
To prevent fog-openstack building the wrong query for
.tenants.find_by_id which leads to a 404 error query all tenants during
a targeted refresh.