### PR TITLE
Add delete_queue method for Template

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -110,6 +110,22 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
     raw_update_image(options)
   end
 
+  def delete_image_queue(userid)
+    task_opts = {
+      :action => "Deleting image for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => "ManageIQ::Providers::Openstack::CloudManager::Template",
+      :method_name => 'delete_image',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
   def raw_delete_image
     ext_management_system.with_provider_connection(:service => 'Image') do |service|
       service.delete_image(ems_ref)


### PR DESCRIPTION
Added missing method `delete_image_queue` for templates in order to use it in API `delete` action
https://github.com/ManageIQ/manageiq-api/pull/328