### PR TITLE
Dont return Storage Services if They arent present

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -103,12 +103,12 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def cinder_service
     vs = openstack_handle.detect_volume_service
-    vs.name == :cinder ? vs : nil
+    vs&.name == :cinder ? vs : nil
   end
 
   def swift_service
     vs = openstack_handle.detect_storage_service
-    vs.name == :swift ? vs : nil
+    vs&.name == :swift ? vs : nil
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
            :class_name  => "ManageIQ::Providers::StorageManager",
            :autosave    => true
 
-  include ManageIQ::Providers::Openstack::CinderManagerMixin
+  include CinderManagerMixin
   include SwiftManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
   include ManageIQ::Providers::Openstack::IdentitySyncMixin


### PR DESCRIPTION
Check if the cinder and swift services are actually present before
checking the names and returning them.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1458959

along with https://github.com/ManageIQ/manageiq/pull/17067.

Order of merging is irrelevant.  Related PR was https://github.com/ManageIQ/manageiq/pull/16922

@roliveri @hsong-rh please review and merge when appropriate.