### PR TITLE
Filter openstack networks without subnets

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -85,6 +85,13 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     validate_placement(field, values, dlg, fld, value)
   end
 
+  def allowed_cloud_networks(_options = {})
+    return {} unless (src = provider_or_tenant_object)
+    targets = get_targets_for_source(src, :cloud_filter, CloudNetwork, 'all_cloud_networks')
+    targets = filter_cloud_networks(targets)
+    allowed_ci(:cloud_network, [:availability_zone], targets.map(&:id))
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
@@ -93,5 +100,11 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
 
   def self.provider_model
     ManageIQ::Providers::Openstack::CloudManager
+  end
+
+  def filter_cloud_networks(networks)
+    networks.select do |cloud_network|
+      cloud_network.cloud_subnets.any?
+    end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -256,9 +256,16 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
       context "availability_zone_to_cloud_network" do
         it "has one when it should" do
-          FactoryGirl.create(:cloud_network_google, :ext_management_system => provider.network_manager)
+          subnet = FactoryGirl.create(:cloud_subnet_openstack)
+          FactoryGirl.create(:cloud_network_openstack, :ext_management_system => provider.network_manager, :cloud_subnets => [subnet])
 
           expect(workflow.allowed_cloud_networks.size).to eq(1)
+        end
+
+        it "filters cloud networks without subnets" do
+          FactoryGirl.create(:cloud_network_openstack, :ext_management_system => provider.network_manager)
+
+          expect(workflow.allowed_cloud_networks.size).to eq(0)
         end
 
         it "has none when it should" do
@@ -287,24 +294,34 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
         context "cloud networks" do
           before do
+            subnet1 = FactoryGirl.create(:cloud_subnet_openstack)
+            subnet2 = FactoryGirl.create(:cloud_subnet_openstack)
+            subnet3 = FactoryGirl.create(:cloud_subnet_openstack)
+            subnet4 = FactoryGirl.create(:cloud_subnet_openstack)
+            subnet5 = FactoryGirl.create(:cloud_subnet_openstack)
             @cn1 = FactoryGirl.create(:cloud_network_private_openstack,
                                       :cloud_tenant          => @ct1,
-                                      :ext_management_system => provider.network_manager)
+                                      :ext_management_system => provider.network_manager,
+                                      :cloud_subnets         => [subnet1])
             @cn2 = FactoryGirl.create(:cloud_network_private_openstack,
                                       :cloud_tenant          => @ct2,
-                                      :ext_management_system => provider.network_manager)
+                                      :ext_management_system => provider.network_manager,
+                                      :cloud_subnets         => [subnet2])
             @cn3 = FactoryGirl.create(:cloud_network_public_openstack,
                                       :cloud_tenant          => @ct2,
-                                      :ext_management_system => provider.network_manager)
+                                      :ext_management_system => provider.network_manager,
+                                      :cloud_subnets         => [subnet3])
 
             @cn_shared        = FactoryGirl.create(:cloud_network_private_openstack,
                                                    :shared                => true,
                                                    :cloud_tenant          => @ct2,
-                                                   :ext_management_system => provider.network_manager)
+                                                   :ext_management_system => provider.network_manager,
+                                                   :cloud_subnets         => [subnet4])
             @cn_public_shared = FactoryGirl.create(:cloud_network_public_openstack,
                                                    :shared                => true,
                                                    :cloud_tenant          => @ct2,
-                                                   :ext_management_system => provider.network_manager)
+                                                   :ext_management_system => provider.network_manager,
+                                                   :cloud_subnets         => [subnet5])
           end
 
           it "#allowed_cloud_networks with tenant selected" do


### PR DESCRIPTION
Add eligible_for_vm_provisioning method for networks. Network requires a subnet in order to be used for provisioning.
This method is needed for this [PR](https://github.com/ManageIQ/manageiq/pull/17055) and should fix [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1541308)