### PR TITLE
Don't lose VM volume attachments when refreshing the cloud inventory

### DIFF
--- a/spec/models/manageiq/providers/openstack/openstack_stubs.rb
+++ b/spec/models/manageiq/providers/openstack/openstack_stubs.rb
@@ -233,7 +233,8 @@ module OpenstackStubs
         :flavor             => {"id" => i},
         :availability_zone  => "nova",
         :private_ip_address => '10.10.10.1',
-        :public_ip_address  => '172.1.1.2'
+        :public_ip_address  => '172.1.1.2',
+        :attributes         => {}
       )
     end
     mocked_vms

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:09 GMT
+      - Thu, 19 Apr 2018 17:42:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55f69d61-0ad4-44f7-a710-aa2c71673138
+      - req-b61fd18a-dd5e-4c17-87a4-4c383e446e50
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:09.652601", "expires":
-        "2018-04-09T17:31:09Z", "id": "4d250b0289ad44f89abd70b5b2394cea", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:07.240211", "expires":
+        "2018-04-19T18:42:07Z", "id": "9d8c280878e54593aa4147c8e2b55282", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tLI0KvpZQoKnvVpwTbqltg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["lc4lSobDRVChpEMpuCrzvw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:31:09 GMT
+      - Thu, 19 Apr 2018 17:42:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-3b922879-8e57-478e-9608-cdd426ab3288
+      - req-d365fd7e-fa56-4cc6-8ff6-253d5ef50471
       Date:
-      - Mon, 09 Apr 2018 16:31:10 GMT
+      - Thu, 19 Apr 2018 17:42:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:10 GMT
+      - Thu, 19 Apr 2018 17:42:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e460595a-cc52-42ff-8c4e-4c834d472071
+      - req-d5097d28-947d-4942-b04d-a90c28f12fe3
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:10.391963", "expires":
-        "2018-04-09T17:31:10Z", "id": "daeb51c329a5484dbd38b075e43dbe4a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:07.879108", "expires":
+        "2018-04-19T18:42:07Z", "id": "d20cb4e119cd41cfa6eba95991a7d9a2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uF535OrTTIuBtuf9apjuPQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2NJ3wY_aRX2dmWrIio6uHw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - daeb51c329a5484dbd38b075e43dbe4a
+      - d20cb4e119cd41cfa6eba95991a7d9a2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-57155849-28c7-412d-8cc2-16f00b0f8cf1
+      - req-01e48759-b54e-4e1d-803d-46af3ea3e4e5
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-57155849-28c7-412d-8cc2-16f00b0f8cf1
+      - req-01e48759-b54e-4e1d-803d-46af3ea3e4e5
       Date:
-      - Mon, 09 Apr 2018 16:31:10 GMT
+      - Thu, 19 Apr 2018 17:42:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:10 GMT
+      - Thu, 19 Apr 2018 17:42:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-15ef5f62-f401-448e-be1c-30c8e37efce9
+      - req-b31a753f-bf0c-4c77-b101-c470139e07bb
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:10.973158", "expires":
-        "2018-04-09T17:31:10Z", "id": "1c52de6aa97246b9a5a824e9f68aade2", "audit_ids":
-        ["ipEJZ43TQAGWu9fgMyFaHg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:08.410754", "expires":
+        "2018-04-19T18:42:08Z", "id": "77a223ccdd7e4234a15deaeec30da452", "audit_ids":
+        ["UTyXw1C9ROiONSkZuyigTQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:08 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c52de6aa97246b9a5a824e9f68aade2
+      - 77a223ccdd7e4234a15deaeec30da452
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:11 GMT
+      - Thu, 19 Apr 2018 17:42:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f905c1e5-e571-4ee5-a0aa-bcab3e0130ed
+      - req-2ddb4e16-b74b-461e-bdf4-d493e3f0d0c6
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1c52de6aa97246b9a5a824e9f68aade2"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"77a223ccdd7e4234a15deaeec30da452"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:11 GMT
+      - Thu, 19 Apr 2018 17:42:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-84862a25-6787-4bde-b335-b3deb67d0451
+      - req-57415a02-3f3d-4ffd-88e5-70f3c532d607
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:11.405905", "expires":
-        "2018-04-09T17:31:10Z", "id": "806ecb7531274e9f8dd74c3dec67aa3a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:09.898928", "expires":
+        "2018-04-19T18:42:08Z", "id": "fe6f8fa5b41948db849755c4df976794", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Yh_3To3rSgSqQ1Zq9Gejdw",
-        "ipEJZ43TQAGWu9fgMyFaHg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AI--Sr0LRxuy44FlzbH7Ng",
+        "UTyXw1C9ROiONSkZuyigTQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:09 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c52de6aa97246b9a5a824e9f68aade2
+      - 77a223ccdd7e4234a15deaeec30da452
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:11 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0731453d-8064-4324-a0a0-d7f1a73046c2
+      - req-40eabfd1-e91f-45f0-86b8-9d30e09289d1
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:11 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47d1ba32-75c6-4838-bc70-d2c930fe8d60
+      - req-fe9e341d-41f2-49f0-aa28-abd4e4724015
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:11.894175", "expires":
-        "2018-04-09T17:31:11Z", "id": "81cb86d540fc4393bf8ca85a64cfbe0f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:10.360430", "expires":
+        "2018-04-19T18:42:10Z", "id": "148b3c279dce49deb88eb1b4c151ccc7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lbmhB2V6Qc2P3dYflIy-3A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vuNaOhOjTqG-UyQy3KMH2w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:31:11 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:12 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7b966c04-de11-43fa-8270-1d8ee1facc0d
+      - req-110adf2b-5082-4366-9ed1-42b9eebe7f07
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:12.236595", "expires":
-        "2018-04-09T17:31:12Z", "id": "59e77442e70a45878c3b72a43cd909ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:10.662452", "expires":
+        "2018-04-19T18:42:10Z", "id": "c4cd3b5bdf79491c80145f1422399c2b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["L0Lgb_58Raqr5bb2rPU3EQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ltdfsKDETfCOiQisp1m2mQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:31:12 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:12 GMT
+      - Thu, 19 Apr 2018 17:42:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3619533f-622b-42c2-aae5-0fa55b7900ba
+      - req-d4b7f9ff-3ae7-4f1c-92e9-b19562d7eb76
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:12.735187", "expires":
-        "2018-04-09T17:31:12Z", "id": "f32ad17dfdc1400b8231f593be7047d2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:10.979521", "expires":
+        "2018-04-19T18:42:10Z", "id": "ae2b7cd017bb4f63bd74b75318a8bdd7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hsCqUKTnSWizAcBIDYcdXQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yVh4FHgfR9ShgcCl36BuYA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:31:12 GMT
+      - Thu, 19 Apr 2018 17:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e934e88f-c7d2-46af-be29-edf6e486422f
+      - req-38b2202e-294a-4d81-af2e-9cad29896a09
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-273eb43c-b9d2-48c4-b21f-243fa9ed361b
+      - req-83cb9368-0075-4aa1-95c4-6aa08f647a8f
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7cbc1864-679d-4f2c-8653-91a27eaf8acc
+      - req-f6f11dad-c974-4b31-bc30-92e44022b330
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9ef87f4f-f06c-4603-aec5-645bc8e2ccf2
+      - req-dacd6a2b-9e3a-4ade-9371-e14c19016e47
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-564eda32-d174-4d3d-9d09-4b02c8b9d457
+      - req-d88f8803-790a-4206-9395-09d09bbc235a
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0c0e2f89-a055-4acf-9216-993a05d4dcfb
+      - req-6231c430-986a-4fdc-bfa1-24512f59c836
       Date:
-      - Mon, 09 Apr 2018 16:31:13 GMT
+      - Thu, 19 Apr 2018 17:42:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d92d2f84-ea9b-46ff-8fbb-cfdcabe76955
+      - req-48cb892d-cfe0-4939-961d-a2143fbdd9bf
       Date:
-      - Mon, 09 Apr 2018 16:31:14 GMT
+      - Thu, 19 Apr 2018 17:42:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-5f5f3737-91e6-4ea8-9691-801367a7ff3c
+      - req-70193a3e-1e55-4480-9bca-42932a1a5b4f
       Date:
-      - Mon, 09 Apr 2018 16:31:14 GMT
+      - Thu, 19 Apr 2018 17:42:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:31:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:42:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:31:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:42:03.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:31:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:42:05.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:31:04.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:42:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:31:04.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:42:05.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-6608b9ec-3af4-4cb7-aa23-5dbbe70618c4
+      - req-1600ebbd-dbf6-4806-9af4-ced4dffa4b70
       Date:
-      - Mon, 09 Apr 2018 16:31:14 GMT
+      - Thu, 19 Apr 2018 17:42:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-a739c6fd-a837-439f-9dff-969be982e3ef
+      - req-b489f12a-71e0-4119-804d-865d7b3f4dc9
       Date:
-      - Mon, 09 Apr 2018 16:31:14 GMT
+      - Thu, 19 Apr 2018 17:42:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-b76d3aed-3d83-4a23-996a-85c7852c20f9
+      - req-2692f1d0-917b-4029-83d7-b4ae4d09189f
       Date:
-      - Mon, 09 Apr 2018 16:31:15 GMT
+      - Thu, 19 Apr 2018 17:42:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-8381d67d-30cd-4870-a953-1ae81783642b
+      - req-3b7e9407-71b7-4482-b31e-8b8289569d97
       Date:
-      - Mon, 09 Apr 2018 16:31:15 GMT
+      - Thu, 19 Apr 2018 17:42:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,9 +1400,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-0c499479-8e97-4dcb-a800-4d8360329d3c
+      - req-972a5fc8-3368-439c-9d7c-b18fe6cd19a9
       Date:
-      - Mon, 09 Apr 2018 16:31:15 GMT
+      - Thu, 19 Apr 2018 17:42:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/1",
@@ -1416,7 +1416,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2
@@ -1431,7 +1431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1444,9 +1444,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-72a01202-237d-49e1-bfb0-c2c186f53975
+      - req-d0937c77-6b58-4dea-9de6-86051c0577c2
       Date:
-      - Mon, 09 Apr 2018 16:31:15 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/3",
@@ -1460,7 +1460,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4
@@ -1475,7 +1475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1488,9 +1488,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-088f5c34-d9e9-419f-89b3-caf0900ba10f
+      - req-5f6306a2-9880-4fe8-8959-ca4451d838ea
       Date:
-      - Mon, 09 Apr 2018 16:31:15 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/5",
@@ -1505,7 +1505,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6
@@ -1520,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1533,14 +1533,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-effb1253-dbb5-4f79-96e5-a423b83f7d0c
+      - req-3d500836-d362-418c-a173-2e4d83b7c6c3
       Date:
-      - Mon, 09 Apr 2018 16:31:16 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000
@@ -1555,7 +1555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1568,9 +1568,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-8a16759b-52ee-42db-a2a4-b09b2f440856
+      - req-b9295b3e-6c00-41be-ba18-2d7563c7377b
       Date:
-      - Mon, 09 Apr 2018 16:31:16 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1584,7 +1584,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2
@@ -1599,7 +1599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1612,9 +1612,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-56aabdd4-5496-4876-be5a-bbaf519f7cfb
+      - req-619d5a5e-455d-4dc3-b296-e5d6a121680a
       Date:
-      - Mon, 09 Apr 2018 16:31:16 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1628,7 +1628,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4
@@ -1643,7 +1643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1656,9 +1656,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-ebe4cf90-7d49-46ee-97cf-1c33bb5d3b6b
+      - req-2e3bd749-84d7-41ad-93c7-c1e716529ab9
       Date:
-      - Mon, 09 Apr 2018 16:31:16 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1673,7 +1673,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6
@@ -1688,7 +1688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1701,14 +1701,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-52289519-e829-4db7-85e4-6d7ad252e8bc
+      - req-fe0b5ccc-5b41-401d-8699-4ce52c36127c
       Date:
-      - Mon, 09 Apr 2018 16:31:16 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000
@@ -1723,7 +1723,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1736,9 +1736,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-14c0bcd2-39fe-41bb-a2a3-831380437d0a
+      - req-765536b9-f8d0-4d9f-ac74-e15c987dd578
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/1",
@@ -1752,7 +1752,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2
@@ -1767,7 +1767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1780,9 +1780,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-ffa1ee11-285b-4706-80ae-02cafaac6d97
+      - req-0cde008c-90b4-4786-9612-fa8e9051a9cb
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/3",
@@ -1796,7 +1796,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4
@@ -1811,7 +1811,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1824,9 +1824,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-142aec7f-6ebd-4c88-abc9-e687a93b67df
+      - req-1b39b2f9-f599-418e-baae-1ad1c56bfd41
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/5",
@@ -1841,7 +1841,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6
@@ -1856,7 +1856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1869,14 +1869,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e0b4018e-0391-4814-a2a6-5d6802be2e7f
+      - req-955dcee7-cfc8-4599-a305-07f03d4358d4
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1891,7 +1891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1904,15 +1904,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-5b93ac31-67e0-4cb9-a76c-47af78fb547f
+      - req-9ec0c2ec-2136-4412-9000-72a63cb3e05d
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1930,13 +1930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:17 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0370d7b0-07b8-4872-a970-0a8bc77a9138
+      - req-3077bd17-ee05-4c32-aeb2-02b4a47845c5
       Content-Length:
       - '4170'
       Connection:
@@ -1945,10 +1945,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:18.010812", "expires":
-        "2018-04-09T17:31:17Z", "id": "a971ad93635849b0b8226ab6ce771b44", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:15.619863", "expires":
+        "2018-04-19T18:42:15Z", "id": "6e2cb3cc888e430b80509056896bea02", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vUSlCKpHTka68khR8lBtIg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rOAuC0brTfGJLDsaBY_Nlw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1993,7 +1993,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -2008,7 +2008,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a971ad93635849b0b8226ab6ce771b44
+      - 6e2cb3cc888e430b80509056896bea02
   response:
     status:
       code: 300
@@ -2019,7 +2019,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:31:18 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -2032,7 +2032,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2050,13 +2050,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:18 GMT
+      - Thu, 19 Apr 2018 17:42:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-64a89085-5e8d-4c6a-a1f1-daa9bfa0e7c0
+      - req-325594a8-320c-4c7d-b44f-b611a86cd0c1
       Content-Length:
       - '4117'
       Connection:
@@ -2065,10 +2065,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:18.357397", "expires":
-        "2018-04-09T17:31:18Z", "id": "243ab3cc1bea431ab11f219ebc504589", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:15.897009", "expires":
+        "2018-04-19T18:42:15Z", "id": "dbeb927375e74853917044d05c5eb92d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DMn48qQxT0yJtVMGffC6dA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kaSXzJvURma37gc_Oxh4NA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2112,7 +2112,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2127,7 +2127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243ab3cc1bea431ab11f219ebc504589
+      - dbeb927375e74853917044d05c5eb92d
   response:
     status:
       code: 200
@@ -2138,9 +2138,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-646df02d-63a2-4621-a06e-3fea39d91636
+      - req-34bacbd1-7cab-4847-88aa-b5ba8c5c3a8c
       Date:
-      - Mon, 09 Apr 2018 16:31:18 GMT
+      - Thu, 19 Apr 2018 17:42:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2182,7 +2182,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2197,7 +2197,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243ab3cc1bea431ab11f219ebc504589
+      - dbeb927375e74853917044d05c5eb92d
   response:
     status:
       code: 200
@@ -2208,14 +2208,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a770ebbf-9028-49a8-9179-f3996b052d3c
+      - req-595903c8-d70b-480a-9c13-a5564e071731
       Date:
-      - Mon, 09 Apr 2018 16:31:19 GMT
+      - Thu, 19 Apr 2018 17:42:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2233,13 +2233,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:19 GMT
+      - Thu, 19 Apr 2018 17:42:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-476c07e5-dfe5-443c-9bd1-1822fa60c610
+      - req-218b3243-73cf-4b6b-9bdd-750d78844a88
       Content-Length:
       - '4131'
       Connection:
@@ -2248,10 +2248,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:19.342927", "expires":
-        "2018-04-09T17:31:19Z", "id": "a4974f5aaa65469abadf289479820590", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:16.397093", "expires":
+        "2018-04-19T18:42:16Z", "id": "0df073833bb94d369edd808f7ef0a10e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4X4yoLwjTHaeAoCSkN91xg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3BkMMEwVRpe1g14g8yyyLA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2295,7 +2295,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4974f5aaa65469abadf289479820590
+      - 0df073833bb94d369edd808f7ef0a10e
   response:
     status:
       code: 200
@@ -2321,9 +2321,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6a3f6429-5c8a-486e-9fcf-38f1643416c8
+      - req-ce8a8ef1-c1de-4307-a65e-b7a344e6d711
       Date:
-      - Mon, 09 Apr 2018 16:31:19 GMT
+      - Thu, 19 Apr 2018 17:42:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2365,7 +2365,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2380,7 +2380,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4974f5aaa65469abadf289479820590
+      - 0df073833bb94d369edd808f7ef0a10e
   response:
     status:
       code: 200
@@ -2391,14 +2391,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9f44d037-5618-4476-9de0-2e68ea41c162
+      - req-b5e4f075-5fac-45cf-ad08-a3295c7ee797
       Date:
-      - Mon, 09 Apr 2018 16:31:19 GMT
+      - Thu, 19 Apr 2018 17:42:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2413,7 +2413,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a971ad93635849b0b8226ab6ce771b44
+      - 6e2cb3cc888e430b80509056896bea02
   response:
     status:
       code: 200
@@ -2424,9 +2424,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3ef9392b-bd16-41da-a747-54bcec4a69c2
+      - req-722be9dd-eec2-425d-b921-ef73f8c87d7a
       Date:
-      - Mon, 09 Apr 2018 16:31:20 GMT
+      - Thu, 19 Apr 2018 17:42:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2468,7 +2468,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2483,7 +2483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a971ad93635849b0b8226ab6ce771b44
+      - 6e2cb3cc888e430b80509056896bea02
   response:
     status:
       code: 200
@@ -2494,14 +2494,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d6f4abe1-c769-4570-83ed-bba3c69f51d5
+      - req-34264a4b-e9ae-419f-898b-17bc76d75a1c
       Date:
-      - Mon, 09 Apr 2018 16:31:20 GMT
+      - Thu, 19 Apr 2018 17:42:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2519,13 +2519,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:20 GMT
+      - Thu, 19 Apr 2018 17:42:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1681370a-93a7-4d9d-a290-0cf35eaa9e55
+      - req-7321bee7-7254-4d51-87ae-9a84e95945f0
       Content-Length:
       - '4118'
       Connection:
@@ -2534,10 +2534,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:20.837478", "expires":
-        "2018-04-09T17:31:20Z", "id": "9b6e76ade25b49cdbac2585fab32d4fd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:17.899552", "expires":
+        "2018-04-19T18:42:17Z", "id": "ee03dc60b22a4e96b28110e550a70dca", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ur_mREjTQxOfd_U53Mtz0Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["S0uqhtIER0i8w_bglgyIoA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2596,7 +2596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6e76ade25b49cdbac2585fab32d4fd
+      - ee03dc60b22a4e96b28110e550a70dca
   response:
     status:
       code: 200
@@ -2607,9 +2607,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5da7c31f-8bf4-4a47-8c53-08b3ec9df633
+      - req-2f887b77-6a83-480b-9371-2e11a12ca52f
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2651,7 +2651,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2666,7 +2666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6e76ade25b49cdbac2585fab32d4fd
+      - ee03dc60b22a4e96b28110e550a70dca
   response:
     status:
       code: 200
@@ -2677,14 +2677,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-242a820c-e048-422a-be7f-f009fba40804
+      - req-9485288f-4c87-4af1-aaf1-6a4a1ae6e3e7
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2699,7 +2699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2712,9 +2712,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a23920b2-0b5f-4b3f-a89c-2e1d836e76f4
+      - req-46b19d07-cfd1-4531-9d6a-68676eab4bf6
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2724,7 +2724,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2739,7 +2739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2752,9 +2752,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-93d446f4-281e-4469-9c79-0f20b226022d
+      - req-d67c45a3-e576-4a2e-b803-1073fa26f4ce
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2764,7 +2764,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2779,7 +2779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2792,9 +2792,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-cbd959dd-933c-4af5-b61b-7d63ca50bf09
+      - req-cce53d6c-9660-4323-adea-c2d2655a4df2
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2804,7 +2804,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2819,7 +2819,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2832,9 +2832,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-985facab-3e1d-4128-9fe8-803d79bb27a9
+      - req-a9cc3dae-7483-4323-a37d-79929cf8f7ee
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2844,7 +2844,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2859,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2872,9 +2872,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5f651839-91a6-419d-84ab-6ec2623810cf
+      - req-e4af5f24-ce91-4561-a900-4655a3c32d87
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2884,7 +2884,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2899,7 +2899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2912,9 +2912,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-474d22f6-07ae-4298-9f43-f7ceeac77dd1
+      - req-6586f326-61ab-45b3-936c-9e0e956b45ef
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2924,7 +2924,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2939,7 +2939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2952,9 +2952,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-008fc561-6db2-4263-8853-afb387c004ba
+      - req-6a593362-25c5-4606-bbfa-5d5763e0ec91
       Date:
-      - Mon, 09 Apr 2018 16:31:21 GMT
+      - Thu, 19 Apr 2018 17:42:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2964,7 +2964,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2979,7 +2979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2992,9 +2992,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c5c03bb8-aa18-4352-9e8f-e7ef46f11439
+      - req-19336358-43dd-46f3-aecb-ccc70d2e02df
       Date:
-      - Mon, 09 Apr 2018 16:31:22 GMT
+      - Thu, 19 Apr 2018 17:42:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -3004,7 +3004,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3022,13 +3022,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:22 GMT
+      - Thu, 19 Apr 2018 17:42:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-809627dd-dac7-40b4-9a95-03737e1cda8e
+      - req-38fd2bf1-3284-47bf-a730-87fb95622e85
       Content-Length:
       - '4170'
       Connection:
@@ -3037,10 +3037,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:22.322192", "expires":
-        "2018-04-09T17:31:22Z", "id": "a38dc3302a984761a269604c92081848", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:19.406632", "expires":
+        "2018-04-19T18:42:19Z", "id": "4a3ea2a9305047b1a5a8c20dec2e97b8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nnTf5zoyS2ySDrvHXUXBbA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XvibmnyKT6q8SmFuJLCCyQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3085,7 +3085,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3103,13 +3103,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:22 GMT
+      - Thu, 19 Apr 2018 17:42:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2424390-c3f3-44b7-aa64-8989d1be898c
+      - req-137d90b6-46d4-4aab-9b6f-b3a81431a931
       Content-Length:
       - '4117'
       Connection:
@@ -3118,10 +3118,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:22.677568", "expires":
-        "2018-04-09T17:31:22Z", "id": "a25f7bbc3c87476b966633aaa93a8f28", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:19.656206", "expires":
+        "2018-04-19T18:42:19Z", "id": "25c663df731b45c3acaa59748753756d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0ObV0rgYQ7W_7ys1I3iO9A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wpPppU9QShyCVnOF49HD5g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3165,7 +3165,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -3180,7 +3180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3191,9 +3191,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-54950747-3f99-4d5d-abae-2d5488e4ad3d
+      - req-50099427-c757-4e6a-b179-cdec8f6777d8
       Date:
-      - Mon, 09 Apr 2018 16:31:23 GMT
+      - Thu, 19 Apr 2018 17:42:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -3227,7 +3227,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -3242,7 +3242,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3253,14 +3253,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f6e36ed0-1c8d-4089-9074-7365d166a859
+      - req-1e1e7e34-4425-4d53-beb1-f2060af95d5e
       Date:
-      - Mon, 09 Apr 2018 16:31:23 GMT
+      - Thu, 19 Apr 2018 17:42:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3278,13 +3278,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:23 GMT
+      - Thu, 19 Apr 2018 17:42:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1c26ca46-b33b-460a-805f-eaeb97d66024
+      - req-f56183a1-2d70-4cae-86ea-473450083031
       Content-Length:
       - '4131'
       Connection:
@@ -3293,10 +3293,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:23.469508", "expires":
-        "2018-04-09T17:31:23Z", "id": "03f7d25a94e04dfab2ccb3b98d54923e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:23.046049", "expires":
+        "2018-04-19T18:42:23Z", "id": "11c494167ce54d5fa6e78d62e99d669f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ZyqYg0MZQi-73OZOTruFmQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MWJbf4T3S0SUZf4pOlgScw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3340,7 +3340,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -3355,7 +3355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 03f7d25a94e04dfab2ccb3b98d54923e
+      - 11c494167ce54d5fa6e78d62e99d669f
   response:
     status:
       code: 200
@@ -3366,14 +3366,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7935c774-ce0d-4bd0-b7ea-f1b24f748df3
+      - req-ba9e4e14-bcf1-4d41-a677-fe51e0a5d915
       Date:
-      - Mon, 09 Apr 2018 16:31:23 GMT
+      - Thu, 19 Apr 2018 17:42:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3388,7 +3388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a38dc3302a984761a269604c92081848
+      - 4a3ea2a9305047b1a5a8c20dec2e97b8
   response:
     status:
       code: 200
@@ -3399,14 +3399,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6a8e4616-f40a-425d-b801-ab17e897e637
+      - req-1e049272-777c-45d2-a638-bf46bd5f5f40
       Date:
-      - Mon, 09 Apr 2018 16:31:24 GMT
+      - Thu, 19 Apr 2018 17:42:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3424,13 +3424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:24 GMT
+      - Thu, 19 Apr 2018 17:42:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cfbac44b-f0c4-4592-8b29-89be4c4d12b9
+      - req-397abcb7-2528-42a8-a020-cf53abe631ff
       Content-Length:
       - '4118'
       Connection:
@@ -3439,10 +3439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:24.400183", "expires":
-        "2018-04-09T17:31:24Z", "id": "61a3a596029c47bd879900810393bd76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:23.564021", "expires":
+        "2018-04-19T18:42:23Z", "id": "d2f274d0a7e2401483a203f46c846df4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6NqbxnqQQeilYteU2pWuEQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qpc2e5faTjy_MZAoTg0Q8Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3486,7 +3486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3501,7 +3501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61a3a596029c47bd879900810393bd76
+      - d2f274d0a7e2401483a203f46c846df4
   response:
     status:
       code: 200
@@ -3512,14 +3512,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-577eb307-a35a-4aac-b23f-9f2077b73f6d
+      - req-c6bf5795-c9b6-4776-b195-0d88363fc4a6
       Date:
-      - Mon, 09 Apr 2018 16:31:24 GMT
+      - Thu, 19 Apr 2018 17:42:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3534,7 +3534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3545,9 +3545,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-65d08640-db4e-4a0f-80fc-ab16384f7818
+      - req-fbfc0ba2-061f-4d78-b46d-d6cff380f2a8
       Date:
-      - Mon, 09 Apr 2018 16:31:25 GMT
+      - Thu, 19 Apr 2018 17:42:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3574,7 +3574,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3589,7 +3589,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3600,9 +3600,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-129bc9b2-ac7f-4ed9-b1e7-103bb8e6ebcd
+      - req-acbf5de8-8aaf-4e97-b94d-212e7bef00af
       Date:
-      - Mon, 09 Apr 2018 16:31:26 GMT
+      - Thu, 19 Apr 2018 17:42:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3629,7 +3629,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3644,7 +3644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3655,9 +3655,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0fa3dfa2-3685-4dbc-835a-bb469242df8d
+      - req-8304edee-e938-4a87-897a-46757a055f1f
       Date:
-      - Mon, 09 Apr 2018 16:31:27 GMT
+      - Thu, 19 Apr 2018 17:42:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3684,7 +3684,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3699,7 +3699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3710,9 +3710,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-0776829b-0019-4d90-8aa6-2d43115075c7
+      - req-6b83c604-aa33-4145-9ff0-d1880efc822f
       Date:
-      - Mon, 09 Apr 2018 16:31:27 GMT
+      - Thu, 19 Apr 2018 17:42:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3768,7 +3768,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3783,7 +3783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -3794,9 +3794,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d45d83d9-3920-48c7-82f8-3071e1fd1171
+      - req-4c8a36bc-835a-48d6-aeef-2396587a9926
       Date:
-      - Mon, 09 Apr 2018 16:31:27 GMT
+      - Thu, 19 Apr 2018 17:42:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3808,7 +3808,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3823,7 +3823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3836,9 +3836,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-23f4e1de-f055-41e2-bb34-f8763b160c95
+      - req-dc26ba25-b7e0-4a86-af09-0b6887e484b5
       Date:
-      - Mon, 09 Apr 2018 16:31:28 GMT
+      - Thu, 19 Apr 2018 17:42:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3884,7 +3884,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3899,7 +3899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3912,9 +3912,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-e9ca962c-3b63-4b69-b8c5-81871d940623
+      - req-88b91e32-ec64-44f9-8171-3880535f71cf
       Date:
-      - Mon, 09 Apr 2018 16:31:28 GMT
+      - Thu, 19 Apr 2018 17:42:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3960,7 +3960,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3975,7 +3975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3988,9 +3988,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-596de47a-bf39-4998-8b14-44846221159e
+      - req-ca99f4eb-cb48-4e95-a017-06b2a2b2c519
       Date:
-      - Mon, 09 Apr 2018 16:31:29 GMT
+      - Thu, 19 Apr 2018 17:42:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -4038,7 +4038,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4053,7 +4053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4066,9 +4066,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-48a10ec5-ee34-4c51-8927-253d470a9e33
+      - req-209bd46c-0a76-43b9-9b76-dd625c5d0eee
       Date:
-      - Mon, 09 Apr 2018 16:31:29 GMT
+      - Thu, 19 Apr 2018 17:42:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4110,7 +4110,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4125,7 +4125,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4138,9 +4138,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-b572fabe-364f-4b2c-97f1-f9d637434479
+      - req-ee25a1fc-4694-433e-ad39-a54f8bf3f3f9
       Date:
-      - Mon, 09 Apr 2018 16:31:30 GMT
+      - Thu, 19 Apr 2018 17:42:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4163,7 +4163,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -4178,7 +4178,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4191,14 +4191,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-a7767fa2-3973-4e4f-8ab6-8f67fe8b340e
+      - req-8084605c-8369-43dd-9002-6c9e9ef2674c
       Date:
-      - Mon, 09 Apr 2018 16:31:30 GMT
+      - Thu, 19 Apr 2018 17:42:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -4213,7 +4213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4226,14 +4226,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-0c87e873-852c-4660-af03-d5c9c6d219e1
+      - req-62003572-e209-421e-b5cc-e0054c1633ad
       Date:
-      - Mon, 09 Apr 2018 16:31:30 GMT
+      - Thu, 19 Apr 2018 17:42:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -4248,7 +4248,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4261,14 +4261,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-6d84cac1-dc85-453f-82e3-9acaf32dd9c4
+      - req-e403f78d-96d1-493d-acea-497d18c24c0b
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -4283,7 +4283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -4294,9 +4294,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-1dbbadf0-aaff-4015-85b9-2e2f9a60e935
+      - req-961dfd41-1315-4e80-80f6-46bb7a78d4ce
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4352,7 +4352,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -4367,7 +4367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -4378,9 +4378,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-db064bb4-4307-423e-963d-77b3e3e0b020
+      - req-c3445a70-da23-4496-a28a-cea78af1c889
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4392,7 +4392,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -4407,7 +4407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -4418,9 +4418,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c68d34a8-4ec3-4080-8278-fc9cb3370ffd
+      - req-8bb91dae-65d8-4e28-abd8-e8a0e8af6a77
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4476,7 +4476,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -4491,7 +4491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a25f7bbc3c87476b966633aaa93a8f28
+      - 25c663df731b45c3acaa59748753756d
   response:
     status:
       code: 200
@@ -4502,9 +4502,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e28a9b92-d600-4b83-904b-15770147b3a4
+      - req-f4e426d2-4534-4716-9033-656e241f1143
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4516,7 +4516,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4531,7 +4531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4544,9 +4544,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c327dc77-1373-419f-8e7d-dac7c15817be
+      - req-bcb781ca-0c96-4d44-b792-640c26a64672
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4555,7 +4555,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4570,7 +4570,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59e77442e70a45878c3b72a43cd909ef
+      - c4cd3b5bdf79491c80145f1422399c2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4583,9 +4583,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-0fa0ec55-5495-41d7-b121-bcfea962e17d
+      - req-2312f9c9-3fd1-4f20-9578-c21c27fd9a7e
       Date:
-      - Mon, 09 Apr 2018 16:31:31 GMT
+      - Thu, 19 Apr 2018 17:42:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4594,7 +4594,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4609,7 +4609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4622,9 +4622,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7efff5ce-2976-42bb-9029-2a70374b4d40
+      - req-aff99943-dc02-4587-abe0-6e325755a90c
       Date:
-      - Mon, 09 Apr 2018 16:31:32 GMT
+      - Thu, 19 Apr 2018 17:42:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4633,7 +4633,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4648,7 +4648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f32ad17dfdc1400b8231f593be7047d2
+      - ae2b7cd017bb4f63bd74b75318a8bdd7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4661,9 +4661,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-1cf79910-3e9e-4801-aaca-8d59a7e431a4
+      - req-60c5813f-a268-4be9-8bdb-2c7b01e1b39b
       Date:
-      - Mon, 09 Apr 2018 16:31:33 GMT
+      - Thu, 19 Apr 2018 17:42:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4672,7 +4672,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4690,13 +4690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:33 GMT
+      - Thu, 19 Apr 2018 17:42:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0561a085-9d6e-45e6-968e-e3eb3e52b684
+      - req-2d362085-8328-4e60-bc6c-84d3d924895e
       Content-Length:
       - '4117'
       Connection:
@@ -4705,10 +4705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:33.461296", "expires":
-        "2018-04-09T17:31:33Z", "id": "e5a1651523164834883e8a87303f858a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:33.411686", "expires":
+        "2018-04-19T18:42:33Z", "id": "474d18710aa046e981c495b94ecfa039", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["80TM09KATTqzQOb16MNYTw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["E2SQ_aNHTZuhOJwKDm4iwA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4752,7 +4752,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4767,22 +4767,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a1651523164834883e8a87303f858a
+      - 474d18710aa046e981c495b94ecfa039
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3d33d99-9e11-49db-9989-864986ad03ed
+      - req-093774fa-8e9f-4412-9ae1-1e729b2b56eb
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b3d33d99-9e11-49db-9989-864986ad03ed
+      - req-093774fa-8e9f-4412-9ae1-1e729b2b56eb
       Date:
-      - Mon, 09 Apr 2018 16:31:34 GMT
+      - Thu, 19 Apr 2018 17:42:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4792,7 +4792,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4810,13 +4810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:34 GMT
+      - Thu, 19 Apr 2018 17:42:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1471cdf5-2be4-405d-9c2f-ca8355b49fd5
+      - req-971e782e-18d3-4e8e-817b-e1b2b279bd72
       Content-Length:
       - '4131'
       Connection:
@@ -4825,10 +4825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:34.494780", "expires":
-        "2018-04-09T17:31:34Z", "id": "4b098e6558034d1d807f779668f7212a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:34.068464", "expires":
+        "2018-04-19T18:42:33Z", "id": "c129b7dcad6447d4a8b7b0d92f47c79e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["YRWCdD0zRJGzJBMHSh3bCw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fKMVS-ifRsyISXuH_FKyMA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4872,7 +4872,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4887,22 +4887,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b098e6558034d1d807f779668f7212a
+      - c129b7dcad6447d4a8b7b0d92f47c79e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31dc1156-1079-4ce0-86f4-6184377a4093
+      - req-22e128cb-dbe4-48dd-b7ff-000bbdf3b448
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-31dc1156-1079-4ce0-86f4-6184377a4093
+      - req-22e128cb-dbe4-48dd-b7ff-000bbdf3b448
       Date:
-      - Mon, 09 Apr 2018 16:31:35 GMT
+      - Thu, 19 Apr 2018 17:42:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4912,7 +4912,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4927,22 +4927,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - daeb51c329a5484dbd38b075e43dbe4a
+      - d20cb4e119cd41cfa6eba95991a7d9a2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a339c5b5-a27f-409b-a198-3e5dc85e5a47
+      - req-7e7a0bb0-4560-4a1b-b7b4-b751dad13c78
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a339c5b5-a27f-409b-a198-3e5dc85e5a47
+      - req-7e7a0bb0-4560-4a1b-b7b4-b751dad13c78
       Date:
-      - Mon, 09 Apr 2018 16:31:35 GMT
+      - Thu, 19 Apr 2018 17:42:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4952,7 +4952,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4970,13 +4970,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:36 GMT
+      - Thu, 19 Apr 2018 17:42:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b0dfbb3-5797-445c-a675-9fd95cbb318f
+      - req-505dc291-0e56-47f3-8c96-35adbec3315a
       Content-Length:
       - '4118'
       Connection:
@@ -4985,10 +4985,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:36.168753", "expires":
-        "2018-04-09T17:31:36Z", "id": "e30edc3399994bc18d2608ca3d58f9d1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:37.152021", "expires":
+        "2018-04-19T18:42:37Z", "id": "bf7bb353a6384deebeaf991a798ee6f8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ukpAyppUShiRy-TgmsYaSw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zabxJmOHRY2dpyM4ZTuIHA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5032,7 +5032,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -5047,22 +5047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e30edc3399994bc18d2608ca3d58f9d1
+      - bf7bb353a6384deebeaf991a798ee6f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b4565775-2aa4-49e7-bf04-a9ac96433636
+      - req-5e93539d-e3fc-42db-a0f9-00b06240ce38
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b4565775-2aa4-49e7-bf04-a9ac96433636
+      - req-5e93539d-e3fc-42db-a0f9-00b06240ce38
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5072,7 +5072,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5090,13 +5090,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ed3bbf6a-8c55-4e37-815a-38a5fa66eccf
+      - req-d0d0e3de-3780-4b4d-9df3-bd780558d9c2
       Content-Length:
       - '4170'
       Connection:
@@ -5105,10 +5105,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:37.254448", "expires":
-        "2018-04-09T17:31:37Z", "id": "5ca6ffe135d8491bb5a9cbaf9539bd33", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:38.619205", "expires":
+        "2018-04-19T18:42:38Z", "id": "311bcfccc0184547afcd154d19f49fa1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["T7LwJLGtTMKHbBWuIntPUg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_G03gkhoSEulMcalf3OBNQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5153,7 +5153,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -5168,7 +5168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ca6ffe135d8491bb5a9cbaf9539bd33
+      - 311bcfccc0184547afcd154d19f49fa1
   response:
     status:
       code: 200
@@ -5179,13 +5179,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5203,13 +5203,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b12e9987-6228-4a48-93d4-0b3aab37390c
+      - req-1180bb36-3edc-44a2-973c-9bf078e0ab11
       Content-Length:
       - '4117'
       Connection:
@@ -5218,10 +5218,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:37.570923", "expires":
-        "2018-04-09T17:31:37Z", "id": "9c90e03a764943b489cb1fb9982a5988", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:38.927753", "expires":
+        "2018-04-19T18:42:38Z", "id": "f588f01f8c3a4c508223422a99f2fa1e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yzrI0wXSRQybAoXLbbTVDg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LJMv9OsMQOi7AnT1ZpGlYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5265,7 +5265,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -5280,7 +5280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c90e03a764943b489cb1fb9982a5988
+      - f588f01f8c3a4c508223422a99f2fa1e
   response:
     status:
       code: 200
@@ -5291,16 +5291,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3bbf54d1-201c-40e7-8785-50ed4997d3fa
+      - req-7d7dfbef-fce8-46c9-b7f2-94550c27c939
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5318,13 +5318,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:37 GMT
+      - Thu, 19 Apr 2018 17:42:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2c524e8-aa31-47c7-950f-440fba578199
+      - req-178bac5d-da4d-40fc-9a8c-3651e4c60c71
       Content-Length:
       - '4131'
       Connection:
@@ -5333,10 +5333,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:38.112499", "expires":
-        "2018-04-09T17:31:38Z", "id": "9f8ca92afe8f419c9f8b0f2e0fad7e19", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:39.533168", "expires":
+        "2018-04-19T18:42:39Z", "id": "ececf485009b411e92e0ae744bca8838", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_kLJNJ2lQrGSkHULQy6M5Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["cJKkyNcITb-YzORbqVfRmg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5380,7 +5380,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -5395,7 +5395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f8ca92afe8f419c9f8b0f2e0fad7e19
+      - ececf485009b411e92e0ae744bca8838
   response:
     status:
       code: 200
@@ -5406,16 +5406,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b985a3e1-b01b-45c5-b747-679c57db7647
+      - req-6b433737-ad37-49e7-a1be-8775c7e96784
       Date:
-      - Mon, 09 Apr 2018 16:31:38 GMT
+      - Thu, 19 Apr 2018 17:42:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ca6ffe135d8491bb5a9cbaf9539bd33
+      - 311bcfccc0184547afcd154d19f49fa1
   response:
     status:
       code: 200
@@ -5441,16 +5441,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fc8a8f69-35c1-4eb7-9af3-e79c75de3a4c
+      - req-62b22183-2b37-42dc-9b1b-c6c7483821f4
       Date:
-      - Mon, 09 Apr 2018 16:31:38 GMT
+      - Thu, 19 Apr 2018 17:42:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5468,13 +5468,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:38 GMT
+      - Thu, 19 Apr 2018 17:42:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-11853d95-2f52-4604-bf7f-e89bed87d58b
+      - req-9c3cb9b2-e20a-44bf-aedf-56b384edce8f
       Content-Length:
       - '4118'
       Connection:
@@ -5483,10 +5483,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:39.030987", "expires":
-        "2018-04-09T17:31:38Z", "id": "4c79f52a88634906bc739a43a77b5f2d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:40.379001", "expires":
+        "2018-04-19T18:42:40Z", "id": "0dfb7fcf7e76481faee7924c19ef846f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Yp75Kq5OTNelr25FLyghRA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["iZNdRJxPTvGwbAXvH-dn9A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5530,7 +5530,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5545,7 +5545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c79f52a88634906bc739a43a77b5f2d
+      - 0dfb7fcf7e76481faee7924c19ef846f
   response:
     status:
       code: 200
@@ -5556,16 +5556,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-da8db783-7942-4a1f-ab52-581564242121
+      - req-e5e6ce74-6115-4b61-9362-0ce0d0fce6ed
       Date:
-      - Mon, 09 Apr 2018 16:31:39 GMT
+      - Thu, 19 Apr 2018 17:42:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5580,7 +5580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5593,9 +5593,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-e0122210-1fad-4729-ae5f-d91a7cdeb0aa
+      - req-a041c67f-b280-4da5-9d20-02e26005a33c
       Date:
-      - Mon, 09 Apr 2018 16:31:39 GMT
+      - Thu, 19 Apr 2018 17:42:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5618,7 +5618,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5633,7 +5633,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5646,9 +5646,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-cfeb7647-a8f0-42db-991e-77d67d86a640
+      - req-5e499ee0-02e9-4a6f-9830-25efc9952ced
       Date:
-      - Mon, 09 Apr 2018 16:31:40 GMT
+      - Thu, 19 Apr 2018 17:42:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5671,7 +5671,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5686,7 +5686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5699,9 +5699,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-e38dd2a0-ca1a-4bdf-921b-b1f0550b5d83
+      - req-2ee79249-c362-417b-9f97-170d9c748e6d
       Date:
-      - Mon, 09 Apr 2018 16:31:40 GMT
+      - Thu, 19 Apr 2018 17:42:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5724,7 +5724,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5739,7 +5739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5752,9 +5752,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-17acbe8f-7f78-431c-a08c-c58e10cf41e8
+      - req-2a797561-34b4-4e75-a302-ace465104e01
       Date:
-      - Mon, 09 Apr 2018 16:31:40 GMT
+      - Thu, 19 Apr 2018 17:42:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5777,7 +5777,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5792,7 +5792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5805,9 +5805,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-75d8e647-18f9-4373-8732-5c0e1f5eca5b
+      - req-90e6c53c-524f-4a85-a150-648d44a925b1
       Date:
-      - Mon, 09 Apr 2018 16:31:41 GMT
+      - Thu, 19 Apr 2018 17:42:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5830,7 +5830,43 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 148b3c279dce49deb88eb1b4c151ccc7
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-c4de72f8-46be-429a-9b6d-e5e77566eff2
+      Date:
+      - Thu, 19 Apr 2018 17:42:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
+        "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:42:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5845,7 +5881,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5858,9 +5894,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1b75543f-6456-456f-b84a-d6fba7ce38f8
+      - req-4b0acd2a-6863-4099-ac8d-67c429198fac
       Date:
-      - Mon, 09 Apr 2018 16:31:41 GMT
+      - Thu, 19 Apr 2018 17:42:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5883,7 +5919,43 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 148b3c279dce49deb88eb1b4c151ccc7
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-ab6e14e8-5b5f-4a72-9802-910c3dc55c72
+      Date:
+      - Thu, 19 Apr 2018 17:42:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:42:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5898,7 +5970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5911,9 +5983,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-c0a506ee-9a95-466b-b115-66524643b761
+      - req-804bc6ce-fd93-4387-b62c-91f9ba43c677
       Date:
-      - Mon, 09 Apr 2018 16:31:41 GMT
+      - Thu, 19 Apr 2018 17:42:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5936,7 +6008,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5951,7 +6023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5964,9 +6036,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-c76cd149-252d-48f3-acdb-a5b1bb7c3b1a
+      - req-5c7de2e2-3e81-4824-993a-0191f60edb4b
       Date:
-      - Mon, 09 Apr 2018 16:31:42 GMT
+      - Thu, 19 Apr 2018 17:42:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5989,7 +6061,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -6004,7 +6076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cb86d540fc4393bf8ca85a64cfbe0f
+      - 148b3c279dce49deb88eb1b4c151ccc7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6017,9 +6089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-e8309de2-3fe4-4601-bc35-c6c09fa15402
+      - req-a3074ec7-132f-454c-a63f-58f7d1ae8580
       Date:
-      - Mon, 09 Apr 2018 16:31:42 GMT
+      - Thu, 19 Apr 2018 17:42:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -6042,7 +6114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6060,13 +6132,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:42 GMT
+      - Thu, 19 Apr 2018 17:42:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e5092dd6-8a5b-45cb-9188-e3a1bee0dfca
+      - req-996f5a57-935f-4598-bd83-a4b52c537fb2
       Content-Length:
       - '4170'
       Connection:
@@ -6075,10 +6147,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:42.804831", "expires":
-        "2018-04-09T17:31:42Z", "id": "1c3402554fee476585770cbe90d1ff4b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:46.338628", "expires":
+        "2018-04-19T18:42:46Z", "id": "4d4584dc06c84a1298a8c8ad2842de4e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_pxh2lgbTlq1RU7zRIhaiw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QlPS7gTaTnSkDs8bm4U8wA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6123,13 +6195,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1c3402554fee476585770cbe90d1ff4b"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"4d4584dc06c84a1298a8c8ad2842de4e"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6141,13 +6213,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:42 GMT
+      - Thu, 19 Apr 2018 17:42:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bc5fb4f7-b40b-41a4-9427-e650b8c6a4f9
+      - req-35bc6692-fb93-43c9-888d-5712547c3299
       Content-Length:
       - '4196'
       Connection:
@@ -6156,10 +6228,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:43.054987", "expires":
-        "2018-04-09T17:31:42Z", "id": "652f636fd3104e9ebd867c0bc4acedb0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:48.294886", "expires":
+        "2018-04-19T18:42:46Z", "id": "bd5cf53453974e47bcf256e3af9c7cef", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["-4pb-OoVS9Oy-xWUpJq2jA", "_pxh2lgbTlq1RU7zRIhaiw"]},
+        "name": "admin"}, "audit_ids": ["E8EwGeYLRK-PAqhZTCx25A", "QlPS7gTaTnSkDs8bm4U8wA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6204,7 +6276,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6222,13 +6294,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:43 GMT
+      - Thu, 19 Apr 2018 17:42:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3e225e07-65f7-424b-83eb-3ecae49a1f23
+      - req-b1f66112-f4f0-4314-8939-db190f086d07
       Content-Length:
       - '4170'
       Connection:
@@ -6237,10 +6309,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:43.345697", "expires":
-        "2018-04-09T17:31:43Z", "id": "2378b87400ed4c029e1e1a28d23b2155", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:48.645487", "expires":
+        "2018-04-19T18:42:48Z", "id": "60362da6ddb14ee1ada0fada838996c0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YalDMIqMSVGdnCO2ZvcYBA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["D2p8VfQ7Tg6VDk7oON-6-Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6285,13 +6357,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"2378b87400ed4c029e1e1a28d23b2155"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"60362da6ddb14ee1ada0fada838996c0"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6303,13 +6375,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:43 GMT
+      - Thu, 19 Apr 2018 17:42:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f551283-433e-4d12-baec-691809ddca5a
+      - req-2577ed9d-64c4-4329-af83-1108e6ddf9c8
       Content-Length:
       - '4196'
       Connection:
@@ -6318,10 +6390,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:43.765145", "expires":
-        "2018-04-09T17:31:43Z", "id": "51af85ec11594ea9817ec932b697b54e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:49.204217", "expires":
+        "2018-04-19T18:42:48Z", "id": "cfd97a45f58b4d218ed8064825990e52", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["OQkkWqaeSXK5WmV6-osJJA", "YalDMIqMSVGdnCO2ZvcYBA"]},
+        "name": "admin"}, "audit_ids": ["Vkhcf6-0RiKCdtc0TMj_vQ", "D2p8VfQ7Tg6VDk7oON-6-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6366,7 +6438,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -6381,7 +6453,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d250b0289ad44f89abd70b5b2394cea
+      - 9d8c280878e54593aa4147c8e2b55282
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6394,14 +6466,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-9a8802ea-d618-4e78-9799-28db3a979cfa
+      - req-1c4b69fd-d0f0-4689-9d83-2f10ab94932e
       Date:
-      - Mon, 09 Apr 2018 16:31:43 GMT
+      - Thu, 19 Apr 2018 17:42:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -6416,22 +6488,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a1651523164834883e8a87303f858a
+      - 474d18710aa046e981c495b94ecfa039
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f48bda5b-97d0-4c84-aaaf-693820fbacfe
+      - req-223dc582-82e2-4616-8161-1d457c74c684
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-f48bda5b-97d0-4c84-aaaf-693820fbacfe
+      - req-223dc582-82e2-4616-8161-1d457c74c684
       Date:
-      - Mon, 09 Apr 2018 16:31:44 GMT
+      - Thu, 19 Apr 2018 17:42:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6464,7 +6536,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6479,22 +6551,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a1651523164834883e8a87303f858a
+      - 474d18710aa046e981c495b94ecfa039
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c5a9003-fca7-49ef-a01d-6a05187eced1
+      - req-1c2f5e6b-df7b-4edf-b1c4-517d57cf865f
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-9c5a9003-fca7-49ef-a01d-6a05187eced1
+      - req-1c2f5e6b-df7b-4edf-b1c4-517d57cf865f
       Date:
-      - Mon, 09 Apr 2018 16:31:44 GMT
+      - Thu, 19 Apr 2018 17:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6511,7 +6583,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6526,27 +6598,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b098e6558034d1d807f779668f7212a
+      - c129b7dcad6447d4a8b7b0d92f47c79e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-701a6586-bea2-4b5d-91dd-c462930c4f9e
+      - req-8e3f527a-09d2-4207-ab0f-a044cfb93b90
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-701a6586-bea2-4b5d-91dd-c462930c4f9e
+      - req-8e3f527a-09d2-4207-ab0f-a044cfb93b90
       Date:
-      - Mon, 09 Apr 2018 16:31:45 GMT
+      - Thu, 19 Apr 2018 17:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6561,27 +6633,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - daeb51c329a5484dbd38b075e43dbe4a
+      - d20cb4e119cd41cfa6eba95991a7d9a2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b52ef2b-2a26-401d-99c1-1a87808bf699
+      - req-a6f7f628-587c-4671-a6ca-4dff982e3954
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8b52ef2b-2a26-401d-99c1-1a87808bf699
+      - req-a6f7f628-587c-4671-a6ca-4dff982e3954
       Date:
-      - Mon, 09 Apr 2018 16:31:45 GMT
+      - Thu, 19 Apr 2018 17:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6596,27 +6668,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e30edc3399994bc18d2608ca3d58f9d1
+      - bf7bb353a6384deebeaf991a798ee6f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a3eba3db-fa69-4460-a45a-d12c5486dc6d
+      - req-8ceebdc5-58ce-4121-992e-0be8f36a5391
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a3eba3db-fa69-4460-a45a-d12c5486dc6d
+      - req-8ceebdc5-58ce-4121-992e-0be8f36a5391
       Date:
-      - Mon, 09 Apr 2018 16:31:45 GMT
+      - Thu, 19 Apr 2018 17:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6631,22 +6703,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a1651523164834883e8a87303f858a
+      - 474d18710aa046e981c495b94ecfa039
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-366a8a4b-c0f0-4c85-9b23-d995050f807c
+      - req-ba4c6bde-2ec6-4308-b42e-9b199fa55629
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-366a8a4b-c0f0-4c85-9b23-d995050f807c
+      - req-ba4c6bde-2ec6-4308-b42e-9b199fa55629
       Date:
-      - Mon, 09 Apr 2018 16:31:45 GMT
+      - Thu, 19 Apr 2018 17:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6661,7 +6733,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6676,22 +6748,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a1651523164834883e8a87303f858a
+      - 474d18710aa046e981c495b94ecfa039
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb2f04c8-fd07-4b09-9bd3-b8e2434a1abc
+      - req-92dccd8e-f16c-4319-8775-7701919817aa
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-fb2f04c8-fd07-4b09-9bd3-b8e2434a1abc
+      - req-92dccd8e-f16c-4319-8775-7701919817aa
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6706,7 +6778,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6721,27 +6793,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b098e6558034d1d807f779668f7212a
+      - c129b7dcad6447d4a8b7b0d92f47c79e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-66fe1305-0235-486d-ae94-25e796d17852
+      - req-290ea7c2-498d-48e5-a460-2c7c7a5e25c0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-66fe1305-0235-486d-ae94-25e796d17852
+      - req-290ea7c2-498d-48e5-a460-2c7c7a5e25c0
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6756,27 +6828,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b098e6558034d1d807f779668f7212a
+      - c129b7dcad6447d4a8b7b0d92f47c79e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8b7372a-75ef-4f4e-995f-2334476eb476
+      - req-05002fec-af33-48e4-b119-bb618472706d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b8b7372a-75ef-4f4e-995f-2334476eb476
+      - req-05002fec-af33-48e4-b119-bb618472706d
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6791,27 +6863,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - daeb51c329a5484dbd38b075e43dbe4a
+      - d20cb4e119cd41cfa6eba95991a7d9a2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cdca0af-433b-4a72-a8db-8aad9773ec16
+      - req-bf745f0d-7511-4b59-b3be-c846908ab852
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4cdca0af-433b-4a72-a8db-8aad9773ec16
+      - req-bf745f0d-7511-4b59-b3be-c846908ab852
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6826,27 +6898,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - daeb51c329a5484dbd38b075e43dbe4a
+      - d20cb4e119cd41cfa6eba95991a7d9a2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f90df34c-e60d-4e1a-a667-3eb1b3de9bf7
+      - req-0b903942-f27e-411e-8591-bf2ed29de709
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f90df34c-e60d-4e1a-a667-3eb1b3de9bf7
+      - req-0b903942-f27e-411e-8591-bf2ed29de709
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6861,27 +6933,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e30edc3399994bc18d2608ca3d58f9d1
+      - bf7bb353a6384deebeaf991a798ee6f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-397ea948-c05c-4634-a8f1-4b6c00923fb2
+      - req-4288254a-d980-44fd-8725-619fb333cd56
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-397ea948-c05c-4634-a8f1-4b6c00923fb2
+      - req-4288254a-d980-44fd-8725-619fb333cd56
       Date:
-      - Mon, 09 Apr 2018 16:31:46 GMT
+      - Thu, 19 Apr 2018 17:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6896,27 +6968,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e30edc3399994bc18d2608ca3d58f9d1
+      - bf7bb353a6384deebeaf991a798ee6f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d46090d-4c81-48a2-8cee-ee6ba620f10c
+      - req-6db3ef16-7eed-46b3-8056-48fe40533acd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4d46090d-4c81-48a2-8cee-ee6ba620f10c
+      - req-6db3ef16-7eed-46b3-8056-48fe40533acd
       Date:
-      - Mon, 09 Apr 2018 16:31:47 GMT
+      - Thu, 19 Apr 2018 17:42:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6934,13 +7006,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:47 GMT
+      - Thu, 19 Apr 2018 17:42:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3bc47de7-0e3c-42ae-be63-3f39097f4702
+      - req-a81a8993-16b7-4a81-89a7-c2c504f3d88c
       Content-Length:
       - '4170'
       Connection:
@@ -6949,10 +7021,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:47.985783", "expires":
-        "2018-04-09T17:31:47Z", "id": "df940e01149a47519ce0e41ce56c036f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:53.504684", "expires":
+        "2018-04-19T18:42:53Z", "id": "6c90121a85cc4f869ca9f3838a0dccf5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["OdUW82lYTGiDqiEmVlhIrg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["egJGZ9ytRcyXOahfOdnVaA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6997,7 +7069,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7015,13 +7087,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:48 GMT
+      - Thu, 19 Apr 2018 17:42:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10f5c8db-f06c-45cc-b5e7-bd5ac569a01a
+      - req-68b04ec2-11b5-4a1c-9cf7-6fb97f17f26e
       Content-Length:
       - '4170'
       Connection:
@@ -7030,10 +7102,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:48.252241", "expires":
-        "2018-04-09T17:31:48Z", "id": "bfd181d8be9c407995ee6fed84caddcf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:53.908901", "expires":
+        "2018-04-19T18:42:53Z", "id": "8bed6cdafc3a401faae37c080b1cbbec", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["xaAfW8hVQzKPK5k-oFiRKg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["VXvvrc_cS8qjQrRONcS9hQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7078,7 +7150,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -7093,7 +7165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -7104,37 +7176,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-1fbf4754-f3e4-4e2f-a1b1-b4999150338e
+      - req-db294f10-f6eb-49bf-863b-6e7a9e1342ab
       Date:
-      - Mon, 09 Apr 2018 16:31:48 GMT
+      - Thu, 19 Apr 2018 17:42:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7144,7 +7191,12 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -7169,14 +7221,34 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7194,13 +7266,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:48 GMT
+      - Thu, 19 Apr 2018 17:42:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d4817d0-ae73-4aa2-a52b-479802f55ea5
+      - req-e3f08f25-fbd2-42de-a9b3-53e3b9c9d412
       Content-Length:
       - '4170'
       Connection:
@@ -7209,10 +7281,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:48.910273", "expires":
-        "2018-04-09T17:31:48Z", "id": "eeb98e53f3bf48069138691fdb7a0b07", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:54.554778", "expires":
+        "2018-04-19T18:42:54Z", "id": "65e28090e7bf4118aaba9873ac1d5271", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mmC57ldPSzKhCRhPruasEw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EAPiQZlVQ7ur5iqDZYy_WA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7257,7 +7329,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7275,13 +7347,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:49 GMT
+      - Thu, 19 Apr 2018 17:42:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b999c1e4-f60e-4363-b970-34370cf81fcd
+      - req-f1f76567-0256-482d-af1a-087579be73c4
       Content-Length:
       - '370'
       Connection:
@@ -7290,13 +7362,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:49.114036", "expires":
-        "2018-04-09T17:31:49Z", "id": "9d24449fc0dc470f82b52ad6050e0914", "audit_ids":
-        ["6DfFv2eZRpyyFHjuCxGt0Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:54.723854", "expires":
+        "2018-04-19T18:42:54Z", "id": "20035bfdd5544f999ffe7e264b0cf88f", "audit_ids":
+        ["EW3olAp6RFqvTG_qO1ipYA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:54 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7311,20 +7383,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d24449fc0dc470f82b52ad6050e0914
+      - 20035bfdd5544f999ffe7e264b0cf88f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:49 GMT
+      - Thu, 19 Apr 2018 17:42:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-83456e91-a1b9-4eaf-9578-7bcd1cb69a07
+      - req-f9658182-d08e-450f-a923-384436be9913
       Content-Length:
       - '500'
       Connection:
@@ -7341,13 +7413,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9d24449fc0dc470f82b52ad6050e0914"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"20035bfdd5544f999ffe7e264b0cf88f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7359,13 +7431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:49 GMT
+      - Thu, 19 Apr 2018 17:42:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29eabbb5-da96-45b4-aa6e-cfc307eeb305
+      - req-71803315-a44e-49ad-9581-379d2599369b
       Content-Length:
       - '4143'
       Connection:
@@ -7374,11 +7446,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:49.581406", "expires":
-        "2018-04-09T17:31:49Z", "id": "14a81c09df104625b55aad9a3c1aba56", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:55.288426", "expires":
+        "2018-04-19T18:42:54Z", "id": "175cc8310ec445fa8d8b5b73f99dac90", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["090PKuo7Qtm0FNNTG1WVGQ",
-        "6DfFv2eZRpyyFHjuCxGt0Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fn5vWf0_RuO_h6E6Ljk19A",
+        "EW3olAp6RFqvTG_qO1ipYA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7422,7 +7494,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:55 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7437,20 +7509,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d24449fc0dc470f82b52ad6050e0914
+      - 20035bfdd5544f999ffe7e264b0cf88f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:49 GMT
+      - Thu, 19 Apr 2018 17:42:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-311d4c7b-be66-4aa7-8f24-593c7176471d
+      - req-187c74f8-a0de-400b-b606-d6727ae5359f
       Content-Length:
       - '500'
       Connection:
@@ -7467,7 +7539,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7485,13 +7557,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:49 GMT
+      - Thu, 19 Apr 2018 17:42:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a73b89cb-24b2-4fab-af47-31dceed184f3
+      - req-25eedb9c-26e5-4ed1-aba7-ee597006b053
       Content-Length:
       - '4117'
       Connection:
@@ -7500,10 +7572,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:50.008690", "expires":
-        "2018-04-09T17:31:49Z", "id": "8d426de05d9149f3a0b354e2c976a69c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:55.678037", "expires":
+        "2018-04-19T18:42:55Z", "id": "66db962947d34910966e8c4093b439e9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3CdaI0UBSyqTkKESKhkVXg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["w3Dx8GaXS_Wuyd8tOKt84Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7547,7 +7619,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7565,13 +7637,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:50 GMT
+      - Thu, 19 Apr 2018 17:42:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76b63e3e-dd67-4794-9371-e26ac8acc11a
+      - req-efef7edf-3b84-41cc-9b2e-06eabf75d2dc
       Content-Length:
       - '4131'
       Connection:
@@ -7580,10 +7652,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:50.286220", "expires":
-        "2018-04-09T17:31:50Z", "id": "edc002d824474a038ba3be1c6137296e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:55.963196", "expires":
+        "2018-04-19T18:42:55Z", "id": "c075752a25ef4bdeb7afac18843213ef", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zxhufolMQ-mvLSrelc_-cg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["y7F5VXKhSy6cbbygpyadPA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7627,7 +7699,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7645,13 +7717,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:50 GMT
+      - Thu, 19 Apr 2018 17:42:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e5d05415-f863-440f-bb0d-3104302c274f
+      - req-49305e21-92fa-4eb2-82ab-2ae3e63b92fc
       Content-Length:
       - '4118'
       Connection:
@@ -7660,10 +7732,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:50.590257", "expires":
-        "2018-04-09T17:31:50Z", "id": "f8b935f7381743899bb1d82aaf50530c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:56.261572", "expires":
+        "2018-04-19T18:42:56Z", "id": "3d340c5cf94c4abc9dd0f9c7b67bd501", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e8enTOa3RBKawNVrT_em-g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mucOeJjmSNWTGno-h5QbUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7707,7 +7779,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7725,13 +7797,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:50 GMT
+      - Thu, 19 Apr 2018 17:42:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04cf6960-b1bc-49fd-a7f0-91722b3f8879
+      - req-74f7a063-02c8-4fc4-b7a4-d4855c6e8ed5
       Content-Length:
       - '4117'
       Connection:
@@ -7740,10 +7812,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:50.881757", "expires":
-        "2018-04-09T17:31:50Z", "id": "2b4e1f2da4b54df580e4b761e1749c1e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:56.497592", "expires":
+        "2018-04-19T18:42:56Z", "id": "1e1878228d9542ba8aaf11027d4df9ff", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xOPpVVrPRj-3H0DsY2HF_A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2Kahzes4R-yXEnW76A14NQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7787,7 +7859,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7802,7 +7874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -7813,9 +7885,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-a196deed-1c17-49c4-b31f-4eddc7e1180c
+      - req-1c970760-1e7a-4e1e-99c1-6781027997c3
       Date:
-      - Mon, 09 Apr 2018 16:31:51 GMT
+      - Thu, 19 Apr 2018 17:42:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7849,7 +7921,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7864,7 +7936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -7875,14 +7947,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-81de7150-e718-4456-a3a9-f543e40713e7
+      - req-eae18fe9-ec7f-48a9-b2b9-a9d5cbacb972
       Date:
-      - Mon, 09 Apr 2018 16:31:51 GMT
+      - Thu, 19 Apr 2018 17:42:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7900,13 +7972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:51 GMT
+      - Thu, 19 Apr 2018 17:42:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-59c7e21c-6b06-45c3-9074-05fe09377d1a
+      - req-a93b1b22-9535-4061-9663-5f0c335c111f
       Content-Length:
       - '4131'
       Connection:
@@ -7915,10 +7987,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:51.613206", "expires":
-        "2018-04-09T17:31:51Z", "id": "6e6e278c35e0433d801adca2c971a813", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:57.267770", "expires":
+        "2018-04-19T18:42:57Z", "id": "079e66b003a04e6996e4514fcbf99cd5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["wR8PmV7NS8C7B2UzDYmr-g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["msAx3E8sQluplCE2trvLZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7962,7 +8034,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7977,7 +8049,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e6e278c35e0433d801adca2c971a813
+      - '079e66b003a04e6996e4514fcbf99cd5'
   response:
     status:
       code: 200
@@ -7988,14 +8060,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-217f6716-9647-4884-b4bf-531b09c49ec4
+      - req-e1134fa0-82c7-4d07-a340-c13f04d55254
       Date:
-      - Mon, 09 Apr 2018 16:31:52 GMT
+      - Thu, 19 Apr 2018 17:42:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -8010,7 +8082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eeb98e53f3bf48069138691fdb7a0b07
+      - 65e28090e7bf4118aaba9873ac1d5271
   response:
     status:
       code: 200
@@ -8021,14 +8093,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-706c1076-6539-4528-82f4-fcdd2624fd45
+      - req-92a5be07-5584-4148-aeee-c93bd251b57b
       Date:
-      - Mon, 09 Apr 2018 16:31:52 GMT
+      - Thu, 19 Apr 2018 17:42:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8046,13 +8118,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:52 GMT
+      - Thu, 19 Apr 2018 17:42:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df93ccdc-ef19-4efd-a535-be8da1e637dc
+      - req-36271210-f954-4b79-aa64-f422f026ef41
       Content-Length:
       - '4118'
       Connection:
@@ -8061,10 +8133,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:52.814959", "expires":
-        "2018-04-09T17:31:52Z", "id": "9a127ab41bca4d5a8963bcc1f837f3ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:58.097981", "expires":
+        "2018-04-19T18:42:58Z", "id": "1417b70ee26a4a80981f598c06bcc778", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F-nODGOxSBC6K8U6Hipazw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5Im2JfnjSgOvyqnErh_qvw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8108,7 +8180,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8123,7 +8195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a127ab41bca4d5a8963bcc1f837f3ef
+      - 1417b70ee26a4a80981f598c06bcc778
   response:
     status:
       code: 200
@@ -8134,14 +8206,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-874e73e5-3164-4f79-a227-5d8b1ded6126
+      - req-5f1c9721-80f2-403c-be95-52d9f76b34de
       Date:
-      - Mon, 09 Apr 2018 16:31:53 GMT
+      - Thu, 19 Apr 2018 17:42:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8156,7 +8228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8167,9 +8239,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-07f08d48-ac7a-46f2-b669-854a365cb87f
+      - req-7ff1e05b-69e5-4edf-9fce-01ae93a1ed24
       Date:
-      - Mon, 09 Apr 2018 16:31:54 GMT
+      - Thu, 19 Apr 2018 17:42:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8196,7 +8268,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8211,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8222,9 +8294,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3a141fa2-3902-4f75-a860-35ad8ae9a526
+      - req-a88bde6e-d75a-4c47-80fe-036704001b73
       Date:
-      - Mon, 09 Apr 2018 16:31:55 GMT
+      - Thu, 19 Apr 2018 17:43:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8251,7 +8323,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8266,7 +8338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8277,9 +8349,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e7788aa7-45d0-495e-8aff-18994431d2c9
+      - req-915267c1-98cf-4f8d-94a5-e95b4d09b9c4
       Date:
-      - Mon, 09 Apr 2018 16:31:56 GMT
+      - Thu, 19 Apr 2018 17:43:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8306,7 +8378,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8321,7 +8393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8332,9 +8404,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-225e0e84-8b3d-43f1-af22-126068b2f743
+      - req-dda140c4-6827-4375-8f39-8b66ce74a11e
       Date:
-      - Mon, 09 Apr 2018 16:31:56 GMT
+      - Thu, 19 Apr 2018 17:43:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8346,7 +8418,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8361,7 +8433,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8372,9 +8444,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1c6481cc-465d-405d-95a2-2b23c0469caf
+      - req-11bb6638-cbc8-41c1-b3f9-66da8feade5e
       Date:
-      - Mon, 09 Apr 2018 16:31:56 GMT
+      - Thu, 19 Apr 2018 17:43:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8386,7 +8458,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8401,7 +8473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b4e1f2da4b54df580e4b761e1749c1e
+      - 1e1878228d9542ba8aaf11027d4df9ff
   response:
     status:
       code: 200
@@ -8412,9 +8484,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-cec1a5b8-d685-4eed-b3c9-d6965c30f7c9
+      - req-aaa079f6-2b61-494d-9b21-77cfa3d9c421
       Date:
-      - Mon, 09 Apr 2018 16:31:56 GMT
+      - Thu, 19 Apr 2018 17:43:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8426,7 +8498,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8444,13 +8516,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:56 GMT
+      - Thu, 19 Apr 2018 17:43:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fb0f334d-9ee6-42d4-91fd-3e53360a5584
+      - req-01898090-cc7c-4104-9c31-fc36a68782b9
       Content-Length:
       - '4117'
       Connection:
@@ -8459,10 +8531,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:56.947609", "expires":
-        "2018-04-09T17:31:56Z", "id": "c4b248e64168496f87ca9595e6c96d93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:02.117912", "expires":
+        "2018-04-19T18:43:02Z", "id": "db058d41e3c4485ab27d37fec9a98a73", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["pfEZeIRVQWKWab9SRxrOeQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XZo9HXFUQY2UAWHJx1gY_w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8506,7 +8578,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8521,7 +8593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -8532,9 +8604,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c13e74ed-517b-4289-a598-6634ceb7b581
+      - req-c02b5b87-995d-46c3-a989-b54930757028
       Date:
-      - Mon, 09 Apr 2018 16:31:57 GMT
+      - Thu, 19 Apr 2018 17:43:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - db058d41e3c4485ab27d37fec9a98a73
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ddc6e00e-2f56-4678-9645-b619f38ecc8a
+      Date:
+      - Thu, 19 Apr 2018 17:43:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -8638,271 +8842,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c04a8faa-b322-4944-b89d-242c36023d15
-      Date:
-      - Mon, 09 Apr 2018 16:31:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8773bda5-0be1-4ff6-8bbc-7a752d870864
-      Date:
-      - Mon, 09 Apr 2018 16:31:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8920,13 +8860,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:58 GMT
+      - Thu, 19 Apr 2018 17:43:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1f77aced-bc52-4623-850e-20a75c86b8c4
+      - req-0b0e6326-017a-456f-a5df-472e11512bca
       Content-Length:
       - '4131'
       Connection:
@@ -8935,10 +8875,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:31:58.153529", "expires":
-        "2018-04-09T17:31:58Z", "id": "b255dd42dcb04870914447bd84b74247", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:02.713440", "expires":
+        "2018-04-19T18:43:02Z", "id": "f37d8451d76a46fa892d0f844daf50e0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lnuaHYobSLurOL6N33LDRw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zq9zL78KTtuK-zsEwMg03w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8982,7 +8922,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8997,7 +8937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -9008,9 +8948,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8d5aace-50a9-4219-902c-4e6e277e1ae7
+      - req-ae92437a-f7c4-4134-96a2-4c6c1b7c29f0
       Date:
-      - Mon, 09 Apr 2018 16:31:58 GMT
+      - Thu, 19 Apr 2018 17:43:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -9020,35 +8960,34 @@ http_interactions:
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -9061,16 +9000,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -9084,6 +9018,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -9095,12 +9035,12 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9114,7 +9054,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9129,7 +9069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -9140,9 +9080,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a57fb325-6338-4dea-b396-e7714e9b3c9f
+      - req-749c61d6-8d33-4ca4-bc0a-6dbb8c03b101
       Date:
-      - Mon, 09 Apr 2018 16:31:58 GMT
+      - Thu, 19 Apr 2018 17:43:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f37d8451d76a46fa892d0f844daf50e0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5e343459-379b-461a-9ed8-f8b37cfc29de
+      Date:
+      - Thu, 19 Apr 2018 17:43:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -9246,7 +9318,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f37d8451d76a46fa892d0f844daf50e0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8aa244fa-c24c-4dce-b0e6-926829516e83
+      Date:
+      - Thu, 19 Apr 2018 17:43:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9261,7 +9465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -9272,53 +9476,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-eeb1a1a2-259d-4f9c-b8bf-406a5d6cae74
+      - req-1178bbee-c387-45ad-a31d-c1a9c2a7c9a0
       Date:
-      - Mon, 09 Apr 2018 16:31:59 GMT
+      - Thu, 19 Apr 2018 17:43:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -9365,23 +9528,64 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:04 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -9393,7 +9597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -9404,9 +9608,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c20db2cd-3eff-4f6f-ba9f-1e4912a358b5
+      - req-c6b6f02c-be5d-430a-ac97-ff8a371f259f
       Date:
-      - Mon, 09 Apr 2018 16:31:59 GMT
+      - Thu, 19 Apr 2018 17:43:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -9510,535 +9714,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-830f699b-13d0-47ab-a969-346f8ea0820e
-      Date:
-      - Mon, 09 Apr 2018 16:31:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f62c0edf-c4c8-40fc-b581-00c8bfdc732e
-      Date:
-      - Mon, 09 Apr 2018 16:31:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-76008d8a-d872-4874-b836-efbdbd30d4c7
-      Date:
-      - Mon, 09 Apr 2018 16:32:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3c9bc42b-2c37-4c97-afe8-a3eb28f6267f
-      Date:
-      - Mon, 09 Apr 2018 16:32:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10056,13 +9732,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:00 GMT
+      - Thu, 19 Apr 2018 17:43:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8a92a93a-cdd6-4738-8fa6-805b3a1c9629
+      - req-96594186-5385-4dbb-b7bf-2ff953e356c0
       Content-Length:
       - '4118'
       Connection:
@@ -10071,10 +9747,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:00.729933", "expires":
-        "2018-04-09T17:32:00Z", "id": "06ef1ffa2eb54db4835785ccf98f8b9e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:04.786854", "expires":
+        "2018-04-19T18:43:04Z", "id": "788f9fed11bf4196b1f3f693514ee8f0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zcZWnvrPSbaqI6mWrfd0Kg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["RgCo1cXWT7qMrUIYvVGmLg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10118,7 +9794,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -10133,7 +9809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -10144,47 +9820,75 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5aa608db-4d82-4402-9074-7d29fbfbdde8
+      - req-65802113-bb73-4754-8ffc-076c530f205b
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -10197,16 +9901,114 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 788f9fed11bf4196b1f3f693514ee8f0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f56ac228-0f54-4eae-b12a-4f23b09285fd
+      Date:
+      - Thu, 19 Apr 2018 17:43:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -10220,6 +10022,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -10231,12 +10039,12 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -10250,7 +10058,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -10265,7 +10073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -10276,9 +10084,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8a3ed68e-a5da-41d7-bbf9-70e113824ec4
+      - req-1412a155-1fae-447d-b5c6-c2e86aca7f73
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -10382,7 +10190,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10397,7 +10205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -10408,9 +10216,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-92aa6fa5-6ea4-4fbd-8a17-cc15cc02a22a
+      - req-76fd8aca-13c0-4472-ba6f-62af0879ca27
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10452,7 +10260,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10467,7 +10275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -10478,9 +10286,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-833fb720-e983-4f39-8236-6d600334042c
+      - req-8ca2c1ac-b7cf-40b6-a0e9-32494db9e4c7
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10522,7 +10330,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10537,7 +10345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -10548,9 +10356,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-182a2174-addc-4af3-a524-8bf9def384d2
+      - req-b4f80072-490f-42e4-8b6e-60b6ab4da0eb
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10592,7 +10400,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10607,7 +10415,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -10618,9 +10426,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-79c02288-7fdf-4d29-bda2-120e60a63da5
+      - req-61568986-55e5-4349-80bd-d49a6565091a
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10662,7 +10470,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10677,7 +10485,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -10688,9 +10496,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6e16c280-a5f4-4aeb-bab2-9d40ba23d5e9
+      - req-fe7c1e52-5a0a-47e7-88d4-7f08b2dc4f45
       Date:
-      - Mon, 09 Apr 2018 16:32:01 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10732,7 +10540,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10747,7 +10555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -10758,9 +10566,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c92fa34b-2d76-4a59-93aa-fdbae70ff1e3
+      - req-6a3bb0d2-c47a-4dac-b887-dbc6f7f30065
       Date:
-      - Mon, 09 Apr 2018 16:32:02 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10802,7 +10610,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10817,7 +10625,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -10828,9 +10636,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3b4bdd5c-fd94-4ca1-a186-79b602c05a65
+      - req-06d655d5-c499-4ab6-94fd-b8102bd4c0f4
       Date:
-      - Mon, 09 Apr 2018 16:32:02 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10872,7 +10680,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10887,7 +10695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -10898,9 +10706,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-660b7e8c-7008-410a-8607-da14105a7052
+      - req-a5d26af9-7f70-4b5d-87d6-0f9735d6a99c
       Date:
-      - Mon, 09 Apr 2018 16:32:02 GMT
+      - Thu, 19 Apr 2018 17:43:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10942,7 +10750,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10957,7 +10765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -10968,9 +10776,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-acf36464-640c-4584-bbf8-f27f563a580e
+      - req-afce08a0-a510-470a-8f18-c02d77e1c1e7
       Date:
-      - Mon, 09 Apr 2018 16:32:02 GMT
+      - Thu, 19 Apr 2018 17:43:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11373,7 +11181,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11388,7 +11196,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -11399,9 +11207,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8a055fde-1f61-4dbd-acbf-ed2a979d0cbb
+      - req-18c56325-2c09-4eb6-b66d-1bd19503c598
       Date:
-      - Mon, 09 Apr 2018 16:32:02 GMT
+      - Thu, 19 Apr 2018 17:43:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11804,7 +11612,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11819,7 +11627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -11830,9 +11638,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-63d697f0-cc23-4341-b7d2-ddbb3c671d0a
+      - req-49d23c93-0023-4417-be2d-76868c624e41
       Date:
-      - Mon, 09 Apr 2018 16:32:03 GMT
+      - Thu, 19 Apr 2018 17:43:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12235,7 +12043,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12250,7 +12058,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -12261,9 +12069,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3251061f-bf60-4ad2-bc6f-b52d53a7286c
+      - req-ca027b8a-4200-4977-9679-8738aeedf658
       Date:
-      - Mon, 09 Apr 2018 16:32:03 GMT
+      - Thu, 19 Apr 2018 17:43:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12666,7 +12474,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12681,7 +12489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -12692,9 +12500,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-09dae4f2-3d7e-45cb-99ce-c2078d41ff08
+      - req-e875d63f-e92d-436c-91d6-484bfcbed023
       Date:
-      - Mon, 09 Apr 2018 16:32:03 GMT
+      - Thu, 19 Apr 2018 17:43:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13097,7 +12905,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13112,7 +12920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -13123,9 +12931,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-749e6d67-9041-4f9c-a91d-e0492b07c0c5
+      - req-8fc6577a-19a2-4523-a150-b6de4fdded50
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13528,7 +13336,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13543,7 +13351,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -13554,9 +13362,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0cfa9526-30d1-49dc-a41f-8d36f01b8b46
+      - req-3f1c79ae-bc96-4dce-a254-2b45e5c533d8
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13959,7 +13767,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13974,7 +13782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -13985,9 +13793,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d6a03f7a-dc6c-416b-ad40-9b0c7a49ba68
+      - req-d5519b05-c173-4403-bf08-9206b864b035
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14390,7 +14198,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14405,7 +14213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -14416,9 +14224,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-7a0f245e-c064-49a2-9d3a-0f940a92e733
+      - req-7cfe0294-0e34-49fd-8d77-199d0ed94008
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14450,7 +14258,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14465,7 +14273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -14476,9 +14284,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5e3074bc-5339-48b9-88cc-cd829bd44e21
+      - req-3cdc9332-6a03-482a-a2e7-03fbc71a9f2d
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14510,7 +14318,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14525,7 +14333,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -14536,9 +14344,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f7782343-2707-4cd5-8afd-59a5b3359163
+      - req-f113ad1f-b7e7-4830-998e-f02fc50cb802
       Date:
-      - Mon, 09 Apr 2018 16:32:04 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14570,7 +14378,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14585,7 +14393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -14596,9 +14404,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2e13d5e4-a450-4160-a192-cbb153af4389
+      - req-f62ca387-994e-4efe-9061-b802a3104484
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14630,7 +14438,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14645,7 +14453,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -14656,9 +14464,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-67828bf8-7da5-48fb-93fc-4cd5e1b5b8ae
+      - req-463265f0-92d8-402e-8f31-cbbb46678770
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14690,7 +14498,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14705,7 +14513,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -14716,9 +14524,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-bbe7f5c6-fbc2-4b77-b221-050575283e1d
+      - req-54d21f06-3392-478a-8049-4b127393cc1e
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14750,7 +14558,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14765,7 +14573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -14776,9 +14584,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-65601acc-eb69-42be-bc3c-6f54beea3651
+      - req-28ac50d0-a2db-404d-9a15-da6137997e4e
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14810,7 +14618,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14825,7 +14633,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -14836,9 +14644,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b3052b5d-0852-4f75-b47c-1d592181b21a
+      - req-3768978f-7916-4716-af70-3996dc476358
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14870,7 +14678,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14885,7 +14693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -14896,9 +14704,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d8c64f99-b441-49ad-8a6f-96d860b56484
+      - req-eef8c555-df7d-4fdc-9937-72516070cc14
       Date:
-      - Mon, 09 Apr 2018 16:32:05 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14940,7 +14748,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14955,7 +14763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -14966,9 +14774,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0076f835-8ced-4878-8398-8306e79b7f23
+      - req-75a567bb-123e-49d1-887d-919d88d7147a
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15011,7 +14819,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15026,7 +14834,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -15037,9 +14845,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-d8067830-550e-4b97-915d-11f1639980e6
+      - req-d12a24fc-0ea5-49e2-bd80-a72118b219a6
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15074,7 +14882,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15089,7 +14897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4b248e64168496f87ca9595e6c96d93
+      - db058d41e3c4485ab27d37fec9a98a73
   response:
     status:
       code: 200
@@ -15100,9 +14908,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-8e84bcdb-0beb-4fa9-b0f8-47dd493e595b
+      - req-6ee5e3d4-09d8-45ce-be45-be43e8ad3a2e
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15189,7 +14997,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15204,7 +15012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -15215,9 +15023,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b117a764-180d-4133-9a1c-cbf4c65e1b76
+      - req-3d9656a2-346a-4d6a-9cca-121b3580ae8a
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15259,7 +15067,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15274,7 +15082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -15285,9 +15093,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-93b2c311-7e9c-45b9-9b46-4541a57f2326
+      - req-bd2d35cc-ac7c-4520-b662-317f02094890
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15330,7 +15138,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15345,7 +15153,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -15356,9 +15164,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-79c6e115-a636-493e-bd50-1edc55bcf945
+      - req-7f407730-6c93-44ad-898a-9a8015e4cf36
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15393,7 +15201,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15408,7 +15216,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b255dd42dcb04870914447bd84b74247
+      - f37d8451d76a46fa892d0f844daf50e0
   response:
     status:
       code: 200
@@ -15419,9 +15227,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-b479e4d7-678f-4693-8337-4f90d46df96c
+      - req-39150491-d0b4-4fa5-b61c-ce37b63df4ff
       Date:
-      - Mon, 09 Apr 2018 16:32:06 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15508,7 +15316,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15523,7 +15331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -15534,9 +15342,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-34b85b0b-1c17-4e4f-b7e8-74f89f4e42f0
+      - req-a5cd6e74-5f66-42e3-b60f-e554232d90c3
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15578,7 +15386,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15593,7 +15401,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -15604,9 +15412,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-df2e71e1-52b4-4c78-a02b-c77fadab89f7
+      - req-9a4ff904-55af-40a2-ab23-2f9f4106c08c
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15649,7 +15457,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15664,7 +15472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -15675,9 +15483,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-8139a3cc-721a-4830-8a34-029727807db7
+      - req-8536ca67-52aa-4b3e-8d94-d99a32b04b34
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15712,7 +15520,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15727,7 +15535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfd181d8be9c407995ee6fed84caddcf
+      - 8bed6cdafc3a401faae37c080b1cbbec
   response:
     status:
       code: 200
@@ -15738,9 +15546,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-6dba0c46-5791-4814-8bac-f24c0ced0ff4
+      - req-53f06195-7660-4e34-a125-c4ff5ec9a9b8
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15827,7 +15635,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15842,7 +15650,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -15853,9 +15661,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0851f9f1-97d4-4dee-9670-b2f02e708b84
+      - req-fa449740-0858-4b73-b97b-e3ed33e8752a
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15897,7 +15705,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15912,7 +15720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -15923,9 +15731,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-22a5d2f4-8b19-4984-bb91-3232d0fe7ee9
+      - req-4cf16853-8d71-4f21-9aa7-4bd2acf6fc27
       Date:
-      - Mon, 09 Apr 2018 16:32:07 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15968,7 +15776,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15983,7 +15791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -15994,9 +15802,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-7c2e3b84-a34a-4f54-8d9a-40f43c29cd88
+      - req-a94134f9-0052-4a1e-b16c-2da748ebd6d3
       Date:
-      - Mon, 09 Apr 2018 16:32:08 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -16031,7 +15839,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -16046,7 +15854,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06ef1ffa2eb54db4835785ccf98f8b9e
+      - 788f9fed11bf4196b1f3f693514ee8f0
   response:
     status:
       code: 200
@@ -16057,9 +15865,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-95ea609a-467e-4c23-a362-ea7f55ca73af
+      - req-28fd5e5e-21ef-4131-8c13-afb2d2570509
       Date:
-      - Mon, 09 Apr 2018 16:32:08 GMT
+      - Thu, 19 Apr 2018 17:43:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -16146,7 +15954,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16164,13 +15972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:08 GMT
+      - Thu, 19 Apr 2018 17:43:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b620d64d-6dac-4db4-aeed-2bc7a28cc9d1
+      - req-0ff38b9d-68ef-4839-ac31-601026bf9ee2
       Content-Length:
       - '4170'
       Connection:
@@ -16179,10 +15987,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:08.824830", "expires":
-        "2018-04-09T17:32:08Z", "id": "14c1747d4a474ddea2fdf3ade2f257b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:15.545983", "expires":
+        "2018-04-19T18:43:15Z", "id": "af7d3d584552463382deb1a0f0f31983", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hK6atBuYRt6tqFSb_mKPsA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["1Pjk37hbRHuMinQitKGPBg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16227,7 +16035,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16245,13 +16053,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:08 GMT
+      - Thu, 19 Apr 2018 17:43:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-24ab0828-7ceb-4744-8169-3d36ee04314c
+      - req-f9d3842c-8d5a-4d89-be58-4516176950c5
       Content-Length:
       - '4170'
       Connection:
@@ -16260,10 +16068,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:09.120715", "expires":
-        "2018-04-09T17:32:09Z", "id": "2c7a2d50ffb24557bc19f833dbbb21b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:15.814724", "expires":
+        "2018-04-19T18:43:15Z", "id": "1c3fab3b85f6468bba154ac8dc21ba73", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Ca3pVamOQpuYvrKUianpKg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iJaR-9DpRwGy1siPK2vtIA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16308,7 +16116,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16326,13 +16134,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:09 GMT
+      - Thu, 19 Apr 2018 17:43:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e06bd5bc-4f3d-4ea3-b9c2-5b06e9c61681
+      - req-360c809c-5547-401b-b741-93dbef0d3806
       Content-Length:
       - '370'
       Connection:
@@ -16341,13 +16149,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:09.313213", "expires":
-        "2018-04-09T17:32:09Z", "id": "d28cc196a70c461da97ff77e828d224a", "audit_ids":
-        ["s-banQ1PSK-9ScM3FThdKw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:16.316586", "expires":
+        "2018-04-19T18:43:16Z", "id": "af19e84cbe27487181695f8a5a423589", "audit_ids":
+        ["WbHSETi3QaiAFv71G7Z89Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16362,20 +16170,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28cc196a70c461da97ff77e828d224a
+      - af19e84cbe27487181695f8a5a423589
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:09 GMT
+      - Thu, 19 Apr 2018 17:43:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e1e8778-88f1-4be2-bb80-3f8e41b9931e
+      - req-43319166-8ed2-49e5-832c-c39e97174c78
       Content-Length:
       - '500'
       Connection:
@@ -16392,13 +16200,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"d28cc196a70c461da97ff77e828d224a"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"af19e84cbe27487181695f8a5a423589"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16410,13 +16218,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:09 GMT
+      - Thu, 19 Apr 2018 17:43:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bea511b7-f97a-4513-8a32-83b34fbd9a7d
+      - req-247a0d5f-fa0e-452d-9148-d209d1f1d85e
       Content-Length:
       - '4143'
       Connection:
@@ -16425,11 +16233,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:09.713082", "expires":
-        "2018-04-09T17:32:09Z", "id": "3406baf32e264deb84d8a22e7c33e8b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:16.719147", "expires":
+        "2018-04-19T18:43:16Z", "id": "cfe5a0ae87d843f48dd9b489cedf0203", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ANJsCvJ3T5ibE0yi5VY9oQ",
-        "s-banQ1PSK-9ScM3FThdKw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_5jqFgmrRd2-wrl5dMk8Vw",
+        "WbHSETi3QaiAFv71G7Z89Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16473,7 +16281,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16488,20 +16296,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28cc196a70c461da97ff77e828d224a
+      - af19e84cbe27487181695f8a5a423589
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:09 GMT
+      - Thu, 19 Apr 2018 17:43:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec811fc8-886b-4912-9ffb-f2b37c4c8366
+      - req-62c7b50e-93e1-4c3d-b42c-152a1ac680d9
       Content-Length:
       - '500'
       Connection:
@@ -16518,7 +16326,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16536,13 +16344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:10 GMT
+      - Thu, 19 Apr 2018 17:43:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-17ec807c-9940-4da0-addf-891d11530f79
+      - req-3587a7f1-cfed-4aa3-863d-d51bba761348
       Content-Length:
       - '4117'
       Connection:
@@ -16551,10 +16359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:10.147610", "expires":
-        "2018-04-09T17:32:10Z", "id": "d7d2e996043545a5a99e0cee9925da6d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:17.116593", "expires":
+        "2018-04-19T18:43:17Z", "id": "a2745ff6e5d7427888fda006edf58b26", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mr0TZcn4Sr2HgNAHcOVs7g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["w5hG1iKASkWXiz-4yO_feA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16598,7 +16406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16616,13 +16424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:10 GMT
+      - Thu, 19 Apr 2018 17:43:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d189701f-314a-4d25-b736-6f167a51c363
+      - req-7df0cce7-f789-48a5-93e2-05a66713b5a0
       Content-Length:
       - '4131'
       Connection:
@@ -16631,10 +16439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:10.453089", "expires":
-        "2018-04-09T17:32:10Z", "id": "87648d604fb94056a785ccd0d97a9091", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:17.358138", "expires":
+        "2018-04-19T18:43:17Z", "id": "e4ca8a5e033c42378db1c622858b041c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8ZYVh7mySJGEL5ZLcL1Jkg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["j8_sQk6jTJCGF7mbbgl-dQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16678,7 +16486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16696,13 +16504,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:10 GMT
+      - Thu, 19 Apr 2018 17:43:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7fdd7bdc-b16f-4b4c-b0cd-07f889f86bae
+      - req-01c370d5-8cbc-4622-90b2-0637401ac2e5
       Content-Length:
       - '4118'
       Connection:
@@ -16711,10 +16519,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:10.857108", "expires":
-        "2018-04-09T17:32:10Z", "id": "65716210232745e4ac7d1ed2723f3190", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:17.638653", "expires":
+        "2018-04-19T18:43:17Z", "id": "ca720d2030c6466898f5dce9039b8160", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BIpULuBWTSKBruknCU6YeQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jnD21-JPR12yZy7oaAYaRQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16758,7 +16566,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16776,13 +16584,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:10 GMT
+      - Thu, 19 Apr 2018 17:43:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0bada52-4d10-4fd6-a730-eda1712daf55
+      - req-b38565ce-4fe2-4b92-9edf-181835480b2e
       Content-Length:
       - '4117'
       Connection:
@@ -16791,10 +16599,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:11.173203", "expires":
-        "2018-04-09T17:32:11Z", "id": "d9610b10dcbd4512a6c48d49fd7fdf9f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:17.877052", "expires":
+        "2018-04-19T18:43:17Z", "id": "f88f30ebc71449879042fd29909fb9ff", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["eM-_HzqwRhWrH8r556xPmA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["da-Dic-_QFqOpFOAC1aaaw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16838,7 +16646,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16853,22 +16661,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d74c7be-e7ae-40d3-b03f-58e043980d7f
+      - req-d981780c-ce67-4c6a-ba34-2a68ff610bea
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-9d74c7be-e7ae-40d3-b03f-58e043980d7f
+      - req-d981780c-ce67-4c6a-ba34-2a68ff610bea
       Date:
-      - Mon, 09 Apr 2018 16:32:11 GMT
+      - Thu, 19 Apr 2018 17:43:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16901,7 +16709,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16916,22 +16724,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-850f8d77-d80c-4176-b851-88a87e0ef5c0
+      - req-5ebac767-4e09-4069-ade3-9c11ce7a9702
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-850f8d77-d80c-4176-b851-88a87e0ef5c0
+      - req-5ebac767-4e09-4069-ade3-9c11ce7a9702
       Date:
-      - Mon, 09 Apr 2018 16:32:12 GMT
+      - Thu, 19 Apr 2018 17:43:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16972,7 +16780,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16987,22 +16795,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-703e3673-bf4d-4b0d-b30d-303b45f24a5e
+      - req-93631789-437f-4392-a5fc-ddfdd9776626
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-703e3673-bf4d-4b0d-b30d-303b45f24a5e
+      - req-93631789-437f-4392-a5fc-ddfdd9776626
       Date:
-      - Mon, 09 Apr 2018 16:32:12 GMT
+      - Thu, 19 Apr 2018 17:43:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -17036,7 +16844,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -17051,27 +16859,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6b8507e-da5c-47ec-a3fc-1816cede708b
+      - req-f70593de-8104-47a6-bf7f-3e3b2bbee3ac
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c6b8507e-da5c-47ec-a3fc-1816cede708b
+      - req-f70593de-8104-47a6-bf7f-3e3b2bbee3ac
       Date:
-      - Mon, 09 Apr 2018 16:32:12 GMT
+      - Thu, 19 Apr 2018 17:43:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17089,13 +16897,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:13 GMT
+      - Thu, 19 Apr 2018 17:43:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69c67e5a-536c-43f7-b437-9d2229d1cd16
+      - req-0d4a715c-f830-4fc6-86a7-284e349d8eb1
       Content-Length:
       - '4131'
       Connection:
@@ -17104,10 +16912,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:13.146788", "expires":
-        "2018-04-09T17:32:13Z", "id": "8521cd5b28ec4f4e8817886ac59cf2c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:19.682941", "expires":
+        "2018-04-19T18:43:19Z", "id": "8cc52a335ecc4bd0942f0377049c7fed", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["66L3ULD6SWiO1l9jlr-udw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yrjrUg_oQ5qZbmLRH6Dasg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17151,7 +16959,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -17166,27 +16974,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8521cd5b28ec4f4e8817886ac59cf2c5
+      - 8cc52a335ecc4bd0942f0377049c7fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e149aa2-0b04-4db9-b1c3-69bcfed0cfa1
+      - req-72db130f-f50a-4f59-807c-9d16245a3721
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8e149aa2-0b04-4db9-b1c3-69bcfed0cfa1
+      - req-72db130f-f50a-4f59-807c-9d16245a3721
       Date:
-      - Mon, 09 Apr 2018 16:32:13 GMT
+      - Thu, 19 Apr 2018 17:43:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -17201,27 +17009,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c7a2d50ffb24557bc19f833dbbb21b9
+      - 1c3fab3b85f6468bba154ac8dc21ba73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-64027ec2-086c-490e-94bf-325a7d2dca47
+      - req-c0e63c1b-023e-4b20-bb3c-02fd9abcc4d3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-64027ec2-086c-490e-94bf-325a7d2dca47
+      - req-c0e63c1b-023e-4b20-bb3c-02fd9abcc4d3
       Date:
-      - Mon, 09 Apr 2018 16:32:13 GMT
+      - Thu, 19 Apr 2018 17:43:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17239,13 +17047,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:14 GMT
+      - Thu, 19 Apr 2018 17:43:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a4ded1ad-7bf4-401d-9ddc-f5081dfc8df5
+      - req-7e948a20-0b53-4a70-b292-bd6291941084
       Content-Length:
       - '4118'
       Connection:
@@ -17254,10 +17062,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:14.164622", "expires":
-        "2018-04-09T17:32:14Z", "id": "3a27cdbba6cb41b3a69b240fe92a8204", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:21.258779", "expires":
+        "2018-04-19T18:43:21Z", "id": "e219b19bea994b348a8567a3390c0b63", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AZHyLauQRdOO7ZQZLiUBNg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bBYPmAdOR-q_I-WvafdIiQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17301,7 +17109,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -17316,27 +17124,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a27cdbba6cb41b3a69b240fe92a8204
+      - e219b19bea994b348a8567a3390c0b63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05715f92-30b5-4bd5-b533-abb2bf7cd2ec
+      - req-b7e1ad8d-8910-46b7-8a26-a1fd7112fc1c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-05715f92-30b5-4bd5-b533-abb2bf7cd2ec
+      - req-b7e1ad8d-8910-46b7-8a26-a1fd7112fc1c
       Date:
-      - Mon, 09 Apr 2018 16:32:14 GMT
+      - Thu, 19 Apr 2018 17:43:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -17351,22 +17159,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d452460-2ee1-4824-aea1-93e976ed65dd
+      - req-e8be5865-ef4b-41b2-aefb-19192e62db8d
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-8d452460-2ee1-4824-aea1-93e976ed65dd
+      - req-e8be5865-ef4b-41b2-aefb-19192e62db8d
       Date:
-      - Mon, 09 Apr 2018 16:32:14 GMT
+      - Thu, 19 Apr 2018 17:43:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17381,7 +17189,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -17396,22 +17204,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7f2eaeb1-c7b6-47aa-81bf-169c1da02ca4
+      - req-e3deccbe-eb17-4f46-b482-f94d89bead7b
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-7f2eaeb1-c7b6-47aa-81bf-169c1da02ca4
+      - req-e3deccbe-eb17-4f46-b482-f94d89bead7b
       Date:
-      - Mon, 09 Apr 2018 16:32:14 GMT
+      - Thu, 19 Apr 2018 17:43:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17426,7 +17234,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -17441,27 +17249,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8521cd5b28ec4f4e8817886ac59cf2c5
+      - 8cc52a335ecc4bd0942f0377049c7fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93943730-f7e8-42f8-87f7-0dd64a75b453
+      - req-403468ea-04da-49b5-a74b-947946c944de
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-93943730-f7e8-42f8-87f7-0dd64a75b453
+      - req-403468ea-04da-49b5-a74b-947946c944de
       Date:
-      - Mon, 09 Apr 2018 16:32:15 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -17476,27 +17284,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8521cd5b28ec4f4e8817886ac59cf2c5
+      - 8cc52a335ecc4bd0942f0377049c7fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-beeaa6c6-0805-4226-bf4a-ce100e8b1e1a
+      - req-ef112e42-6b50-49b9-908b-c2de0b6c030b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-beeaa6c6-0805-4226-bf4a-ce100e8b1e1a
+      - req-ef112e42-6b50-49b9-908b-c2de0b6c030b
       Date:
-      - Mon, 09 Apr 2018 16:32:15 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -17511,27 +17319,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c7a2d50ffb24557bc19f833dbbb21b9
+      - 1c3fab3b85f6468bba154ac8dc21ba73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-47881830-1cdf-42b7-bcc3-dbe7fb962ef1
+      - req-63b23f5f-3094-4303-aa21-76d7a7e5a69f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-47881830-1cdf-42b7-bcc3-dbe7fb962ef1
+      - req-63b23f5f-3094-4303-aa21-76d7a7e5a69f
       Date:
-      - Mon, 09 Apr 2018 16:32:15 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -17546,27 +17354,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c7a2d50ffb24557bc19f833dbbb21b9
+      - 1c3fab3b85f6468bba154ac8dc21ba73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-492b6266-159e-49b4-b9fb-0987f12e77bc
+      - req-4574729a-238b-4ed7-b7e3-17434d352577
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-492b6266-159e-49b4-b9fb-0987f12e77bc
+      - req-4574729a-238b-4ed7-b7e3-17434d352577
       Date:
-      - Mon, 09 Apr 2018 16:32:15 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -17581,27 +17389,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a27cdbba6cb41b3a69b240fe92a8204
+      - e219b19bea994b348a8567a3390c0b63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a7a083d4-ce1c-4452-99c1-966bc2cb37cd
+      - req-ea1d515a-abf0-4a49-a2c7-10928e1d3759
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a7a083d4-ce1c-4452-99c1-966bc2cb37cd
+      - req-ea1d515a-abf0-4a49-a2c7-10928e1d3759
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -17616,27 +17424,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a27cdbba6cb41b3a69b240fe92a8204
+      - e219b19bea994b348a8567a3390c0b63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b86813f3-8d8a-429a-b56c-dfc7b7bd4038
+      - req-8cf74018-2142-426b-9dae-0fa3894d5cfc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b86813f3-8d8a-429a-b56c-dfc7b7bd4038
+      - req-8cf74018-2142-426b-9dae-0fa3894d5cfc
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -17651,27 +17459,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-965ae22a-584b-4013-a6e0-cda615040a6c
+      - req-2294d991-c6c0-4dfc-9f55-9beef5e10de0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-965ae22a-584b-4013-a6e0-cda615040a6c
+      - req-2294d991-c6c0-4dfc-9f55-9beef5e10de0
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -17686,27 +17494,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9610b10dcbd4512a6c48d49fd7fdf9f
+      - f88f30ebc71449879042fd29909fb9ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9cbbc0e0-b2a9-4e7b-bb9a-52197c5067bd
+      - req-6ee470b7-0584-4874-8186-637d57df72b8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9cbbc0e0-b2a9-4e7b-bb9a-52197c5067bd
+      - req-6ee470b7-0584-4874-8186-637d57df72b8
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -17721,27 +17529,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8521cd5b28ec4f4e8817886ac59cf2c5
+      - 8cc52a335ecc4bd0942f0377049c7fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ea8b341-3b4a-4ab2-a3fb-4dd913a6dcf9
+      - req-74b5e126-ac4a-4b1d-9ca1-7869cc822dfe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ea8b341-3b4a-4ab2-a3fb-4dd913a6dcf9
+      - req-74b5e126-ac4a-4b1d-9ca1-7869cc822dfe
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17756,27 +17564,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8521cd5b28ec4f4e8817886ac59cf2c5
+      - 8cc52a335ecc4bd0942f0377049c7fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a570357e-a111-4b47-b2e9-2299652b7664
+      - req-4293b8d3-3f54-48c3-83e4-ad226dc62b33
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a570357e-a111-4b47-b2e9-2299652b7664
+      - req-4293b8d3-3f54-48c3-83e4-ad226dc62b33
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17791,27 +17599,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c7a2d50ffb24557bc19f833dbbb21b9
+      - 1c3fab3b85f6468bba154ac8dc21ba73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-abd16be5-f86c-4a60-b856-c8be9ef5ed86
+      - req-1b11f07f-de99-42be-ba6b-15440aaf8655
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-abd16be5-f86c-4a60-b856-c8be9ef5ed86
+      - req-1b11f07f-de99-42be-ba6b-15440aaf8655
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17826,27 +17634,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c7a2d50ffb24557bc19f833dbbb21b9
+      - 1c3fab3b85f6468bba154ac8dc21ba73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-964abed8-eb1f-4205-91ab-ba0aa750940e
+      - req-3412bae3-6f84-4cc0-9fc4-c15ea0fd570e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-964abed8-eb1f-4205-91ab-ba0aa750940e
+      - req-3412bae3-6f84-4cc0-9fc4-c15ea0fd570e
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17861,27 +17669,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a27cdbba6cb41b3a69b240fe92a8204
+      - e219b19bea994b348a8567a3390c0b63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-515e01a4-1708-4625-afdb-f21330f0899b
+      - req-8f764de7-65d4-49e7-97e0-8f5de785fca7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-515e01a4-1708-4625-afdb-f21330f0899b
+      - req-8f764de7-65d4-49e7-97e0-8f5de785fca7
       Date:
-      - Mon, 09 Apr 2018 16:32:16 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17896,27 +17704,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a27cdbba6cb41b3a69b240fe92a8204
+      - e219b19bea994b348a8567a3390c0b63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a8adfde3-f686-440c-8c8f-cb95bd96ba94
+      - req-685a0cd8-87ff-4090-9f2d-36dd82e52b4a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a8adfde3-f686-440c-8c8f-cb95bd96ba94
+      - req-685a0cd8-87ff-4090-9f2d-36dd82e52b4a
       Date:
-      - Mon, 09 Apr 2018 16:32:17 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17934,13 +17742,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:17 GMT
+      - Thu, 19 Apr 2018 17:43:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6dbf4e00-d119-4f6e-8e46-d1d82e16a190
+      - req-7d1f4f63-a0ea-439f-aaf5-23cfcfdef978
       Content-Length:
       - '4170'
       Connection:
@@ -17949,10 +17757,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:17.402631", "expires":
-        "2018-04-09T17:32:17Z", "id": "fe8a2677928341b8b57ce72b70caa63b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:24.104899", "expires":
+        "2018-04-19T18:43:24Z", "id": "f1556b9e5b3b43f69857280e02e196b9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0dqCyhlYS1eO7tK32pawsg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jaEMBSY1QQiKiJDFtu90nQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17997,7 +17805,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18015,13 +17823,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:17 GMT
+      - Thu, 19 Apr 2018 17:43:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec182e98-c5b7-486e-b4fa-48dce56cd585
+      - req-07ce2acf-8467-4770-824a-3abb180a5698
       Content-Length:
       - '4170'
       Connection:
@@ -18030,10 +17838,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:17.677681", "expires":
-        "2018-04-09T17:32:17Z", "id": "b1cfd78ea36c413bb5b69ce213d4374f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:24.404940", "expires":
+        "2018-04-19T18:43:24Z", "id": "bfbf6c29d6ab4a1486fc6d899d6c19b9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1Jyezj1mSMmTX9zS7wiAMA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vMpjzWsrS5OZswy9AFiNSA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18078,7 +17886,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18096,13 +17904,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:17 GMT
+      - Thu, 19 Apr 2018 17:43:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8cb92e9f-e1a1-4526-b3c8-65c9d9e8f29d
+      - req-800b8357-8a9e-41a2-a268-61632f948069
       Content-Length:
       - '370'
       Connection:
@@ -18111,13 +17919,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:17.865227", "expires":
-        "2018-04-09T17:32:17Z", "id": "26f4abe1d43a421c86b6ac72b929697b", "audit_ids":
-        ["U5_6UAV7QxyCE-EEXC61ZA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:24.593148", "expires":
+        "2018-04-19T18:43:24Z", "id": "02b10dbe36de4170bd40531a9ac5dfa9", "audit_ids":
+        ["1JglH9lsSzWU4rqwK3h8fQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:24 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18132,20 +17940,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26f4abe1d43a421c86b6ac72b929697b
+      - 02b10dbe36de4170bd40531a9ac5dfa9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:17 GMT
+      - Thu, 19 Apr 2018 17:43:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-938491a4-2448-48bf-b691-904977cf7343
+      - req-9faffb85-88b2-4561-9a70-0d96d1ebedfe
       Content-Length:
       - '500'
       Connection:
@@ -18162,13 +17970,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"26f4abe1d43a421c86b6ac72b929697b"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"02b10dbe36de4170bd40531a9ac5dfa9"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18180,13 +17988,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:18 GMT
+      - Thu, 19 Apr 2018 17:43:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-116ae50b-3fe9-4ebf-8405-e273a734d13c
+      - req-6f524d97-f200-4551-8804-c16b10690338
       Content-Length:
       - '4143'
       Connection:
@@ -18195,11 +18003,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:18.247261", "expires":
-        "2018-04-09T17:32:17Z", "id": "ffbe3083683c49589c064d0c43db7f65", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:24.981817", "expires":
+        "2018-04-19T18:43:24Z", "id": "6d68a03ed6c54250b7ba9390bc03c977", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-GQjq8VZSeSsw8JOVfrKzw",
-        "U5_6UAV7QxyCE-EEXC61ZA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9lwbbdBjTt6B_67wffmXyw",
+        "1JglH9lsSzWU4rqwK3h8fQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18243,7 +18051,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:25 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18258,20 +18066,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26f4abe1d43a421c86b6ac72b929697b
+      - 02b10dbe36de4170bd40531a9ac5dfa9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:18 GMT
+      - Thu, 19 Apr 2018 17:43:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a9eb229-3e9b-4fc2-a691-867d942fd73c
+      - req-8a7b4d25-a0cf-4dbe-a521-8d19dcff3337
       Content-Length:
       - '500'
       Connection:
@@ -18288,7 +18096,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18306,13 +18114,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:18 GMT
+      - Thu, 19 Apr 2018 17:43:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74ce7ba4-764f-49d2-afe2-6a4dd2aa06a3
+      - req-9e8f2ee5-353c-467c-aa14-d04945c8c513
       Content-Length:
       - '4117'
       Connection:
@@ -18321,10 +18129,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:18.798835", "expires":
-        "2018-04-09T17:32:18Z", "id": "37e0d8e110ce4cd18d09e9dbe6fbbc4c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:25.395603", "expires":
+        "2018-04-19T18:43:25Z", "id": "24e91c75346b44d3a839e33d81109729", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0vjwLdlWRISXaAq73iQrOA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_hMJQRlZRIqXUKeUEUhr7g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18368,7 +18176,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18386,13 +18194,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:18 GMT
+      - Thu, 19 Apr 2018 17:43:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-012ef39b-24c5-4e07-af85-1a5fa3c5457e
+      - req-f88de699-6c0d-44e6-8c99-93b227918a5a
       Content-Length:
       - '4131'
       Connection:
@@ -18401,10 +18209,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:19.098620", "expires":
-        "2018-04-09T17:32:19Z", "id": "08e2674896d941b7839abca1801b9f1d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:25.669169", "expires":
+        "2018-04-19T18:43:25Z", "id": "82e7a29691e943c8bd2953132e578f82", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["p7uTgJ8VRWqtfoSlTFDk8Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["HWPeZJx6R_-61SHuDH25aA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18448,7 +18256,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18466,13 +18274,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:19 GMT
+      - Thu, 19 Apr 2018 17:43:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-671e450b-6fe2-436c-9824-19ad25d1e026
+      - req-925c3c20-d904-4c60-9d4a-856dd3b187f8
       Content-Length:
       - '4118'
       Connection:
@@ -18481,10 +18289,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:19.359052", "expires":
-        "2018-04-09T17:32:19Z", "id": "649cceb1907a4bd595e2cce297f40825", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:25.931188", "expires":
+        "2018-04-19T18:43:25Z", "id": "f4a1f94db6e04716966a12635cfe1c62", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["j3arggjpQlOp2AdkPTlUMg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_PjxeGFxTnWvTl_QXuLHLQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18528,7 +18336,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18546,13 +18354,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:19 GMT
+      - Thu, 19 Apr 2018 17:43:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c6e5ede6-19a4-4900-81c7-58853f378c81
+      - req-891bcde6-71f3-46dd-8615-f6590a7f3ccb
       Content-Length:
       - '4117'
       Connection:
@@ -18561,10 +18369,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:19.631465", "expires":
-        "2018-04-09T17:32:19Z", "id": "87d15b5e94aa46c9b344e5e053b65194", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:26.764387", "expires":
+        "2018-04-19T18:43:26Z", "id": "efe6fe103b0a4c71bc0ed8d03d266317", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["U5B1IUvARYm1zNyESilp_w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lp6yN_MnSgabAsyXbAIozw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18608,7 +18416,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18623,7 +18431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87d15b5e94aa46c9b344e5e053b65194
+      - efe6fe103b0a4c71bc0ed8d03d266317
   response:
     status:
       code: 200
@@ -18652,15 +18460,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx42b10860189d48879beb9-005acb9593
+      - txbe80f898f67f47e3a4b01-005ad8d53e
       Date:
-      - Mon, 09 Apr 2018 16:32:19 GMT
+      - Thu, 19 Apr 2018 17:43:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18675,7 +18483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87d15b5e94aa46c9b344e5e053b65194
+      - efe6fe103b0a4c71bc0ed8d03d266317
   response:
     status:
       code: 200
@@ -18704,14 +18512,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx1f930ca1e8d64899b009b-005acb9593
+      - txc39e6ea4bab844658fbc6-005ad8d53f
       Date:
-      - Mon, 09 Apr 2018 16:32:20 GMT
+      - Thu, 19 Apr 2018 17:43:27 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18729,13 +18537,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:20 GMT
+      - Thu, 19 Apr 2018 17:43:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f55e378c-0823-46cf-9810-acd4abeffcea
+      - req-35e547c2-ca32-4c30-9e1b-ee96e5de0313
       Content-Length:
       - '4131'
       Connection:
@@ -18744,10 +18552,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:20.264098", "expires":
-        "2018-04-09T17:32:20Z", "id": "866eec774fad4c45844008003eadd21e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:27.442750", "expires":
+        "2018-04-19T18:43:27Z", "id": "3a1aac7910a04cda8e6481a325550678", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PH45EfH1TTuVxev-dv9fsg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Hhb3glL_T3CRAYXtgl9XOw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18791,7 +18599,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18806,7 +18614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 866eec774fad4c45844008003eadd21e
+      - 3a1aac7910a04cda8e6481a325550678
   response:
     status:
       code: 200
@@ -18819,22 +18627,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291540.57316'
+      - '1524159807.71102'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291540.57316'
+      - '1524159807.71102'
       X-Trans-Id:
-      - txd76bbf1247314e3f9ee2a-005acb9594
+      - tx7b3c674a2e44468bb3bd7-005ad8d53f
       Date:
-      - Mon, 09 Apr 2018 16:32:20 GMT
+      - Thu, 19 Apr 2018 17:43:27 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18849,7 +18657,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1cfd78ea36c413bb5b69ce213d4374f
+      - bfbf6c29d6ab4a1486fc6d899d6c19b9
   response:
     status:
       code: 200
@@ -18862,22 +18670,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291540.91899'
+      - '1524159808.10440'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291540.91899'
+      - '1524159808.10440'
       X-Trans-Id:
-      - txe9b6bd99e32647f08ba0f-005acb9594
+      - txb59ef3c8ac80498e8ccf3-005ad8d53f
       Date:
-      - Mon, 09 Apr 2018 16:32:20 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18895,13 +18703,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:21 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cb8d990-d21d-40a6-95d1-de36e6b96e52
+      - req-65cd76ad-e411-4f93-a081-62a73f7749b1
       Content-Length:
       - '4118'
       Connection:
@@ -18910,10 +18718,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:21.209678", "expires":
-        "2018-04-09T17:32:21Z", "id": "2156ead3d6af4a4296764b438041b356", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:28.398179", "expires":
+        "2018-04-19T18:43:28Z", "id": "2fbaaca1fa244681b8883859988bb5f5", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["s0MUZLVQRVODqrj36vfnuA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3CqH6cvtTfaQJuoqI9mjuQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18957,7 +18765,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18972,7 +18780,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2156ead3d6af4a4296764b438041b356
+      - 2fbaaca1fa244681b8883859988bb5f5
   response:
     status:
       code: 200
@@ -18985,22 +18793,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291541.51875'
+      - '1524159808.67550'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291541.51875'
+      - '1524159808.67550'
       X-Trans-Id:
-      - txaa5fb40d9ba248e3aecba-005acb9595
+      - txb84500aa600147aba8b35-005ad8d540
       Date:
-      - Mon, 09 Apr 2018 16:32:21 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -19015,7 +18823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87d15b5e94aa46c9b344e5e053b65194
+      - efe6fe103b0a4c71bc0ed8d03d266317
   response:
     status:
       code: 200
@@ -19036,9 +18844,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txac28082a130242a3a54fb-005acb9595
+      - tx07687ff4ca81466c9a75f-005ad8d540
       Date:
-      - Mon, 09 Apr 2018 16:32:21 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -19048,7 +18856,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -19063,7 +18871,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87d15b5e94aa46c9b344e5e053b65194
+      - efe6fe103b0a4c71bc0ed8d03d266317
   response:
     status:
       code: 200
@@ -19084,14 +18892,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0335c478f5d04013bf6e4-005acb9595
+      - tx29ad71927475477f8119f-005ad8d540
       Date:
-      - Mon, 09 Apr 2018 16:32:21 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -19106,7 +18914,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87d15b5e94aa46c9b344e5e053b65194
+      - efe6fe103b0a4c71bc0ed8d03d266317
   response:
     status:
       code: 200
@@ -19127,12 +18935,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1653303185484c4ba8e16-005acb9595
+      - txf7f9f05ecfcd40c992002-005ad8d540
       Date:
-      - Mon, 09 Apr 2018 16:32:21 GMT
+      - Thu, 19 Apr 2018 17:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:27 GMT
+      - Thu, 19 Apr 2018 17:43:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51c46b2b-6fb2-4c41-872d-c3a659cf2038
+      - req-9b9353c5-862b-489a-b1d9-e9006dcd2eb1
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:27.243129", "expires":
-        "2018-04-09T17:35:27Z", "id": "8739f8d5fb164444bf18d4f46efa0ded", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:33.664597", "expires":
+        "2018-04-19T18:43:33Z", "id": "b135377ee20b4b14806836f00df5e469", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nOF7YtE0RD6bsVNBtwMuOA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["6jZzLe2zTIqYGXQjNUgDXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:27 GMT
+      - Thu, 19 Apr 2018 17:43:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-7aab2bcb-428f-4e84-9ae3-243507165150
+      - req-e5cb639b-ab9a-4b6e-856d-c7494dc4f57a
       Date:
-      - Mon, 09 Apr 2018 16:35:27 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:27 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-11b2c784-9042-448f-947d-edfa22d9fe23
+      - req-8e17efd8-d311-40a7-a8bd-d74e15af1bfb
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:27.934641", "expires":
-        "2018-04-09T17:35:27Z", "id": "691b615b463445c8bac3136925a844e2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:34.378997", "expires":
+        "2018-04-19T18:43:34Z", "id": "fe7f32d863bb41b985f9fefab3bfe272", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MP3pN3DaSSqTHMQZOki2iA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SYThKwCXRxC95keMmxr6Xw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-566ae449-b0c2-4186-a3f2-6ef11c8ee43f
+      - req-15f44462-a7b7-47d5-a517-c27ed4a41407
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-566ae449-b0c2-4186-a3f2-6ef11c8ee43f
+      - req-15f44462-a7b7-47d5-a517-c27ed4a41407
       Date:
-      - Mon, 09 Apr 2018 16:35:28 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b4760d43-e980-4777-b0df-4cb344af0a2b
+      - req-a76c01d3-08ab-492f-9587-b0ff81ba3ebf
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:35:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:43:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:35:20.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:43:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:35:22.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:43:25.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:35:24.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:43:34.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:35:24.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:43:25.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-43095c04-25a0-4c41-bb52-b89f54705bc8
+      - req-d27f6663-7a61-4f8e-87d8-afbf4ff3891d
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:35:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:43:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:35:20.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:43:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:35:22.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:43:25.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:35:24.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:43:34.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:35:24.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:43:25.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-9f425645-0896-4e3e-ade0-746f054b8e75
+      - req-45f5b5ce-430e-4dc0-b473-a37aecf9ca31
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-c0103df0-0f50-4383-b5ff-d2652b6a94c7
+      - req-0e378b1e-0935-475f-b01c-7a7550218f8d
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-492f47dd-66e7-46e2-a560-f4741cfb2abb
+      - req-116eab29-a820-4bd8-90fd-363982b3a1cc
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-6292c36a-9189-48fa-990a-1c20930dbfcc
+      - req-93eec78f-25eb-4c97-8abe-484dc9e4ef0d
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:29 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e9260c24-8e08-47e9-8462-5f1990113404
+      - req-f06b1b3b-0003-4e0a-980a-95f36c828fb9
       Content-Length:
       - '4170'
       Connection:
@@ -568,10 +568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:30.103281", "expires":
-        "2018-04-09T17:35:30Z", "id": "62786d0996e542e4a5dd00a9ed19260f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:35.508206", "expires":
+        "2018-04-19T18:43:35Z", "id": "284a79a28e8240b9b09281c9cb22069e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ev2EPtrJQCCxxBfKhTc7Eg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xDeJ1MOCQmKiLVL7QKZnJg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -616,7 +616,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -631,20 +631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62786d0996e542e4a5dd00a9ed19260f
+      - 284a79a28e8240b9b09281c9cb22069e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:30 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f969a8c-b7df-4872-b0d2-3f0a774dcd5c
+      - req-529d7fbb-6706-4ea4-a6ae-ccf5d0547a1e
       Content-Length:
       - '500'
       Connection:
@@ -661,7 +661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -676,7 +676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -689,15 +689,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-efd69ab5-9020-47ce-9688-feb4603fcfce
+      - req-70c9dfae-47e4-4229-a7ac-73088cc529db
       Date:
-      - Mon, 09 Apr 2018 16:35:30 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -715,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:30 GMT
+      - Thu, 19 Apr 2018 17:43:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2b780b20-803d-489b-acb7-685b82f45253
+      - req-8abe11c3-f7e7-45aa-b232-763d02927487
       Content-Length:
       - '4170'
       Connection:
@@ -730,10 +730,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:30.857085", "expires":
-        "2018-04-09T17:35:30Z", "id": "d3593eed0bd54eac98b12c766b41cee0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:35.928543", "expires":
+        "2018-04-19T18:43:35Z", "id": "1fb9b24aa91a4a3ab5862226970f2063", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["olpDuTGxQqGFF0VnXMRUqg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TEjS-O2NQMSlVUsD7X1NSg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -778,7 +778,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -793,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3593eed0bd54eac98b12c766b41cee0
+      - 1fb9b24aa91a4a3ab5862226970f2063
   response:
     status:
       code: 300
@@ -804,7 +804,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:35:30 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -817,7 +817,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -832,7 +832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3593eed0bd54eac98b12c766b41cee0
+      - 1fb9b24aa91a4a3ab5862226970f2063
   response:
     status:
       code: 200
@@ -843,14 +843,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-43486b2f-aca3-45b4-9c6a-7d6977b17552
+      - req-3fa9fe7a-3623-4a2d-a308-9be992bfa273
       Date:
-      - Mon, 09 Apr 2018 16:35:31 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -865,7 +865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3593eed0bd54eac98b12c766b41cee0
+      - 1fb9b24aa91a4a3ab5862226970f2063
   response:
     status:
       code: 200
@@ -876,9 +876,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5907b08a-c2a5-4d6d-b9a2-c9747a238ed5
+      - req-f92ca24b-1d96-451f-95a6-e6d73740bded
       Date:
-      - Mon, 09 Apr 2018 16:35:31 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -920,7 +920,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -935,7 +935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -948,9 +948,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-9fb3966c-22bb-4fd5-9ff1-c481bc2ca955
+      - req-8a3ffbcb-dbe6-4ab1-adfb-bedfba085132
       Date:
-      - Mon, 09 Apr 2018 16:35:31 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -960,7 +960,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -975,7 +975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -988,9 +988,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d8776063-988e-4f76-81d5-f81446e787d5
+      - req-191b05d2-e867-448f-a9ab-74d1544a8216
       Date:
-      - Mon, 09 Apr 2018 16:35:31 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1000,7 +1000,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +1018,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:31 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c80e6ed8-cd13-4b9b-8c4c-b303303dc8ce
+      - req-eeeff8e7-bc5a-431d-9740-76ee1117331d
       Content-Length:
       - '4170'
       Connection:
@@ -1033,10 +1033,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:31.949085", "expires":
-        "2018-04-09T17:35:31Z", "id": "396fc9f1d3cc463a9ddc4950c857f8a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:36.684298", "expires":
+        "2018-04-19T18:43:36Z", "id": "11d8ddb7954c4284ad1fecba34eb3ccb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["lY4wNdd-TUWvkCSa7_zEaQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0_LnvNEGRzK9bF_PyXxeKA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1081,7 +1081,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1099,13 +1099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:32 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45e9f2db-67c4-473a-8d61-66937328fc95
+      - req-bb694f93-a979-4aee-9776-a7519b66836a
       Content-Length:
       - '370'
       Connection:
@@ -1114,13 +1114,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:32.147063", "expires":
-        "2018-04-09T17:35:32Z", "id": "7ac13061547c4b968ac0f905475c8b7f", "audit_ids":
-        ["svoLGV82TSasCQRBprHW7w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:36.817237", "expires":
+        "2018-04-19T18:43:36Z", "id": "f1f27c7fa0c44636892b86ab81352997", "audit_ids":
+        ["u0tCpnRTROOY3axxHqz6dw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1135,20 +1135,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ac13061547c4b968ac0f905475c8b7f
+      - f1f27c7fa0c44636892b86ab81352997
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:32 GMT
+      - Thu, 19 Apr 2018 17:43:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e738cdc-e8c9-4142-ae52-e750b7ee9b2e
+      - req-7281e9e8-ab16-40b1-8801-851fbbad87a1
       Content-Length:
       - '500'
       Connection:
@@ -1165,13 +1165,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7ac13061547c4b968ac0f905475c8b7f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"f1f27c7fa0c44636892b86ab81352997"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1183,13 +1183,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:32 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d0c9b137-c22f-4464-8de4-66f951b7bbd1
+      - req-b3484b07-a8f8-4a13-b599-8fe8e0753eb6
       Content-Length:
       - '4143'
       Connection:
@@ -1198,11 +1198,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:32.580740", "expires":
-        "2018-04-09T17:35:32Z", "id": "7ff667c1e61a496aad5129f4a37b06cc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:37.103218", "expires":
+        "2018-04-19T18:43:36Z", "id": "d6e1ee94b7db4b78ae7f0b9db5233ced", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Fe2Tyiv1Q7W5BF0Am0tbag",
-        "svoLGV82TSasCQRBprHW7w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9MvEMz_vSxWW7MJkRr46yw",
+        "u0tCpnRTROOY3axxHqz6dw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1246,7 +1246,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1261,20 +1261,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ac13061547c4b968ac0f905475c8b7f
+      - f1f27c7fa0c44636892b86ab81352997
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:32 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee8ccd5d-941d-4e12-be1d-ccccb3ec936e
+      - req-82bacff8-2a68-469e-995e-f96cc0d49945
       Content-Length:
       - '500'
       Connection:
@@ -1291,7 +1291,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1309,13 +1309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:32 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55dca1a7-0067-4970-8063-752d5cb7b6f2
+      - req-f3124f16-8f71-49e8-9cf8-476667e5a013
       Content-Length:
       - '4117'
       Connection:
@@ -1324,10 +1324,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:33.057524", "expires":
-        "2018-04-09T17:35:33Z", "id": "d2af54792a3c47f383ec23129fa0c089", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:37.407904", "expires":
+        "2018-04-19T18:43:37Z", "id": "1f4c12c361764595bc2a45975a4d2ef8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Rk_Z-t04TIGH6ROGXt-GZQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CjUWxGKCSvOV_XaITJcFGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1371,7 +1371,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1386,7 +1386,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2af54792a3c47f383ec23129fa0c089
+      - 1f4c12c361764595bc2a45975a4d2ef8
   response:
     status:
       code: 200
@@ -1397,7 +1397,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1406,7 +1406,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1424,13 +1424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-074627c7-a58c-4111-9f82-435a74bfaddf
+      - req-82dcae79-d770-432b-aa4e-57775b715361
       Content-Length:
       - '4131'
       Connection:
@@ -1439,10 +1439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:33.401213", "expires":
-        "2018-04-09T17:35:33Z", "id": "f43659b0c0ff43bf89c0a65f2616c90e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:37.650731", "expires":
+        "2018-04-19T18:43:37Z", "id": "76e72774f5e04f58829cbad7a8fb3e0e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GclAVPMNSs27wCTLkAGM5Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Fx3n7IXtSXmrfbySfKsdvQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1486,7 +1486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1501,7 +1501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f43659b0c0ff43bf89c0a65f2616c90e
+      - 76e72774f5e04f58829cbad7a8fb3e0e
   response:
     status:
       code: 200
@@ -1512,7 +1512,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1521,7 +1521,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1539,13 +1539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b80d7414-f22d-4c99-a396-c46a813d2f9f
+      - req-00e9d38a-4aa0-4531-bbeb-e5ad5aa596cb
       Content-Length:
       - '4118'
       Connection:
@@ -1554,10 +1554,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:33.751442", "expires":
-        "2018-04-09T17:35:33Z", "id": "558f3ada3cd2492fbc5418cc41458cf8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:37.897187", "expires":
+        "2018-04-19T18:43:37Z", "id": "a181bb95a3d84befb93bf31284c48b35", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Lr8RCZdsTn2YFQxXLYXBgQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bcwJIg5bT4y-7DxoC4-uVg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1601,7 +1601,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1616,7 +1616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 558f3ada3cd2492fbc5418cc41458cf8
+      - a181bb95a3d84befb93bf31284c48b35
   response:
     status:
       code: 200
@@ -1627,7 +1627,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1636,7 +1636,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1654,13 +1654,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:33 GMT
+      - Thu, 19 Apr 2018 17:43:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ab2e9d3-8372-4f6e-a3e6-402ea8d85030
+      - req-4c5b1e7b-48ba-41b0-b3fa-5da45b76abd4
       Content-Length:
       - '4117'
       Connection:
@@ -1669,10 +1669,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:34.109757", "expires":
-        "2018-04-09T17:35:34Z", "id": "c725097cf118496ca822adeee76eb8bd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:38.135219", "expires":
+        "2018-04-19T18:43:38Z", "id": "05db1112ac3e4608a788a53714a3173e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["61Ku9XzYQCajd7Lqac9ufg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["02q0PKn2ShK7GxT75fOYSA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1716,7 +1716,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1731,7 +1731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -1742,9 +1742,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-6ab97cbf-5ac1-47fd-aae8-930b5ef2dc8d
+      - req-c058e368-a410-44f0-94f3-1d598fc78060
       Date:
-      - Mon, 09 Apr 2018 16:35:34 GMT
+      - Thu, 19 Apr 2018 17:43:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1778,7 +1778,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1793,7 +1793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -1804,14 +1804,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9d8eb046-c857-49ea-9713-50feda392957
+      - req-ec805467-a619-400b-9732-2f71439241aa
       Date:
-      - Mon, 09 Apr 2018 16:35:34 GMT
+      - Thu, 19 Apr 2018 17:43:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1829,13 +1829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:34 GMT
+      - Thu, 19 Apr 2018 17:43:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a681157b-30ed-4f4d-83f7-0cbc9fbc5b4b
+      - req-b28081d5-0cac-4fdd-b802-6563a6edcca5
       Content-Length:
       - '4131'
       Connection:
@@ -1844,10 +1844,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:34.941015", "expires":
-        "2018-04-09T17:35:34Z", "id": "26493dbfb27945a5a95b5f6ce92c6c67", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:38.646677", "expires":
+        "2018-04-19T18:43:38Z", "id": "ae0724ec80f14b268b10fc867aa9e999", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mQmptUyUT7SiSA_ZoBs7Iw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["tjxJW6UcTXOr_aT2LEtiGg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1891,7 +1891,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1906,7 +1906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26493dbfb27945a5a95b5f6ce92c6c67
+      - ae0724ec80f14b268b10fc867aa9e999
   response:
     status:
       code: 200
@@ -1917,14 +1917,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-661aade2-de0a-492b-a9be-5c6581ee2c80
+      - req-2f69060b-1fdb-43c6-abeb-610fb235e34a
       Date:
-      - Mon, 09 Apr 2018 16:35:35 GMT
+      - Thu, 19 Apr 2018 17:43:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1939,7 +1939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 396fc9f1d3cc463a9ddc4950c857f8a0
+      - 11d8ddb7954c4284ad1fecba34eb3ccb
   response:
     status:
       code: 200
@@ -1950,14 +1950,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6d6a8eca-7140-4934-95c9-10ded5334224
+      - req-f9699520-a876-409d-ab14-26536b8cc71a
       Date:
-      - Mon, 09 Apr 2018 16:35:35 GMT
+      - Thu, 19 Apr 2018 17:43:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1975,13 +1975,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:35 GMT
+      - Thu, 19 Apr 2018 17:43:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6b656dd1-59c1-4722-8796-10a5d5d60f14
+      - req-ac6f1b2d-cbdc-444f-ad2e-ff20a94619d5
       Content-Length:
       - '4118'
       Connection:
@@ -1990,10 +1990,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:35.830055", "expires":
-        "2018-04-09T17:35:35Z", "id": "e8ac3d622e1e485389b760da1c1447b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:39.211070", "expires":
+        "2018-04-19T18:43:39Z", "id": "5e865b1c0565486682db9d98195acfd4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["uyuTI2ADS5mmf5Pb0juevQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["uIpEUDUYQfy9U06Z3vqaNQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2037,7 +2037,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2052,7 +2052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ac3d622e1e485389b760da1c1447b9
+      - 5e865b1c0565486682db9d98195acfd4
   response:
     status:
       code: 200
@@ -2063,14 +2063,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-54bcc3f2-5054-4ec9-b78c-071ceae51dc3
+      - req-c4a6f18c-da96-47f4-865a-4dc6197e0769
       Date:
-      - Mon, 09 Apr 2018 16:35:36 GMT
+      - Thu, 19 Apr 2018 17:43:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2085,7 +2085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2096,9 +2096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e4afaac9-0198-41ca-9d4c-2aa155347afc
+      - req-62a50225-fbb5-441f-b81e-406ede28a476
       Date:
-      - Mon, 09 Apr 2018 16:35:37 GMT
+      - Thu, 19 Apr 2018 17:43:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2125,7 +2125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2140,7 +2140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2151,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-db56afcf-84aa-4a59-9079-77d8f443eb33
+      - req-b09bcea9-fed5-4577-8323-c515f479a992
       Date:
-      - Mon, 09 Apr 2018 16:35:38 GMT
+      - Thu, 19 Apr 2018 17:43:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2180,7 +2180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2206,9 +2206,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a787e577-baae-4ddf-bd5b-78cb6f4020f3
+      - req-cd7b54ae-41d8-4ec5-99f4-77d55c1d9418
       Date:
-      - Mon, 09 Apr 2018 16:35:38 GMT
+      - Thu, 19 Apr 2018 17:43:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2235,7 +2235,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -2250,7 +2250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2261,9 +2261,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-90fcf692-4916-4a28-b44c-bdf83220dabc
+      - req-10d8944d-dc91-4bf2-9640-194040495947
       Date:
-      - Mon, 09 Apr 2018 16:35:39 GMT
+      - Thu, 19 Apr 2018 17:43:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2319,7 +2319,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -2334,7 +2334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2345,9 +2345,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-96347486-7d3b-4f47-a56b-ce275e6da4bb
+      - req-0b5283fa-2b61-4cc1-b7a6-496d17193f27
       Date:
-      - Mon, 09 Apr 2018 16:35:39 GMT
+      - Thu, 19 Apr 2018 17:43:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2359,7 +2359,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -2374,7 +2374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2387,9 +2387,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-8df5ec9b-1ea1-4d06-aa7a-81867bf2d7dc
+      - req-deec73f5-edf6-4c96-a757-89fbe5f2ecf0
       Date:
-      - Mon, 09 Apr 2018 16:35:39 GMT
+      - Thu, 19 Apr 2018 17:43:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -2435,7 +2435,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -2450,7 +2450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2463,9 +2463,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-a39e5a46-479b-444e-9677-66f0f5603313
+      - req-267a48fa-9a2f-4722-b2aa-f63bec7777c9
       Date:
-      - Mon, 09 Apr 2018 16:35:40 GMT
+      - Thu, 19 Apr 2018 17:43:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -2511,7 +2511,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -2526,7 +2526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2539,9 +2539,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-d66399c2-715b-4582-8611-54028d78e7da
+      - req-f693b813-93ac-4812-91a7-3b3072fb1265
       Date:
-      - Mon, 09 Apr 2018 16:35:40 GMT
+      - Thu, 19 Apr 2018 17:43:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -2589,7 +2589,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -2604,7 +2604,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2617,9 +2617,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-2338a429-78df-49be-b9cc-3b36df2ba85a
+      - req-5d4ce5f5-d449-45d6-ba24-6f871af906fc
       Date:
-      - Mon, 09 Apr 2018 16:35:41 GMT
+      - Thu, 19 Apr 2018 17:43:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2661,7 +2661,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2689,9 +2689,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-6ebfd580-4716-4f7b-be25-a11bf2477b6e
+      - req-82959991-0d29-4e80-a9b7-3aa3f0fbd9eb
       Date:
-      - Mon, 09 Apr 2018 16:35:41 GMT
+      - Thu, 19 Apr 2018 17:43:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2714,7 +2714,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2729,7 +2729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2740,9 +2740,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-0a01c588-a564-48f9-addd-64328348ca24
+      - req-bf6f1d5e-d12b-4b78-8424-b931f9400f21
       Date:
-      - Mon, 09 Apr 2018 16:35:42 GMT
+      - Thu, 19 Apr 2018 17:43:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2798,7 +2798,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2813,7 +2813,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2824,9 +2824,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fd87a7d1-0065-4a38-867b-14503e494608
+      - req-6498f015-5b7c-4594-9838-b11316ea9d0b
       Date:
-      - Mon, 09 Apr 2018 16:35:42 GMT
+      - Thu, 19 Apr 2018 17:43:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2838,7 +2838,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2853,7 +2853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2864,9 +2864,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-edaf3e00-d08f-4f49-8443-39d4ba2defae
+      - req-afd87f44-b565-4b37-b18c-d22684400f5d
       Date:
-      - Mon, 09 Apr 2018 16:35:42 GMT
+      - Thu, 19 Apr 2018 17:43:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2922,7 +2922,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2937,7 +2937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c725097cf118496ca822adeee76eb8bd
+      - 05db1112ac3e4608a788a53714a3173e
   response:
     status:
       code: 200
@@ -2948,9 +2948,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fb62b43f-06c7-458e-b855-7cee61812514
+      - req-49400e82-3c2d-44a6-a458-49118506b848
       Date:
-      - Mon, 09 Apr 2018 16:35:42 GMT
+      - Thu, 19 Apr 2018 17:43:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2962,7 +2962,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2977,7 +2977,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2af54792a3c47f383ec23129fa0c089
+      - 1f4c12c361764595bc2a45975a4d2ef8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2990,9 +2990,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-51052dc1-87fa-4a69-9208-e2173e50b1b1
+      - req-ae8a83dd-7c65-44c7-9978-b93010366b6f
       Date:
-      - Mon, 09 Apr 2018 16:35:43 GMT
+      - Thu, 19 Apr 2018 17:43:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3001,7 +3001,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3016,7 +3016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f43659b0c0ff43bf89c0a65f2616c90e
+      - 76e72774f5e04f58829cbad7a8fb3e0e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3029,9 +3029,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-eddcb6c9-ff07-46f1-901c-1b92da786423
+      - req-36646394-7888-4775-b4a6-2f09fa01355c
       Date:
-      - Mon, 09 Apr 2018 16:35:43 GMT
+      - Thu, 19 Apr 2018 17:43:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3040,7 +3040,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3055,7 +3055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3b86cf47-8229-4afb-818d-f2d382117a5d
+      - req-4f625214-3247-4709-bac2-e0892a82602e
       Date:
-      - Mon, 09 Apr 2018 16:35:43 GMT
+      - Thu, 19 Apr 2018 17:43:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3079,7 +3079,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3094,7 +3094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 558f3ada3cd2492fbc5418cc41458cf8
+      - a181bb95a3d84befb93bf31284c48b35
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3107,9 +3107,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d9a86ea7-6e44-4ca6-b590-dd16c890ea61
+      - req-71a70aac-5241-4adf-818e-03b377e3fd90
       Date:
-      - Mon, 09 Apr 2018 16:35:43 GMT
+      - Thu, 19 Apr 2018 17:43:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3118,7 +3118,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3136,13 +3136,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:44 GMT
+      - Thu, 19 Apr 2018 17:43:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-20e53e79-9369-4403-bcf0-f7af417e9fcd
+      - req-4359ffd6-484d-4c5c-bd5e-8b4378e7de7e
       Content-Length:
       - '4117'
       Connection:
@@ -3151,10 +3151,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:44.227896", "expires":
-        "2018-04-09T17:35:44Z", "id": "5ca8911e434142c8bb256b5ecd35a6ba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:45.040425", "expires":
+        "2018-04-19T18:43:44Z", "id": "02795bd152914630a590956b0dcebb48", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7nd5bMhqRTGyI650QwG7og"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FCp_3zEUQuu6SlhYEH5lBw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3198,7 +3198,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3213,22 +3213,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ca8911e434142c8bb256b5ecd35a6ba
+      - '02795bd152914630a590956b0dcebb48'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e61c43f0-a156-44a4-8e5b-d7228b910a12
+      - req-04f079dc-63a3-47b7-85c0-c1af70b3f745
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e61c43f0-a156-44a4-8e5b-d7228b910a12
+      - req-04f079dc-63a3-47b7-85c0-c1af70b3f745
       Date:
-      - Mon, 09 Apr 2018 16:35:45 GMT
+      - Thu, 19 Apr 2018 17:43:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3238,7 +3238,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3256,13 +3256,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:45 GMT
+      - Thu, 19 Apr 2018 17:43:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2066c54d-e453-44d5-ac03-e0709ba6c099
+      - req-c010f9a2-7334-4fea-a725-f91be6dbe13d
       Content-Length:
       - '4131'
       Connection:
@@ -3271,10 +3271,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:45.468848", "expires":
-        "2018-04-09T17:35:45Z", "id": "5262329601b54b79a8a496d81b8f7991", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:46.228106", "expires":
+        "2018-04-19T18:43:46Z", "id": "54d009435dc140c99be1e46a2639909c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rW-AtyhuRNSQp0Ah0WHV6w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dBN118c8SbmX6DRZlpHUeg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3318,7 +3318,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3333,22 +3333,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5262329601b54b79a8a496d81b8f7991
+      - 54d009435dc140c99be1e46a2639909c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96df43f9-2c14-42b2-a9a4-4d5368c8248d
+      - req-d0d54cd8-af58-4ac1-beac-dafdf1534acf
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-96df43f9-2c14-42b2-a9a4-4d5368c8248d
+      - req-d0d54cd8-af58-4ac1-beac-dafdf1534acf
       Date:
-      - Mon, 09 Apr 2018 16:35:46 GMT
+      - Thu, 19 Apr 2018 17:43:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3358,7 +3358,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3373,22 +3373,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbe412b1-84e2-48bd-b29c-c07e12aa2011
+      - req-75d61cd7-802f-42c4-98dd-431432841436
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cbe412b1-84e2-48bd-b29c-c07e12aa2011
+      - req-75d61cd7-802f-42c4-98dd-431432841436
       Date:
-      - Mon, 09 Apr 2018 16:35:46 GMT
+      - Thu, 19 Apr 2018 17:43:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3398,7 +3398,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3416,13 +3416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:47 GMT
+      - Thu, 19 Apr 2018 17:43:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d97a64be-c6db-45bc-a3e6-6eeabd2a76d7
+      - req-db58cb23-67aa-4d18-b21c-d19efd26020d
       Content-Length:
       - '4118'
       Connection:
@@ -3431,10 +3431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:47.210161", "expires":
-        "2018-04-09T17:35:47Z", "id": "862231c8805b4d95ae71ae88ccdbe620", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:47.650711", "expires":
+        "2018-04-19T18:43:47Z", "id": "ddfb5334a26f430ab8bd127c32d6efa2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zoy7j4ADQBO-KueGlwWj8w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wuAfzZsCSFSLuuE1CCuuIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3478,7 +3478,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3493,22 +3493,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 862231c8805b4d95ae71ae88ccdbe620
+      - ddfb5334a26f430ab8bd127c32d6efa2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be4222f2-f5d2-4a4c-aa43-34d30dfd85df
+      - req-9f68a268-aa6f-4502-bb88-2c4bf5e814ab
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-be4222f2-f5d2-4a4c-aa43-34d30dfd85df
+      - req-9f68a268-aa6f-4502-bb88-2c4bf5e814ab
       Date:
-      - Mon, 09 Apr 2018 16:35:47 GMT
+      - Thu, 19 Apr 2018 17:43:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3518,7 +3518,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3536,13 +3536,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:47 GMT
+      - Thu, 19 Apr 2018 17:43:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6fe8f05e-5a83-4564-a89d-fa6d32afe9af
+      - req-af141172-913d-4401-a9b7-adfc710b3503
       Content-Length:
       - '4170'
       Connection:
@@ -3551,10 +3551,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:48.134480", "expires":
-        "2018-04-09T17:35:48Z", "id": "0afc2f2a8e2f4c75ac951f670c99c689", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:48.385888", "expires":
+        "2018-04-19T18:43:48Z", "id": "22cc7a8b1e39453cab50db0fcb03ec6a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Gef5b-r4RFqsYvwlHXRUag"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["lmSpYgzZQiej4RCOPSKCRQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3599,7 +3599,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0afc2f2a8e2f4c75ac951f670c99c689
+      - 22cc7a8b1e39453cab50db0fcb03ec6a
   response:
     status:
       code: 200
@@ -3625,13 +3625,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:35:48 GMT
+      - Thu, 19 Apr 2018 17:43:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3649,13 +3649,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:48 GMT
+      - Thu, 19 Apr 2018 17:43:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbca53b5-2975-4084-80c8-04bf7124b7f0
+      - req-7ecac606-ea57-4db3-bb72-467a4b3f9b08
       Content-Length:
       - '4117'
       Connection:
@@ -3664,10 +3664,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:48.489643", "expires":
-        "2018-04-09T17:35:48Z", "id": "03716c942dde4b42a722ae1846492e57", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:48.751494", "expires":
+        "2018-04-19T18:43:48Z", "id": "79ff22e3abe745b193d1bec987241d70", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xyrpFUAxSYqYm-ucatafJA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9aI7HcSqRdOMNVLEiaPuIA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3711,7 +3711,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3726,7 +3726,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 03716c942dde4b42a722ae1846492e57
+      - 79ff22e3abe745b193d1bec987241d70
   response:
     status:
       code: 200
@@ -3737,16 +3737,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-82a88daa-2ae4-4b45-8344-83a67fe45900
+      - req-19398333-e3b5-47c4-949d-2259d08fbf7d
       Date:
-      - Mon, 09 Apr 2018 16:35:48 GMT
+      - Thu, 19 Apr 2018 17:43:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3764,13 +3764,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:49 GMT
+      - Thu, 19 Apr 2018 17:43:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0a36bc78-8b9a-498a-b69c-0d2c7f2c697f
+      - req-8aa7639a-cb37-42e6-b567-06d7c65b1656
       Content-Length:
       - '4131'
       Connection:
@@ -3779,10 +3779,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:49.127815", "expires":
-        "2018-04-09T17:35:49Z", "id": "037bd8f608a240b2ac834e24862ddb4c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:49.369815", "expires":
+        "2018-04-19T18:43:49Z", "id": "fbad827ec4dd4efa88cca8ccc25b8115", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5KXXjAn6SZewb1T27_1OWA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8tBv6XKQQEKSZjeMwryECg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3826,7 +3826,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3841,7 +3841,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 037bd8f608a240b2ac834e24862ddb4c
+      - fbad827ec4dd4efa88cca8ccc25b8115
   response:
     status:
       code: 200
@@ -3852,16 +3852,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-97f63683-c1eb-4756-8548-29a5197435bc
+      - req-a86a5ee6-d90f-46a2-af54-76ae84b4ee87
       Date:
-      - Mon, 09 Apr 2018 16:35:49 GMT
+      - Thu, 19 Apr 2018 17:43:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0afc2f2a8e2f4c75ac951f670c99c689
+      - 22cc7a8b1e39453cab50db0fcb03ec6a
   response:
     status:
       code: 200
@@ -3887,16 +3887,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0e8bfe66-1784-4045-a0b5-d266f9978573
+      - req-d56c97e9-23e5-4287-852d-ad6044a2b2d7
       Date:
-      - Mon, 09 Apr 2018 16:35:49 GMT
+      - Thu, 19 Apr 2018 17:43:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3914,13 +3914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:49 GMT
+      - Thu, 19 Apr 2018 17:43:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-161234cc-9c91-4dc3-8238-18b504d16a59
+      - req-4e08ba82-64be-47f6-a1fc-7a11dd555a3e
       Content-Length:
       - '4118'
       Connection:
@@ -3929,10 +3929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:49.869532", "expires":
-        "2018-04-09T17:35:49Z", "id": "ef5278a058c645d1a645be7056616793", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:53.725605", "expires":
+        "2018-04-19T18:43:53Z", "id": "b051436fc1e9474d8066542f135144d0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dG1GoID1SoSp29_ShMLbWQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["npNgUtaLR0-I6v13dJ4bgg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3976,7 +3976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3991,7 +3991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef5278a058c645d1a645be7056616793
+      - b051436fc1e9474d8066542f135144d0
   response:
     status:
       code: 200
@@ -4002,16 +4002,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fe64fdb8-a57d-4543-8a5f-3b286d41a411
+      - req-84b839db-9fc8-4037-94e2-575da8f4555b
       Date:
-      - Mon, 09 Apr 2018 16:35:50 GMT
+      - Thu, 19 Apr 2018 17:43:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4026,7 +4026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4039,14 +4039,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-18e2ebcd-c7db-41a6-8823-0374f5138594
+      - req-4a7be2bd-eddc-47af-9dd0-f770f1308c10
       Date:
-      - Mon, 09 Apr 2018 16:35:50 GMT
+      - Thu, 19 Apr 2018 17:43:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4061,7 +4061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4074,14 +4074,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e63cba47-cc23-4bf3-b7c2-b6db424b30ca
+      - req-4498c6f6-c79a-4a4f-b602-fcc6fb78bb56
       Date:
-      - Mon, 09 Apr 2018 16:35:50 GMT
+      - Thu, 19 Apr 2018 17:43:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4096,7 +4096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4109,14 +4109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-842f10cd-f6f1-4c51-9185-1b2d9bb8d5bc
+      - req-b97882c5-1c7a-4053-9e66-067188b86c64
       Date:
-      - Mon, 09 Apr 2018 16:35:51 GMT
+      - Thu, 19 Apr 2018 17:43:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4131,7 +4131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4144,14 +4144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-aacca38c-ff8d-45ab-9c07-47eaaf9045a1
+      - req-108d533a-6b1d-4d70-9542-bef6c3e9ea65
       Date:
-      - Mon, 09 Apr 2018 16:35:51 GMT
+      - Thu, 19 Apr 2018 17:43:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4166,7 +4166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4179,14 +4179,50 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8a26f509-b21e-48ab-b2f1-ca0954e4db7a
+      - req-b1a5f61e-dd44-44bd-82f6-a44b7a8f43cf
       Date:
-      - Mon, 09 Apr 2018 16:35:51 GMT
+      - Thu, 19 Apr 2018 17:43:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b135377ee20b4b14806836f00df5e469
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-80be11cd-d3f8-48fe-aebb-d969519a2f32
+      Date:
+      - Thu, 19 Apr 2018 17:43:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
+        "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4201,7 +4237,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4214,14 +4250,50 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e4a832f2-28ba-4d65-8f84-f5407c716c01
+      - req-6ccc6b37-d5c3-46ca-bb05-12390529a9ef
       Date:
-      - Mon, 09 Apr 2018 16:35:51 GMT
+      - Thu, 19 Apr 2018 17:43:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:56 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b135377ee20b4b14806836f00df5e469
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-1b4e6bed-2ec3-4897-bda7-32c83078b9f5
+      Date:
+      - Thu, 19 Apr 2018 17:43:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:43:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4236,7 +4308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4249,14 +4321,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-80521565-140e-4a02-9de8-688e159a8044
+      - req-36c4d85c-d814-4f73-9296-f03390406bb2
       Date:
-      - Mon, 09 Apr 2018 16:35:52 GMT
+      - Thu, 19 Apr 2018 17:43:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4271,7 +4343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4284,14 +4356,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-80ce36ac-9633-461e-b3bf-7d6284ea079b
+      - req-feb2e88b-7b87-4b1a-9a90-7c5c1f3dd950
       Date:
-      - Mon, 09 Apr 2018 16:35:52 GMT
+      - Thu, 19 Apr 2018 17:43:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4306,7 +4378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4319,14 +4391,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-20568d24-6a14-4206-a5aa-25813745e11e
+      - req-c439f1fb-2bb5-4969-be5b-daa4006fb7eb
       Date:
-      - Mon, 09 Apr 2018 16:35:52 GMT
+      - Thu, 19 Apr 2018 17:43:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4344,13 +4416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:52 GMT
+      - Thu, 19 Apr 2018 17:43:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c850ed70-b6ea-4765-9b70-ea00f4334846
+      - req-806bb218-3673-436d-b5e2-e3cbce9a3b7c
       Content-Length:
       - '4170'
       Connection:
@@ -4359,10 +4431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:53.046935", "expires":
-        "2018-04-09T17:35:52Z", "id": "936425478671445cacea3db1203a5b14", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:57.280697", "expires":
+        "2018-04-19T18:43:57Z", "id": "d9613bf779c34e8e9a4d2e37ca220995", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["sUisyNwcT8yBA9-bj9Mpzw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["oWo9dJR7S92Kgs-jRveEoA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4407,13 +4479,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"936425478671445cacea3db1203a5b14"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"d9613bf779c34e8e9a4d2e37ca220995"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4425,13 +4497,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:53 GMT
+      - Thu, 19 Apr 2018 17:43:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-99eebe93-a79c-4321-9396-304797459e3a
+      - req-b79ecbaf-85d7-4d7b-b9b8-1d168b29ff51
       Content-Length:
       - '4196'
       Connection:
@@ -4440,10 +4512,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:53.280814", "expires":
-        "2018-04-09T17:35:52Z", "id": "e452d80dd7ad427db5b2af0ef1c39c4d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:57.492395", "expires":
+        "2018-04-19T18:43:57Z", "id": "19d59989d0ca4b18816e708bc17cce23", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QcvtCS4vRkGwVi1HLynbKg", "sUisyNwcT8yBA9-bj9Mpzw"]},
+        "name": "admin"}, "audit_ids": ["UdoZxIeqQaGNBq5kOc15Tg", "oWo9dJR7S92Kgs-jRveEoA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4488,7 +4560,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4506,13 +4578,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:53 GMT
+      - Thu, 19 Apr 2018 17:43:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6753dc91-bc6e-4a7a-a178-50e8510751b3
+      - req-fce9d9fb-dd6a-4eab-8187-96ef7cd64d33
       Content-Length:
       - '4170'
       Connection:
@@ -4521,10 +4593,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:53.525714", "expires":
-        "2018-04-09T17:35:53Z", "id": "7b99db8e915746328113a82086642312", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:57.693606", "expires":
+        "2018-04-19T18:43:57Z", "id": "347fc7abe6d1464ea877b18e0ea45c3f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["AGLJSgWiSKaNHHG9coceTQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Nmq57Vb2Ro-Py1NEq6E_0Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4569,13 +4641,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7b99db8e915746328113a82086642312"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"347fc7abe6d1464ea877b18e0ea45c3f"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4587,13 +4659,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:53 GMT
+      - Thu, 19 Apr 2018 17:43:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02b1ea2f-ddca-4cd3-952f-7668f28c8316
+      - req-e80d98cb-1da2-41a1-9ec3-81def551bd9a
       Content-Length:
       - '4196'
       Connection:
@@ -4602,10 +4674,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:53.793345", "expires":
-        "2018-04-09T17:35:53Z", "id": "e2a0f57edbd645f88d7cb0d8ad0a2cfc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:43:57.929153", "expires":
+        "2018-04-19T18:43:57Z", "id": "675fe57bcaf24c89bc9fca3b63cd1c89", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZA0IuAnQTiO9nsj17R9EwA", "AGLJSgWiSKaNHHG9coceTQ"]},
+        "name": "admin"}, "audit_ids": ["e4GsrDN0TNeednjFOqXfnw", "Nmq57Vb2Ro-Py1NEq6E_0Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4650,7 +4722,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -4665,7 +4737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8739f8d5fb164444bf18d4f46efa0ded
+      - b135377ee20b4b14806836f00df5e469
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4678,14 +4750,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-6cfdf294-2c94-40db-ac69-b65c9a9fd9b8
+      - req-28f467f5-7b32-493b-b1eb-6d307befa3da
       Date:
-      - Mon, 09 Apr 2018 16:35:53 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -4700,22 +4772,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38fd5224-93fb-45fe-bfff-ffaed5409f10
+      - req-38767d2a-40bd-4349-80e0-934627eccd4f
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-38fd5224-93fb-45fe-bfff-ffaed5409f10
+      - req-38767d2a-40bd-4349-80e0-934627eccd4f
       Date:
-      - Mon, 09 Apr 2018 16:35:54 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4748,7 +4820,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4763,22 +4835,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2329e30e-ac53-403e-ab05-0895fec75ecd
+      - req-13c2c686-36c5-4e8a-9288-863a6f2971fd
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-2329e30e-ac53-403e-ab05-0895fec75ecd
+      - req-13c2c686-36c5-4e8a-9288-863a6f2971fd
       Date:
-      - Mon, 09 Apr 2018 16:35:54 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4795,7 +4867,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -4810,22 +4882,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ca8911e434142c8bb256b5ecd35a6ba
+      - '02795bd152914630a590956b0dcebb48'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd9e8b7e-1f2c-4d5f-97bd-a03471a634de
+      - req-8367a9f5-5f87-427c-a4c8-e8d7f975cc61
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-dd9e8b7e-1f2c-4d5f-97bd-a03471a634de
+      - req-8367a9f5-5f87-427c-a4c8-e8d7f975cc61
       Date:
-      - Mon, 09 Apr 2018 16:35:54 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4840,7 +4912,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -4855,22 +4927,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ca8911e434142c8bb256b5ecd35a6ba
+      - '02795bd152914630a590956b0dcebb48'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-adb85fb4-dccd-4cbf-8ffa-ca343853b6b3
+      - req-0a0fbda6-a715-4baa-b366-95c5f1674a33
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-adb85fb4-dccd-4cbf-8ffa-ca343853b6b3
+      - req-0a0fbda6-a715-4baa-b366-95c5f1674a33
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4885,7 +4957,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -4900,27 +4972,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5262329601b54b79a8a496d81b8f7991
+      - 54d009435dc140c99be1e46a2639909c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e37828e5-528b-451b-b819-9c3ca7b0e5ca
+      - req-cd3c04bc-14b4-444f-aaeb-6a16a6534a41
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e37828e5-528b-451b-b819-9c3ca7b0e5ca
+      - req-cd3c04bc-14b4-444f-aaeb-6a16a6534a41
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -4935,27 +5007,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5262329601b54b79a8a496d81b8f7991
+      - 54d009435dc140c99be1e46a2639909c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f27470ce-062d-45fa-9bf9-7e0add23594f
+      - req-84e84454-4230-448b-a5a9-49a11d785f80
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f27470ce-062d-45fa-9bf9-7e0add23594f
+      - req-84e84454-4230-448b-a5a9-49a11d785f80
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -4970,27 +5042,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd740ffa-9041-4fac-8d07-5fabfd0412e3
+      - req-7570f0e1-f4c3-4307-843a-c998fa5e7efb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dd740ffa-9041-4fac-8d07-5fabfd0412e3
+      - req-7570f0e1-f4c3-4307-843a-c998fa5e7efb
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5005,27 +5077,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b615b463445c8bac3136925a844e2
+      - fe7f32d863bb41b985f9fefab3bfe272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86a80b39-f1dd-4a98-9de6-b6a2236638f1
+      - req-774503bf-41cf-4054-bf96-f837665c3958
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-86a80b39-f1dd-4a98-9de6-b6a2236638f1
+      - req-774503bf-41cf-4054-bf96-f837665c3958
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5040,27 +5112,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 862231c8805b4d95ae71ae88ccdbe620
+      - ddfb5334a26f430ab8bd127c32d6efa2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b75bbf7-fed0-4bae-be4c-dbeeec03355e
+      - req-50d8758f-e121-4e4a-a753-11c6bc5f710f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3b75bbf7-fed0-4bae-be4c-dbeeec03355e
+      - req-50d8758f-e121-4e4a-a753-11c6bc5f710f
       Date:
-      - Mon, 09 Apr 2018 16:35:55 GMT
+      - Thu, 19 Apr 2018 17:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5075,27 +5147,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 862231c8805b4d95ae71ae88ccdbe620
+      - ddfb5334a26f430ab8bd127c32d6efa2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94837e4d-e5fe-4941-a0f7-3ceb011d4997
+      - req-02e05c9b-93f0-4233-81fd-6e75454b2323
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-94837e4d-e5fe-4941-a0f7-3ceb011d4997
+      - req-02e05c9b-93f0-4233-81fd-6e75454b2323
       Date:
-      - Mon, 09 Apr 2018 16:35:56 GMT
+      - Thu, 19 Apr 2018 17:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:43:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5113,13 +5185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:57 GMT
+      - Thu, 19 Apr 2018 17:44:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c526db90-a2c0-4586-8a99-42ba6b241eef
+      - req-b3d5e467-2add-46c6-aa32-cdf529c35aed
       Content-Length:
       - '4170'
       Connection:
@@ -5128,10 +5200,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:57.151217", "expires":
-        "2018-04-09T17:35:57Z", "id": "8991200c3615466489e2efd12d6d6e5d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:00.576538", "expires":
+        "2018-04-19T18:44:00Z", "id": "06726a78969f4bd894ef3a6462fef30d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zIMsu1NYQLi4uC5HRyNukQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gJ1QfgxaTUmdnPCi2YuOAQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5176,7 +5248,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5194,13 +5266,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:57 GMT
+      - Thu, 19 Apr 2018 17:44:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2edfa86-439c-4bb1-b793-0fa456360515
+      - req-c5522111-6d44-4e69-9ef7-873dd4fae222
       Content-Length:
       - '4170'
       Connection:
@@ -5209,10 +5281,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:57.428632", "expires":
-        "2018-04-09T17:35:57Z", "id": "18353f47d35f4c8e9141d510d1f67355", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:02.137361", "expires":
+        "2018-04-19T18:44:02Z", "id": "77fe853365394bc28e48fae28be5f778", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4svtYE4KQRCWIgvmELMhGQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GBtHx9GvQfqAsH7a6_0HbA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5257,7 +5329,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5272,7 +5344,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -5283,42 +5355,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-80761f69-33e8-491b-8afd-8671a8fc2add
+      - req-61df7014-b1ac-41f0-95ea-4bbebbfb7d2b
       Date:
-      - Mon, 09 Apr 2018 16:35:57 GMT
+      - Thu, 19 Apr 2018 17:44:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -5348,14 +5405,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5373,13 +5445,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:57 GMT
+      - Thu, 19 Apr 2018 17:44:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-433e5db4-41ed-420c-9795-f49187c2b77d
+      - req-fa888702-2924-4b05-8c40-38c1deb49987
       Content-Length:
       - '4170'
       Connection:
@@ -5388,10 +5460,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:58.110289", "expires":
-        "2018-04-09T17:35:58Z", "id": "0f8d67ab9d734fca868a414c95742842", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:02.793677", "expires":
+        "2018-04-19T18:44:02Z", "id": "00588740fc9c436abec9cd531e166b77", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["cmZCWETwQDy4efyD3MUyeA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["5o473xOiS1inSaJD-aiCJQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5436,7 +5508,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5454,13 +5526,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:58 GMT
+      - Thu, 19 Apr 2018 17:44:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-994e6b1c-9e61-4cc2-8be2-6bbaeccab624
+      - req-cad5b1ca-e7d5-44d4-bf85-753085cf02f2
       Content-Length:
       - '370'
       Connection:
@@ -5469,13 +5541,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:58.337047", "expires":
-        "2018-04-09T17:35:58Z", "id": "e045eb2a60574793964dd3fbc3d0117f", "audit_ids":
-        ["M90ha8UWS-OPzuRLFEZE6w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:03.087585", "expires":
+        "2018-04-19T18:44:03Z", "id": "42549c36481e45998a83ce7995ba4ee4", "audit_ids":
+        ["gD59m2sMRjulRQCiU5LZuw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:03 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5490,20 +5562,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e045eb2a60574793964dd3fbc3d0117f
+      - 42549c36481e45998a83ce7995ba4ee4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:58 GMT
+      - Thu, 19 Apr 2018 17:44:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7240065d-8b7c-4d98-8832-8a158df96027
+      - req-1b889d30-07cf-46b8-89da-17a976471639
       Content-Length:
       - '500'
       Connection:
@@ -5520,13 +5592,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"e045eb2a60574793964dd3fbc3d0117f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"42549c36481e45998a83ce7995ba4ee4"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5538,13 +5610,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:58 GMT
+      - Thu, 19 Apr 2018 17:44:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5ef18c14-bb39-4f96-ac88-ca2feb93980f
+      - req-a6b2bae9-3997-4a57-ab8f-189bd5f76f61
       Content-Length:
       - '4143'
       Connection:
@@ -5553,11 +5625,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:58.815690", "expires":
-        "2018-04-09T17:35:58Z", "id": "3221fac59a3e4e9db5e6ca8ecc48d05e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:03.367106", "expires":
+        "2018-04-19T18:44:03Z", "id": "c59bc875679c479492e6d07982655667", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RTd8HM0XRvyT3tDRBHLRzw",
-        "M90ha8UWS-OPzuRLFEZE6w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["byF4RRLwRhq0AS3JyunVZA",
+        "gD59m2sMRjulRQCiU5LZuw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5601,7 +5673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:03 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5616,20 +5688,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e045eb2a60574793964dd3fbc3d0117f
+      - 42549c36481e45998a83ce7995ba4ee4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:58 GMT
+      - Thu, 19 Apr 2018 17:44:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13289e62-fab5-47a3-9497-d873b3477566
+      - req-13188405-d1f0-417e-9749-83e3c4761643
       Content-Length:
       - '500'
       Connection:
@@ -5646,7 +5718,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5664,13 +5736,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:59 GMT
+      - Thu, 19 Apr 2018 17:44:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3f940ba-8b7b-4ab6-895a-21310e669273
+      - req-aefa8cf8-7e21-4736-837a-a22c0820dd4a
       Content-Length:
       - '4117'
       Connection:
@@ -5679,10 +5751,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:59.242658", "expires":
-        "2018-04-09T17:35:59Z", "id": "3f610b2afdb54499b6e2b9e5dd0afcfa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:03.646466", "expires":
+        "2018-04-19T18:44:03Z", "id": "75d7aad277af4d86a72b65d207dc4dc3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Qa0INYIqTy2QwgYGs80UXg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["N6OpS7e5Q3-XiQHmZzTMGw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5726,7 +5798,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5744,13 +5816,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:59 GMT
+      - Thu, 19 Apr 2018 17:44:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-713a90ab-a8ed-4c4c-aef3-f99bb31a5da5
+      - req-4a528af1-900f-4721-89e0-40326b15703e
       Content-Length:
       - '4131'
       Connection:
@@ -5759,10 +5831,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:59.498029", "expires":
-        "2018-04-09T17:35:59Z", "id": "9b432eecc3a242ae81c6a08a45209810", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:04.313116", "expires":
+        "2018-04-19T18:44:04Z", "id": "53074f5486d7429eafdb497eac1ed6fd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ESl5gYMjRHybmT8RjHXI4Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["E47KuiZqSzuv3uCkmsJDEQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5806,7 +5878,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5824,13 +5896,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:59 GMT
+      - Thu, 19 Apr 2018 17:44:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d3bd25c9-ad17-40c4-a6e7-9143a89b2edb
+      - req-f33e5388-4c2b-41ff-85dd-e2c66441edeb
       Content-Length:
       - '4118'
       Connection:
@@ -5839,10 +5911,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:59.709143", "expires":
-        "2018-04-09T17:35:59Z", "id": "1cc6282a925e470d8c80d362641b61fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:04.484506", "expires":
+        "2018-04-19T18:44:04Z", "id": "3cf545cbe9054541b3289efa827cd887", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LBh46tKVTAqf9Ky_f4D9tw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6hGCCr6ZTIKumWPvtntjkA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5886,7 +5958,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5904,13 +5976,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:59 GMT
+      - Thu, 19 Apr 2018 17:44:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-44ff0f90-3404-47dd-86f9-3f877348dc09
+      - req-96805dad-3b85-4617-98a0-65ecd9113208
       Content-Length:
       - '4117'
       Connection:
@@ -5919,10 +5991,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:00.047885", "expires":
-        "2018-04-09T17:35:59Z", "id": "22d74ba0aee242a1ade09e20c0185a75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:04.675491", "expires":
+        "2018-04-19T18:44:04Z", "id": "b31950ac92844589bfdf45cbcd1f3678", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["58Fh4RGySMiwRGXK8xQSyA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["pXTo6vhPRbSOtd5BtBQzUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5966,7 +6038,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -5981,7 +6053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -5992,9 +6064,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-b5d514d2-cd36-4ded-9140-4d41a3017f0c
+      - req-4dfbf67d-6df5-4f41-b908-820b82e45c8c
       Date:
-      - Mon, 09 Apr 2018 16:36:00 GMT
+      - Thu, 19 Apr 2018 17:44:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6028,7 +6100,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6043,7 +6115,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6054,14 +6126,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-14572c0c-6739-410b-919e-2344dc3d3ecd
+      - req-b84361cc-9c3d-40de-8c80-cbcdfdb599a9
       Date:
-      - Mon, 09 Apr 2018 16:36:00 GMT
+      - Thu, 19 Apr 2018 17:44:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6079,13 +6151,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:00 GMT
+      - Thu, 19 Apr 2018 17:44:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b8f07d9-107d-4e46-b7c7-accf8a1a30cf
+      - req-c42c0599-aa3b-4550-82d1-a9baadc926fa
       Content-Length:
       - '4131'
       Connection:
@@ -6094,10 +6166,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:00.936832", "expires":
-        "2018-04-09T17:36:00Z", "id": "916b9fc0f8cc4e2db7684799f702467c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:05.162162", "expires":
+        "2018-04-19T18:44:05Z", "id": "25d394cdebfc4919a60c8d6c59826ee1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["NwRhMBanT465BjublQXc5A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0KWGYgsZTneluDSMS68tzQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6141,7 +6213,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6156,7 +6228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 916b9fc0f8cc4e2db7684799f702467c
+      - 25d394cdebfc4919a60c8d6c59826ee1
   response:
     status:
       code: 200
@@ -6167,14 +6239,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1f6e89a7-12d7-45ff-ad53-49aec00d3be2
+      - req-fb3fd96c-c226-453a-9dbc-c073e14d7118
       Date:
-      - Mon, 09 Apr 2018 16:36:01 GMT
+      - Thu, 19 Apr 2018 17:44:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6189,7 +6261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f8d67ab9d734fca868a414c95742842
+      - '00588740fc9c436abec9cd531e166b77'
   response:
     status:
       code: 200
@@ -6200,14 +6272,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-13e4c49f-9604-421a-8799-40a3a6ad7118
+      - req-2c6e18a5-cb99-46bc-bbef-9bb9299edcdb
       Date:
-      - Mon, 09 Apr 2018 16:36:01 GMT
+      - Thu, 19 Apr 2018 17:44:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6225,13 +6297,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:01 GMT
+      - Thu, 19 Apr 2018 17:44:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-301e13a3-9a42-4ea3-b5ca-26c7b72c0b65
+      - req-10e57517-438c-4723-9c01-ccc382b49704
       Content-Length:
       - '4118'
       Connection:
@@ -6240,10 +6312,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:01.741262", "expires":
-        "2018-04-09T17:36:01Z", "id": "5693626b3cda42599a62b7f5a2650e23", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:05.734668", "expires":
+        "2018-04-19T18:44:05Z", "id": "09a7be0c9ba9492d8f8759e8f66d805d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lhgFarBJR1apy_7yRafOHQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lscoTq9VTNudBNCzQFbuYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6287,7 +6359,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6302,7 +6374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5693626b3cda42599a62b7f5a2650e23
+      - '09a7be0c9ba9492d8f8759e8f66d805d'
   response:
     status:
       code: 200
@@ -6313,14 +6385,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a26ebad9-3316-4198-ad54-32721313e64a
+      - req-27687aa3-8496-49e0-88db-d3738ddb8580
       Date:
-      - Mon, 09 Apr 2018 16:36:02 GMT
+      - Thu, 19 Apr 2018 17:44:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6335,7 +6407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6346,9 +6418,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bf63471f-6756-42d3-a02c-78582364e6f0
+      - req-6f421d17-d866-4696-ba26-77dc600ab9b7
       Date:
-      - Mon, 09 Apr 2018 16:36:03 GMT
+      - Thu, 19 Apr 2018 17:44:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6375,7 +6447,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6390,7 +6462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6401,9 +6473,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-53144563-9fdc-4261-b929-856749d4e556
+      - req-f3462f47-f981-4428-9e1a-0d56878798e7
       Date:
-      - Mon, 09 Apr 2018 16:36:03 GMT
+      - Thu, 19 Apr 2018 17:44:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6430,7 +6502,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6445,7 +6517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6456,9 +6528,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-13dd6cb7-b612-4bba-9384-6294d38c5edd
+      - req-af634b7a-f195-48ca-ac7a-517cf238ee1d
       Date:
-      - Mon, 09 Apr 2018 16:36:04 GMT
+      - Thu, 19 Apr 2018 17:44:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6485,7 +6557,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -6500,7 +6572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6511,9 +6583,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1d3058f4-4875-49a5-b402-24c8780237ff
+      - req-4943ed4f-893a-4229-95be-0d930619069e
       Date:
-      - Mon, 09 Apr 2018 16:36:04 GMT
+      - Thu, 19 Apr 2018 17:44:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6525,7 +6597,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -6540,7 +6612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6551,9 +6623,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b7ac25fd-7f3e-42bd-9c77-c58856130f8a
+      - req-333393e0-ef53-4483-85c3-550356ed5671
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6565,7 +6637,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -6580,7 +6652,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22d74ba0aee242a1ade09e20c0185a75
+      - b31950ac92844589bfdf45cbcd1f3678
   response:
     status:
       code: 200
@@ -6591,9 +6663,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-60237ed6-9a58-4892-9020-d2e7025c31f3
+      - req-7c2114dd-9309-474b-b028-55f9039f4d82
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6605,7 +6677,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -6620,7 +6692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -6631,9 +6703,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e7f7e776-6318-4e96-afa4-8762d4113eb9
+      - req-c157e94e-29e3-4187-b586-b6a74f0b013e
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 77fe853365394bc28e48fae28be5f778
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-dc662c43-e7fb-4b43-9b0d-d949b1079938
+      Date:
+      - Thu, 19 Apr 2018 17:44:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -6737,7 +6941,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6752,7 +6956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -6763,47 +6967,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ad7b476b-b0f7-4cde-b64a-351b5b76366f
+      - req-98491083-354c-4b4e-988d-46ef5653bba9
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -6816,16 +7036,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -6839,37 +7054,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6884,7 +7088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -6895,9 +7099,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-18dcef74-ddbd-41d1-addc-3d6673dc9470
+      - req-46e5ef81-4296-4b4e-90c4-9e5ab1a7e1f7
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6939,7 +7143,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6954,7 +7158,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -6965,9 +7169,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-61073509-6f34-40d2-8391-c3e06342fbe8
+      - req-326743ed-6975-4631-8156-9b5ee3b19e76
       Date:
-      - Mon, 09 Apr 2018 16:36:05 GMT
+      - Thu, 19 Apr 2018 17:44:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7009,7 +7213,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -7024,7 +7228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -7035,9 +7239,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-03838571-d36b-48b1-96c2-613dfbc365c5
+      - req-c4631d0a-283e-45aa-ac09-8521454a6ca3
       Date:
-      - Mon, 09 Apr 2018 16:36:06 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7440,7 +7644,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -7455,7 +7659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -7466,9 +7670,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-db81a948-9419-4074-991d-a652f8ec4105
+      - req-a29613a6-3619-4b01-9192-da5029dd774f
       Date:
-      - Mon, 09 Apr 2018 16:36:06 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7871,7 +8075,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -7886,7 +8090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -7897,9 +8101,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-4c3b0b4c-be3b-4e5b-b466-3cf6f33f7709
+      - req-65b60f8c-32ec-44f3-9e08-ad0d7b605077
       Date:
-      - Mon, 09 Apr 2018 16:36:06 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7931,7 +8135,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -7946,7 +8150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -7957,9 +8161,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fcfe15d1-021b-4a82-86f5-800a2c2548dd
+      - req-8d63a2ba-7814-440c-a0c6-03da18654d80
       Date:
-      - Mon, 09 Apr 2018 16:36:07 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7991,7 +8195,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -8006,7 +8210,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -8017,9 +8221,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-da5cc944-c4e1-4a15-8c77-8d5011cd7041
+      - req-8b2ebca3-740a-4b38-a7b7-89326d045595
       Date:
-      - Mon, 09 Apr 2018 16:36:07 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -8061,7 +8265,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -8076,7 +8280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -8087,9 +8291,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-092c406b-6c81-47e7-8d82-30d810837160
+      - req-7975b58c-8137-4e76-9766-b4945705971d
       Date:
-      - Mon, 09 Apr 2018 16:36:07 GMT
+      - Thu, 19 Apr 2018 17:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -8132,7 +8336,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -8147,7 +8351,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -8158,9 +8362,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-87a7add4-920e-498e-bdfa-6122fe1617dd
+      - req-bd8ab6c4-5b2f-4c44-8831-5c7b3e66733f
       Date:
-      - Mon, 09 Apr 2018 16:36:07 GMT
+      - Thu, 19 Apr 2018 17:44:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -8195,7 +8399,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -8210,7 +8414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18353f47d35f4c8e9141d510d1f67355
+      - 77fe853365394bc28e48fae28be5f778
   response:
     status:
       code: 200
@@ -8221,9 +8425,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-2740bba2-f126-4262-9436-24e5d71b91ed
+      - req-02f9fd7f-18b9-4328-a5d2-dac5a8a94e15
       Date:
-      - Mon, 09 Apr 2018 16:36:07 GMT
+      - Thu, 19 Apr 2018 17:44:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -8310,7 +8514,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8328,13 +8532,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:08 GMT
+      - Thu, 19 Apr 2018 17:44:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-67a9f363-29c1-4c68-87c6-02d8d3bef913
+      - req-0a83c594-d635-4861-9794-6653d05e6926
       Content-Length:
       - '4170'
       Connection:
@@ -8343,10 +8547,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:08.299129", "expires":
-        "2018-04-09T17:36:08Z", "id": "ae20c99713fd495f8119aab39b74892b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:16.133099", "expires":
+        "2018-04-19T18:44:16Z", "id": "341571d817ac413788c8ae581122200b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fPKkjuqxSvu7MbRaoBzlgg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2VbfjvJiQ7GIKwm_MzWY1Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8391,7 +8595,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8409,13 +8613,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:08 GMT
+      - Thu, 19 Apr 2018 17:44:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-031b2456-9136-4c71-a3df-ac1e3f39f469
+      - req-4cef38bb-8043-4564-8286-5bcbb9a8969d
       Content-Length:
       - '4170'
       Connection:
@@ -8424,10 +8628,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:08.573898", "expires":
-        "2018-04-09T17:36:08Z", "id": "d501bb0c18164bc585fc0884ae7929ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:16.536613", "expires":
+        "2018-04-19T18:44:16Z", "id": "68177361472b42febe2f39a03e27ab7a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZgJy3OkGRK-DT0VW9nJpHw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["BLpDt34XRu2dln6srpA-fw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8472,7 +8676,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8490,13 +8694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:08 GMT
+      - Thu, 19 Apr 2018 17:44:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-23f0a128-3cc1-444b-ad48-d01faacff2fc
+      - req-c41301bc-c8ed-4043-9b81-aef55ca11f13
       Content-Length:
       - '370'
       Connection:
@@ -8505,13 +8709,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:08.748092", "expires":
-        "2018-04-09T17:36:08Z", "id": "1bc672e3376544fcaba798208594c02f", "audit_ids":
-        ["fp2H_dFHR7SouIG2UAO9LA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:16.783059", "expires":
+        "2018-04-19T18:44:16Z", "id": "08803b7222ec43d19f2ce6eeb7cab22d", "audit_ids":
+        ["yPr1gR08TSWMuXYw4y-yXw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8526,20 +8730,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bc672e3376544fcaba798208594c02f
+      - '08803b7222ec43d19f2ce6eeb7cab22d'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:08 GMT
+      - Thu, 19 Apr 2018 17:44:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c6f63bb4-ad06-4cd3-8c2b-9b4731fb6c9a
+      - req-19b9dbbc-a56a-4569-bb67-2b1a9beb8c4c
       Content-Length:
       - '500'
       Connection:
@@ -8556,13 +8760,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1bc672e3376544fcaba798208594c02f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"08803b7222ec43d19f2ce6eeb7cab22d"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8574,13 +8778,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:08 GMT
+      - Thu, 19 Apr 2018 17:44:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9dc4f3f2-bdaf-4693-85c5-5ef068778591
+      - req-3b004c9d-690f-450e-a85f-f6868c8bd524
       Content-Length:
       - '4143'
       Connection:
@@ -8589,11 +8793,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:09.049218", "expires":
-        "2018-04-09T17:36:08Z", "id": "6ba4ecce32344c50a16fa52a4f782317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:17.216141", "expires":
+        "2018-04-19T18:44:16Z", "id": "fdd7043fa5574fdf98d85f3fe63e9c9d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yGtCeVcgQ2S8q3RXmFCmeA",
-        "fp2H_dFHR7SouIG2UAO9LA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["f-4bfRRpQYCU32vCDjUkfg",
+        "yPr1gR08TSWMuXYw4y-yXw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8637,7 +8841,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8652,20 +8856,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bc672e3376544fcaba798208594c02f
+      - '08803b7222ec43d19f2ce6eeb7cab22d'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:09 GMT
+      - Thu, 19 Apr 2018 17:44:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87c86fd4-bc16-4aa4-90bf-73b3b152c8ab
+      - req-19958107-1abd-4327-ad1a-1c24cc72ec2e
       Content-Length:
       - '500'
       Connection:
@@ -8682,7 +8886,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8700,13 +8904,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:09 GMT
+      - Thu, 19 Apr 2018 17:44:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb21b4fb-2810-4506-b748-8adda4e46591
+      - req-c264333e-fbb5-496f-af30-2ac523167c6b
       Content-Length:
       - '4117'
       Connection:
@@ -8715,10 +8919,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:09.459955", "expires":
-        "2018-04-09T17:36:09Z", "id": "565eb4d97e1c4aa9b1c50819f6633ff3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:17.684740", "expires":
+        "2018-04-19T18:44:17Z", "id": "9e7e1f7d7426496abb373d0c7d773ab0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Gl7qvQ8_TpuzP52AT9JykQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ch6xnjc7TAuXDFN1lmajZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8762,7 +8966,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8780,13 +8984,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:09 GMT
+      - Thu, 19 Apr 2018 17:44:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b8623eb-4421-4adc-b9d7-c58101befb9b
+      - req-5ef2bf20-c84e-43ba-bcd1-21837e247e11
       Content-Length:
       - '4131'
       Connection:
@@ -8795,10 +8999,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:09.731581", "expires":
-        "2018-04-09T17:36:09Z", "id": "86d5dbdc8f1943889d3c95bd42341e6b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:18.009055", "expires":
+        "2018-04-19T18:44:17Z", "id": "26487ac23b1b4cb7bd831758a0b6a74f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eJTE6y1VRq-r1iPd-HUErg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Zpd370reSPWHyAeHVIEk3A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8842,7 +9046,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8860,13 +9064,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:09 GMT
+      - Thu, 19 Apr 2018 17:44:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-05a94e30-9ef6-468c-90b0-161e7f23ae2b
+      - req-48c725ed-8375-4ca6-aa74-cd0970d2c9cf
       Content-Length:
       - '4118'
       Connection:
@@ -8875,10 +9079,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:10.011300", "expires":
-        "2018-04-09T17:36:09Z", "id": "f6dcb97516de4910824ea56ebe665841", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:18.349431", "expires":
+        "2018-04-19T18:44:18Z", "id": "aec23d6923b1434fb6a3ef3def421797", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rEaVxbXsRmqnwE-PnpCKmw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LnkSFdkrTdyhhrOnoTzSAg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8922,7 +9126,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8940,13 +9144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:10 GMT
+      - Thu, 19 Apr 2018 17:44:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6c114efc-51a5-4b6e-872d-699e3d28740f
+      - req-e91eb701-b808-4cd5-83d5-ff425c559f00
       Content-Length:
       - '4117'
       Connection:
@@ -8955,10 +9159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:10.329464", "expires":
-        "2018-04-09T17:36:10Z", "id": "9075ecb1f1674dd0a9395f1983b5368c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:18.635057", "expires":
+        "2018-04-19T18:44:18Z", "id": "8e842e05d9f64d358f10123c48757803", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JpHE-V5wT5yYHSylXh6Bww"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GTkfOo_3SeKYzxKhgoR0UA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9002,7 +9206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -9017,22 +9221,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9ea0e013-2828-4faa-a7ee-a73cd0427d4f
+      - req-6017d328-ac3d-4251-8150-207499bc5975
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-9ea0e013-2828-4faa-a7ee-a73cd0427d4f
+      - req-6017d328-ac3d-4251-8150-207499bc5975
       Date:
-      - Mon, 09 Apr 2018 16:36:10 GMT
+      - Thu, 19 Apr 2018 17:44:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -9065,7 +9269,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -9080,22 +9284,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78b37c08-e453-4506-8e80-cba8ddf215a5
+      - req-02cc10b9-176f-4944-ae76-d079f72dc260
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-78b37c08-e453-4506-8e80-cba8ddf215a5
+      - req-02cc10b9-176f-4944-ae76-d079f72dc260
       Date:
-      - Mon, 09 Apr 2018 16:36:11 GMT
+      - Thu, 19 Apr 2018 17:44:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -9136,7 +9340,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -9151,22 +9355,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2669dc73-8603-44a7-9349-e1a8224716e8
+      - req-c539fb2e-843c-45ad-8774-89cfe85345e9
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-2669dc73-8603-44a7-9349-e1a8224716e8
+      - req-c539fb2e-843c-45ad-8774-89cfe85345e9
       Date:
-      - Mon, 09 Apr 2018 16:36:11 GMT
+      - Thu, 19 Apr 2018 17:44:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -9200,7 +9404,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -9215,27 +9419,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c8049bd-b67e-4e87-80ee-4c38d0a6b895
+      - req-4ddb284d-19e6-402f-a9db-644bfd89a80f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2c8049bd-b67e-4e87-80ee-4c38d0a6b895
+      - req-4ddb284d-19e6-402f-a9db-644bfd89a80f
       Date:
-      - Mon, 09 Apr 2018 16:36:11 GMT
+      - Thu, 19 Apr 2018 17:44:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9253,13 +9457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:11 GMT
+      - Thu, 19 Apr 2018 17:44:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-be7686e3-9a92-4fdc-97ed-b140cb310e3c
+      - req-4b2c0047-4d8f-4e3d-9944-d23a26f63966
       Content-Length:
       - '4131'
       Connection:
@@ -9268,10 +9472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:11.940175", "expires":
-        "2018-04-09T17:36:11Z", "id": "c8b78b9f11244e32807d268d87e63daf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:20.188870", "expires":
+        "2018-04-19T18:44:20Z", "id": "94f712bb458a45cfbe7c2d7eab368a36", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nRYD4HuJR7Sj3UW8IION3w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FDnRulP4SP2iufWlG_h5Mw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9315,7 +9519,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -9330,27 +9534,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8b78b9f11244e32807d268d87e63daf
+      - 94f712bb458a45cfbe7c2d7eab368a36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ebb7244e-36f0-4dbc-98da-1a7cbfd59482
+      - req-4b6bf824-3284-432e-995a-c301d2a67edb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ebb7244e-36f0-4dbc-98da-1a7cbfd59482
+      - req-4b6bf824-3284-432e-995a-c301d2a67edb
       Date:
-      - Mon, 09 Apr 2018 16:36:12 GMT
+      - Thu, 19 Apr 2018 17:44:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -9365,27 +9569,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d501bb0c18164bc585fc0884ae7929ce
+      - 68177361472b42febe2f39a03e27ab7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb9e71c3-966e-414b-883e-86eaf1e27b91
+      - req-015c7ff3-b6f8-4cfd-821e-0c66769e6855
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fb9e71c3-966e-414b-883e-86eaf1e27b91
+      - req-015c7ff3-b6f8-4cfd-821e-0c66769e6855
       Date:
-      - Mon, 09 Apr 2018 16:36:12 GMT
+      - Thu, 19 Apr 2018 17:44:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9403,13 +9607,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:12 GMT
+      - Thu, 19 Apr 2018 17:44:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7b151f5a-7bfe-4fb6-bfc9-445ae5580e57
+      - req-0d98d0db-4725-4fb8-abc1-533cbd36f9e4
       Content-Length:
       - '4118'
       Connection:
@@ -9418,10 +9622,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:13.072740", "expires":
-        "2018-04-09T17:36:13Z", "id": "ce9babba15ed45f1be7822d20458606f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:21.188052", "expires":
+        "2018-04-19T18:44:21Z", "id": "506603187e5e433db36058a0112829ea", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5dnjGAw2SjCIePyNI5oUyA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WwRdDM9MT5WCWrXkRn_b0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9465,7 +9669,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -9480,27 +9684,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9babba15ed45f1be7822d20458606f
+      - 506603187e5e433db36058a0112829ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b03e82e-2378-48b1-abe2-9ba5a8856337
+      - req-5da278b9-2efc-4a61-9a35-79519fcd581e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1b03e82e-2378-48b1-abe2-9ba5a8856337
+      - req-5da278b9-2efc-4a61-9a35-79519fcd581e
       Date:
-      - Mon, 09 Apr 2018 16:36:13 GMT
+      - Thu, 19 Apr 2018 17:44:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -9515,22 +9719,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26783dc6-d391-4c6f-bf73-7eff05a3db7f
+      - req-0d64c16b-d2ff-4620-ba06-a4877237b9b9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-26783dc6-d391-4c6f-bf73-7eff05a3db7f
+      - req-0d64c16b-d2ff-4620-ba06-a4877237b9b9
       Date:
-      - Mon, 09 Apr 2018 16:36:13 GMT
+      - Thu, 19 Apr 2018 17:44:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9545,7 +9749,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -9560,22 +9764,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-22e52c7e-8da5-45e6-b559-b7f53c829ffb
+      - req-ab6de9b2-25c8-45b3-92a3-b817f1f2c871
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-22e52c7e-8da5-45e6-b559-b7f53c829ffb
+      - req-ab6de9b2-25c8-45b3-92a3-b817f1f2c871
       Date:
-      - Mon, 09 Apr 2018 16:36:13 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9590,7 +9794,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -9605,27 +9809,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8b78b9f11244e32807d268d87e63daf
+      - 94f712bb458a45cfbe7c2d7eab368a36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e01a0741-35fa-4ba1-863e-a7f3ccb7402b
+      - req-31a7febe-a290-458f-9486-d4af038287f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e01a0741-35fa-4ba1-863e-a7f3ccb7402b
+      - req-31a7febe-a290-458f-9486-d4af038287f0
       Date:
-      - Mon, 09 Apr 2018 16:36:14 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -9640,27 +9844,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8b78b9f11244e32807d268d87e63daf
+      - 94f712bb458a45cfbe7c2d7eab368a36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2c7c26b-3cf7-45a4-80da-12a8d5c9a1d7
+      - req-2f91cc90-b080-4e31-8751-053437fe2dc0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f2c7c26b-3cf7-45a4-80da-12a8d5c9a1d7
+      - req-2f91cc90-b080-4e31-8751-053437fe2dc0
       Date:
-      - Mon, 09 Apr 2018 16:36:14 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -9675,27 +9879,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d501bb0c18164bc585fc0884ae7929ce
+      - 68177361472b42febe2f39a03e27ab7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-550b16bc-199a-48f0-81f0-3b630526f0f1
+      - req-394af059-6515-4339-9dfe-ba2b79aa5f9d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-550b16bc-199a-48f0-81f0-3b630526f0f1
+      - req-394af059-6515-4339-9dfe-ba2b79aa5f9d
       Date:
-      - Mon, 09 Apr 2018 16:36:14 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -9710,27 +9914,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d501bb0c18164bc585fc0884ae7929ce
+      - 68177361472b42febe2f39a03e27ab7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc31d2ae-7b40-41a4-b7fe-2cda7146b2e1
+      - req-558b70e9-aaa8-42b3-8d4a-17eb379fdf89
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fc31d2ae-7b40-41a4-b7fe-2cda7146b2e1
+      - req-558b70e9-aaa8-42b3-8d4a-17eb379fdf89
       Date:
-      - Mon, 09 Apr 2018 16:36:14 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -9745,27 +9949,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9babba15ed45f1be7822d20458606f
+      - 506603187e5e433db36058a0112829ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ec5ca21-6ed6-4d07-9f66-8aa07ce9ee39
+      - req-7b2af110-a658-4ec8-9672-d75ed92306fd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7ec5ca21-6ed6-4d07-9f66-8aa07ce9ee39
+      - req-7b2af110-a658-4ec8-9672-d75ed92306fd
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -9780,27 +9984,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9babba15ed45f1be7822d20458606f
+      - 506603187e5e433db36058a0112829ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e199ba4b-72b3-4b9a-bf17-21a1f6e02d14
+      - req-14df79d9-fdd6-4079-a4c9-7aad6523d351
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e199ba4b-72b3-4b9a-bf17-21a1f6e02d14
+      - req-14df79d9-fdd6-4079-a4c9-7aad6523d351
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -9815,27 +10019,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1c412498-8335-4fbc-b309-ba3f51211e1a
+      - req-8e094122-82d8-4ef8-a8f5-6b7894882ce4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1c412498-8335-4fbc-b309-ba3f51211e1a
+      - req-8e094122-82d8-4ef8-a8f5-6b7894882ce4
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -9850,27 +10054,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9075ecb1f1674dd0a9395f1983b5368c
+      - 8e842e05d9f64d358f10123c48757803
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5893ac7e-4bae-45a7-ae03-cd8cab810f77
+      - req-6598794a-405d-4617-a7e9-1775b0086379
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5893ac7e-4bae-45a7-ae03-cd8cab810f77
+      - req-6598794a-405d-4617-a7e9-1775b0086379
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -9885,27 +10089,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8b78b9f11244e32807d268d87e63daf
+      - 94f712bb458a45cfbe7c2d7eab368a36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ff0f33f3-eaf0-4764-99a1-4e23f617efda
+      - req-a678930c-ceea-4aaf-a43f-9006b387f1e2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ff0f33f3-eaf0-4764-99a1-4e23f617efda
+      - req-a678930c-ceea-4aaf-a43f-9006b387f1e2
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -9920,27 +10124,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8b78b9f11244e32807d268d87e63daf
+      - 94f712bb458a45cfbe7c2d7eab368a36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e0921586-7f10-4d88-a19d-a99ae144d505
+      - req-009844db-2f17-4bfd-a7e0-dc5269926e6a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e0921586-7f10-4d88-a19d-a99ae144d505
+      - req-009844db-2f17-4bfd-a7e0-dc5269926e6a
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -9955,27 +10159,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d501bb0c18164bc585fc0884ae7929ce
+      - 68177361472b42febe2f39a03e27ab7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0879c5ce-0bb6-4c28-be25-81a073a4bf52
+      - req-d872ba63-0d06-41f1-b05a-b9b660088915
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0879c5ce-0bb6-4c28-be25-81a073a4bf52
+      - req-d872ba63-0d06-41f1-b05a-b9b660088915
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -9990,27 +10194,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d501bb0c18164bc585fc0884ae7929ce
+      - 68177361472b42febe2f39a03e27ab7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b1f92a75-9693-4b5c-bd56-9a82219a830f
+      - req-32b9eede-33a8-414b-bf1e-2a3f25065e45
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b1f92a75-9693-4b5c-bd56-9a82219a830f
+      - req-32b9eede-33a8-414b-bf1e-2a3f25065e45
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -10025,27 +10229,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9babba15ed45f1be7822d20458606f
+      - 506603187e5e433db36058a0112829ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49a88265-9b2b-4322-bce6-eed844ae88aa
+      - req-163271fd-fa69-4098-9ade-21d51f86a8bc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-49a88265-9b2b-4322-bce6-eed844ae88aa
+      - req-163271fd-fa69-4098-9ade-21d51f86a8bc
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -10060,27 +10264,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9babba15ed45f1be7822d20458606f
+      - 506603187e5e433db36058a0112829ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-278805b5-3e3d-4c90-a216-9b50134b79cb
+      - req-b7d6eb75-4bbc-4c71-9afd-376bc4386c00
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-278805b5-3e3d-4c90-a216-9b50134b79cb
+      - req-b7d6eb75-4bbc-4c71-9afd-376bc4386c00
       Date:
-      - Mon, 09 Apr 2018 16:36:15 GMT
+      - Thu, 19 Apr 2018 17:44:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10098,13 +10302,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:16 GMT
+      - Thu, 19 Apr 2018 17:44:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5b919095-b7fe-437a-9db0-89829d190aa2
+      - req-f0a4b425-8866-44c5-9305-919c3b086040
       Content-Length:
       - '4170'
       Connection:
@@ -10113,10 +10317,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:16.375868", "expires":
-        "2018-04-09T17:36:16Z", "id": "ac8a53df3f384f1baca6e7f629ca3aae", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:24.376778", "expires":
+        "2018-04-19T18:44:24Z", "id": "ded365ae2b1b457883627c3aa41fda6d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["R8DV8hA3SEmMLo0ZOKYiZA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["laGtAAPXTW2d4x9D1on_zw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10161,7 +10365,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10179,13 +10383,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:16 GMT
+      - Thu, 19 Apr 2018 17:44:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d414731-73c1-4752-a50d-4211611fa500
+      - req-30986230-0751-465a-8d82-2683de4c815c
       Content-Length:
       - '4170'
       Connection:
@@ -10194,10 +10398,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:16.679572", "expires":
-        "2018-04-09T17:36:16Z", "id": "6b0a5eb5e8d5447dbbfb627ebe693ba0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:28.968515", "expires":
+        "2018-04-19T18:44:28Z", "id": "dbaf2ad4c83b46dda5d577e9ea56fd17", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4IEtIFjBRGSMHPAjm5pZfw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0FOpujZvT3CzpZCpNeB0ww"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10242,7 +10446,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10260,13 +10464,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:16 GMT
+      - Thu, 19 Apr 2018 17:44:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3e05e6b4-db98-4b69-9b72-537d3e600dd9
+      - req-82e491c3-f89d-43df-9c10-0beb26d2ae6e
       Content-Length:
       - '370'
       Connection:
@@ -10275,13 +10479,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:16.894098", "expires":
-        "2018-04-09T17:36:16Z", "id": "e74a3fa8d36d4f3b9916659086c77c78", "audit_ids":
-        ["sjij6cr6SIid-IC7OzwQ7A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:29.154900", "expires":
+        "2018-04-19T18:44:29Z", "id": "18a5c25cbaea4af28393fec27c99ce52", "audit_ids":
+        ["kU0sqnj2SLWLLTbboYwcZw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10296,20 +10500,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e74a3fa8d36d4f3b9916659086c77c78
+      - 18a5c25cbaea4af28393fec27c99ce52
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:17 GMT
+      - Thu, 19 Apr 2018 17:44:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d219a252-ad99-4ef1-b963-2ea808fc89b8
+      - req-9b25b20f-8ed4-466c-9015-3289c22b56b5
       Content-Length:
       - '500'
       Connection:
@@ -10326,13 +10530,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"e74a3fa8d36d4f3b9916659086c77c78"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"18a5c25cbaea4af28393fec27c99ce52"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10344,13 +10548,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:17 GMT
+      - Thu, 19 Apr 2018 17:44:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-62a4c3d4-4c7b-4341-8759-66e19ecdf625
+      - req-6dbaf3f4-8ab2-4c37-a85f-7ba4b80f35ba
       Content-Length:
       - '4143'
       Connection:
@@ -10359,11 +10563,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:17.320087", "expires":
-        "2018-04-09T17:36:16Z", "id": "74cea96c6d8841f3be7338e23e1ad9d2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:29.567188", "expires":
+        "2018-04-19T18:44:29Z", "id": "d2ca04dc74374037b115192881bae8e8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bwJ9oACqQzWCmf2pBwrVeg",
-        "sjij6cr6SIid-IC7OzwQ7A"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BBauMt-SS92JaXEKWgcxnQ",
+        "kU0sqnj2SLWLLTbboYwcZw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10407,7 +10611,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10422,20 +10626,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e74a3fa8d36d4f3b9916659086c77c78
+      - 18a5c25cbaea4af28393fec27c99ce52
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:17 GMT
+      - Thu, 19 Apr 2018 17:44:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7ec84cbb-b099-49b4-b850-66866f0e3817
+      - req-d86bb784-86a6-4edb-b6af-b740c83c303e
       Content-Length:
       - '500'
       Connection:
@@ -10452,7 +10656,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10470,13 +10674,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:17 GMT
+      - Thu, 19 Apr 2018 17:44:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-82bf77eb-bf63-40d7-bf91-4fc099559388
+      - req-5436e73c-24c0-4740-aa35-aac55a039046
       Content-Length:
       - '4117'
       Connection:
@@ -10485,10 +10689,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:17.726990", "expires":
-        "2018-04-09T17:36:17Z", "id": "fc50508983914f3697feac8c0e1129c3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:29.993367", "expires":
+        "2018-04-19T18:44:29Z", "id": "65248e1ac8834c7daf643b1725871fa5", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["r1Isr7l5QWapEl8jLq0i5w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FD-Y4xIWR1WvgeF2CvCrPw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10532,7 +10736,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10550,13 +10754,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:17 GMT
+      - Thu, 19 Apr 2018 17:44:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f167558-5d89-4a38-b0ad-a94c776d9775
+      - req-bf84ef1e-2e73-4910-9148-39f5874a404c
       Content-Length:
       - '4131'
       Connection:
@@ -10565,10 +10769,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:17.988016", "expires":
-        "2018-04-09T17:36:17Z", "id": "aa47d47625dc4523beb5b9538045f1ee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:30.314524", "expires":
+        "2018-04-19T18:44:30Z", "id": "dd11205b703145d6aaec3ce5252b91cd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["O_SWd6VPSf2mrDZ0wXyugQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aon4a9vmRbufsaEo05poKQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -10612,7 +10816,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10630,13 +10834,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:18 GMT
+      - Thu, 19 Apr 2018 17:44:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e4c0ceeb-a1e7-4c08-bb84-a56d6f07eb05
+      - req-5405d960-a0a6-4b5e-a36d-97644ca0ac04
       Content-Length:
       - '4118'
       Connection:
@@ -10645,10 +10849,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:18.250068", "expires":
-        "2018-04-09T17:36:18Z", "id": "ef1b96aadd554786a0cce8b01381afad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:30.571468", "expires":
+        "2018-04-19T18:44:30Z", "id": "06dff9ef63c74f12ba2d9d68c7de2252", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["iFfnfSyvQD6NxHb1nzRY_Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xeZIVddtQnqWB2NyFceWdw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10692,7 +10896,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10710,13 +10914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:18 GMT
+      - Thu, 19 Apr 2018 17:44:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a78e051a-0ecf-4f56-89e5-fd2023e471b6
+      - req-0fa70d4d-766f-49f1-8834-91d3bda7ff31
       Content-Length:
       - '4117'
       Connection:
@@ -10725,10 +10929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:18.520381", "expires":
-        "2018-04-09T17:36:18Z", "id": "66a635adb2ca40eeb972e85fb8a93504", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:30.761523", "expires":
+        "2018-04-19T18:44:30Z", "id": "7c336e38165a4c709a659e56cf003f42", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5cJDwMEhTVSAv1AyY_0hWQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["H-rGqlumTr2R1KxtoMAPcg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10772,7 +10976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -10787,7 +10991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66a635adb2ca40eeb972e85fb8a93504
+      - 7c336e38165a4c709a659e56cf003f42
   response:
     status:
       code: 200
@@ -10816,15 +11020,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txca4420c67e084787a6a21-005acb9682
+      - tx3accf20799844f8184417-005ad8d57e
       Date:
-      - Mon, 09 Apr 2018 16:36:18 GMT
+      - Thu, 19 Apr 2018 17:44:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -10839,7 +11043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66a635adb2ca40eeb972e85fb8a93504
+      - 7c336e38165a4c709a659e56cf003f42
   response:
     status:
       code: 200
@@ -10868,14 +11072,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txeb20151938194f1fa06c2-005acb9683
+      - txcda00ab4e4f64b6abbc8d-005ad8d580
       Date:
-      - Mon, 09 Apr 2018 16:36:19 GMT
+      - Thu, 19 Apr 2018 17:44:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10893,13 +11097,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:19 GMT
+      - Thu, 19 Apr 2018 17:44:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-568d771c-e615-4aad-815b-3198f837e313
+      - req-a67a63b2-d2f9-470a-a707-cf6f1292c68e
       Content-Length:
       - '4131'
       Connection:
@@ -10908,10 +11112,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:19.304099", "expires":
-        "2018-04-09T17:36:19Z", "id": "1a1c11b0f7fa4dc18e965eee84f5dab2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:32.346100", "expires":
+        "2018-04-19T18:44:32Z", "id": "ded2de136784428c94412a640bccbe6d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VPr1Oaq8TLuQidXAZ0v4KQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["NzKsCDE8Ts-4bB3C7KhebQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -10955,7 +11159,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -10970,7 +11174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a1c11b0f7fa4dc18e965eee84f5dab2
+      - ded2de136784428c94412a640bccbe6d
   response:
     status:
       code: 200
@@ -10983,22 +11187,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291779.63197'
+      - '1524159875.62773'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291779.63197'
+      - '1524159875.62773'
       X-Trans-Id:
-      - tx21e5d60d1f2f41f5b029e-005acb9683
+      - tx1c386e07ba6e4dd880ad1-005ad8d583
       Date:
-      - Mon, 09 Apr 2018 16:36:19 GMT
+      - Thu, 19 Apr 2018 17:44:35 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -11013,7 +11217,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0a5eb5e8d5447dbbfb627ebe693ba0
+      - dbaf2ad4c83b46dda5d577e9ea56fd17
   response:
     status:
       code: 200
@@ -11026,22 +11230,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291779.88044'
+      - '1524159875.80615'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291779.88044'
+      - '1524159875.80615'
       X-Trans-Id:
-      - tx687ea131c4384fea9c3d0-005acb9683
+      - tx4a12d8d079fa49438aa6d-005ad8d583
       Date:
-      - Mon, 09 Apr 2018 16:36:19 GMT
+      - Thu, 19 Apr 2018 17:44:35 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11059,13 +11263,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:36:19 GMT
+      - Thu, 19 Apr 2018 17:44:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-72a9188f-1cac-4aca-831e-6e6cbf596299
+      - req-7a1453aa-3732-46e9-b626-31b6a6517806
       Content-Length:
       - '4118'
       Connection:
@@ -11074,10 +11278,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:36:20.140393", "expires":
-        "2018-04-09T17:36:20Z", "id": "b5ba16b8754b475793f0e791b6a499dd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:36.164964", "expires":
+        "2018-04-19T18:44:36Z", "id": "679f919a8d5b40d2b80fe6dbaf057965", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["PRhViJDDS3q25zYsY66x9A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["W1EqV8rlT1u4KTa75FGsCw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11121,7 +11325,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -11136,7 +11340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b5ba16b8754b475793f0e791b6a499dd
+      - 679f919a8d5b40d2b80fe6dbaf057965
   response:
     status:
       code: 200
@@ -11149,22 +11353,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291780.45771'
+      - '1524159876.37335'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291780.45771'
+      - '1524159876.37335'
       X-Trans-Id:
-      - tx6895a448726641a38e4a7-005acb9684
+      - tx3673f647910042fb81ef8-005ad8d584
       Date:
-      - Mon, 09 Apr 2018 16:36:20 GMT
+      - Thu, 19 Apr 2018 17:44:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -11179,7 +11383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66a635adb2ca40eeb972e85fb8a93504
+      - 7c336e38165a4c709a659e56cf003f42
   response:
     status:
       code: 200
@@ -11200,9 +11404,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx017016f248ed4ec496ac8-005acb9684
+      - tx9e06e13cbc44485f9a90b-005ad8d584
       Date:
-      - Mon, 09 Apr 2018 16:36:20 GMT
+      - Thu, 19 Apr 2018 17:44:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -11212,7 +11416,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -11227,7 +11431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66a635adb2ca40eeb972e85fb8a93504
+      - 7c336e38165a4c709a659e56cf003f42
   response:
     status:
       code: 200
@@ -11248,14 +11452,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0d60005700e74b7aaf9e0-005acb9684
+      - tx5ab2b9472bea43ed81c9e-005ad8d584
       Date:
-      - Mon, 09 Apr 2018 16:36:20 GMT
+      - Thu, 19 Apr 2018 17:44:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -11270,7 +11474,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66a635adb2ca40eeb972e85fb8a93504
+      - 7c336e38165a4c709a659e56cf003f42
   response:
     status:
       code: 200
@@ -11291,12 +11495,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txdf32ffddde9644bc8c87a-005acb9684
+      - txefdb547d09d44467bc512-005ad8d584
       Date:
-      - Mon, 09 Apr 2018 16:36:20 GMT
+      - Thu, 19 Apr 2018 17:44:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:36:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:04 GMT
+      - Thu, 19 Apr 2018 17:37:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a894893c-0dda-4bcd-be02-750af80aec01
+      - req-d415c8f2-6d62-499e-9ca1-b249ddfdc886
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:04.667383Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:56.005992Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rGUIy9s5RHqRd668w9jkkQ"],
-        "issued_at": "2018-04-09T16:28:04.667457Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r2R9XqXuQde6itmcpKcrsw"],
+        "issued_at": "2018-04-19T17:37:56.006060Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:04 GMT
+      - Thu, 19 Apr 2018 17:37:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-cff7d573-dad9-4edc-8d01-ece819e6ad9d
+      - req-071d04ad-e451-480a-991b-e96826cb785c
       Date:
-      - Mon, 09 Apr 2018 16:28:04 GMT
+      - Thu, 19 Apr 2018 17:37:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:05 GMT
+      - Thu, 19 Apr 2018 17:37:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6ded4b7-1391-4e02-a27e-ab5a26eb1036
+      - req-84117fb1-30df-4097-b970-0c8020c2eaed
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:05.318704Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:56.944438Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KDm3OLUSQg2BnYVTr6NhIw"],
-        "issued_at": "2018-04-09T16:28:05.318829Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BhCBSVNFQwCJSPkKPSOZ3g"],
+        "issued_at": "2018-04-19T17:37:56.944504Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-585e46a9-8594-4809-8c8a-4d328be1baf2
+      - req-c1b6078d-6616-45d7-a321-9aa8c46b6c9a
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-585e46a9-8594-4809-8c8a-4d328be1baf2
+      - req-c1b6078d-6616-45d7-a321-9aa8c46b6c9a
       Date:
-      - Mon, 09 Apr 2018 16:28:05 GMT
+      - Thu, 19 Apr 2018 17:37:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:05 GMT
+      - Thu, 19 Apr 2018 17:37:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9bf83b3fe204d618b99f2f0d4b32b5f
+      - 02f136c1a1484773bfd977f5f99b554e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e638443f-e704-48cd-a440-b8e0d6c27d62
+      - req-02580417-de08-4cd1-b626-1df7326889fc
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +381,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:28:05.754861Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:37:57.355453Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YWgaLSSzRX6QC3M4LfHOvQ"],
-        "issued_at": "2018-04-09T16:28:05.754926Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I6JIISUZShKDiGASjudwVA"],
+        "issued_at": "2018-04-19T17:37:57.355514Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -401,20 +401,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9bf83b3fe204d618b99f2f0d4b32b5f
+      - 02f136c1a1484773bfd977f5f99b554e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:05 GMT
+      - Thu, 19 Apr 2018 17:37:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0d3026bd-e8a0-4f7e-8a2f-679e3ed8ac6e
+      - req-d226a888-190e-4a71-9653-c6675b7a2fb1
       Content-Length:
       - '2457'
       Connection:
@@ -447,13 +447,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"e9bf83b3fe204d618b99f2f0d4b32b5f"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"02f136c1a1484773bfd977f5f99b554e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -465,15 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:06 GMT
+      - Thu, 19 Apr 2018 17:37:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 67b6827b041246e29576ba7fe2416fc6
+      - 9ae1e9e3abc04788b0e7e51b1eb00443
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fdf7cad2-a3b1-4d5e-96a9-5ac0e78c0573
+      - req-1b198d69-9657-491e-87d0-d7e795e808aa
       Content-Length:
       - '7313'
       Connection:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:05.754861Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:57.355453Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v4iI52o1RCyDQm3V0gflxA",
-        "YWgaLSSzRX6QC3M4LfHOvQ"], "issued_at": "2018-04-09T16:28:06.225607Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kcbcvWmNSdWvShPsQH08Jg",
+        "I6JIISUZShKDiGASjudwVA"], "issued_at": "2018-04-19T17:37:57.861575Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -582,20 +582,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 67b6827b041246e29576ba7fe2416fc6
+      - 9ae1e9e3abc04788b0e7e51b1eb00443
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:06 GMT
+      - Thu, 19 Apr 2018 17:37:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ce2f9de-4b1b-448c-8d59-e722bd90cf8d
+      - req-da160b34-575d-42a1-a8c5-2b4b802b1f29
       Content-Length:
       - '2179'
       Connection:
@@ -628,7 +628,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -646,15 +646,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:06 GMT
+      - Thu, 19 Apr 2018 17:37:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-83108b16-e48c-41b7-9839-7777166c7bd4
+      - req-86173bd0-deb8-4229-ac85-c246755f5150
       Content-Length:
       - '7278'
       Connection:
@@ -666,7 +666,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:06.697548Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:58.459662Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -745,10 +745,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OoaYrp75Qg2w5Hf2mnPb3Q"],
-        "issued_at": "2018-04-09T16:28:06.697615Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L8IKcerYQyKfp7hY75_Q3w"],
+        "issued_at": "2018-04-19T17:37:58.459722Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:06 GMT
+      - Thu, 19 Apr 2018 17:37:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -801,15 +801,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:06 GMT
+      - Thu, 19 Apr 2018 17:37:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a3fc7bae-d613-436e-bf04-7644b3cf22e2
+      - req-3e6c0cb3-98ab-43cc-b3dc-80317b6802d3
       Content-Length:
       - '7278'
       Connection:
@@ -821,7 +821,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:07.128984Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:58.906300Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -900,10 +900,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["s4RYvihYRYGN8RLutlwfZw"],
-        "issued_at": "2018-04-09T16:28:07.129054Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mlSCGqNMSJeefWseveAn7A"],
+        "issued_at": "2018-04-19T17:37:58.906375Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -918,7 +918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
   response:
     status:
       code: 200
@@ -929,7 +929,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:07 GMT
+      - Thu, 19 Apr 2018 17:37:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -938,7 +938,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -956,15 +956,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:08 GMT
+      - Thu, 19 Apr 2018 17:37:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f3d8e641-6a72-41c8-b260-0539aab179c5
+      - req-2f9bcb4a-04d1-4fef-8749-56386229c502
       Content-Length:
       - '7264'
       Connection:
@@ -976,7 +976,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:08.528978Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:59.302823Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1055,10 +1055,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jaEhbHYNSDuRaaIOhpuGYA"],
-        "issued_at": "2018-04-09T16:28:08.529042Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["znzn0WnSQRG0VB370iaztQ"],
+        "issued_at": "2018-04-19T17:37:59.302891Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
   response:
     status:
       code: 200
@@ -1084,7 +1084,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:08 GMT
+      - Thu, 19 Apr 2018 17:37:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1093,7 +1093,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1111,15 +1111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:08 GMT
+      - Thu, 19 Apr 2018 17:37:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-371d3236-0926-4239-b722-b20ddbb4e9bd
+      - req-94105e48-74e3-4abe-80f4-60a85432d6fd
       Content-Length:
       - '7278'
       Connection:
@@ -1131,7 +1131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:08.981824Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:59.680621Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1210,10 +1210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TnAdlzruTyOc8RFJ9H6zVg"],
-        "issued_at": "2018-04-09T16:28:08.981898Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vpxLRyGmT9yJlV17vswzNg"],
+        "issued_at": "2018-04-19T17:37:59.680696Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1228,7 +1228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
   response:
     status:
       code: 200
@@ -1239,7 +1239,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:09 GMT
+      - Thu, 19 Apr 2018 17:37:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1248,7 +1248,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1266,15 +1266,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:09 GMT
+      - Thu, 19 Apr 2018 17:37:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5375ecc0-9c64-488c-a235-0b1a6bbc14e3
+      - req-1ae98986-47ee-4ef2-82f9-baf61eed0d59
       Content-Length:
       - '7265'
       Connection:
@@ -1286,7 +1286,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:09.401486Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:00.063435Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1365,10 +1365,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JNARXoqaQ2q75zBD6V52pA"],
-        "issued_at": "2018-04-09T16:28:09.401555Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6OwSYqxpSEWC42wpjR4gzA"],
+        "issued_at": "2018-04-19T17:38:00.063509Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1383,7 +1383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
   response:
     status:
       code: 200
@@ -1394,7 +1394,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:09 GMT
+      - Thu, 19 Apr 2018 17:38:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1403,7 +1403,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1421,15 +1421,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:09 GMT
+      - Thu, 19 Apr 2018 17:38:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c0bc75b2-cecc-41f9-9e7c-0bb995d3836c
+      - req-b92c325c-8ddd-48eb-853a-dc32fcdc2d8a
       Content-Length:
       - '7278'
       Connection:
@@ -1441,7 +1441,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:10.067447Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:00.538514Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1520,10 +1520,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qum-P2_5Sg-9jJcfs_Jl_g"],
-        "issued_at": "2018-04-09T16:28:10.067517Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f0CbOJ5MRs6c9Mcte_IFkA"],
+        "issued_at": "2018-04-19T17:38:00.538592Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1538,7 +1538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
   response:
     status:
       code: 200
@@ -1549,7 +1549,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:28:10 GMT
+      - Thu, 19 Apr 2018 17:38:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1558,7 +1558,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1573,7 +1573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1586,26 +1586,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-037e7818-222d-4ebb-b2d2-03c78a1728a1
+      - req-36bc60b0-d230-45c9-ae8b-7c9045fb7e58
       Date:
-      - Mon, 09 Apr 2018 16:28:10 GMT
+      - Thu, 19 Apr 2018 17:38:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1620,7 +1620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1633,26 +1633,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-55251eae-efa5-48cc-a42b-a5416a32719f
+      - req-64dc774a-6368-4d95-8f64-c00b49654343
       Date:
-      - Mon, 09 Apr 2018 16:28:10 GMT
+      - Thu, 19 Apr 2018 17:38:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1667,7 +1667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1680,26 +1680,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-17c66858-c501-4059-930e-1447ad6377c0
+      - req-3280106a-32ce-4065-9db5-07c96ecff3ad
       Date:
-      - Mon, 09 Apr 2018 16:28:10 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1714,7 +1714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1727,26 +1727,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-71ea19ae-99ba-401e-ab31-61747f8dd67a
+      - req-eba72100-d401-4e0b-829a-0affa9289362
       Date:
-      - Mon, 09 Apr 2018 16:28:10 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1761,7 +1761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1774,26 +1774,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-79a4b6c8-c4c3-4245-94b9-050bc171bec7
+      - req-9d5b3741-4e12-403b-88c8-55ba5e6329b2
       Date:
-      - Mon, 09 Apr 2018 16:28:11 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1808,7 +1808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1821,26 +1821,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d17e1600-c2a8-4463-8581-252552652558
+      - req-9457a35f-4e08-4f2e-83f2-0b302b987a82
       Date:
-      - Mon, 09 Apr 2018 16:28:11 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1855,7 +1855,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1868,26 +1868,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-20b44c7f-e1fc-4e02-8114-8fb79ecc4d7e
+      - req-bfca5ac7-aa96-4a13-9a79-7dc073e3433c
       Date:
-      - Mon, 09 Apr 2018 16:28:11 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1902,7 +1902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1915,26 +1915,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a41c7f23-d908-4995-a0d4-f74b75c18b75
+      - req-931a6379-c05a-4e6e-9553-fa21f00cdc1e
       Date:
-      - Mon, 09 Apr 2018 16:28:11 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1949,7 +1949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1962,26 +1962,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2fc9fb01-f5c4-47be-b816-5dac6fde07c9
+      - req-76bcd528-5ef2-4717-879b-19f899d2baf4
       Date:
-      - Mon, 09 Apr 2018 16:28:11 GMT
+      - Thu, 19 Apr 2018 17:38:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1996,7 +1996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2009,26 +2009,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-8b921625-d217-496f-b909-f9e129cb40a8
+      - req-88dde998-5cd6-4971-83b3-5ef1f37281ce
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -2043,7 +2043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2056,26 +2056,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ebaec140-46fa-4cba-91f2-1ac42ef5e3cf
+      - req-bc5f68a6-54b4-4bd0-8e39-bf74a1da3787
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -2090,7 +2090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2103,26 +2103,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-75bdf0b4-6d64-4ace-b2bd-dc9b121dd670
+      - req-e2d83435-3e60-4695-82e0-a960e21af7ad
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -2137,7 +2137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2150,26 +2150,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c454a156-4e2b-436e-bf52-a67191895f83
+      - req-73bf73c0-d3c3-441a-bbb9-62c94ca533c2
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:38:02.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2184,7 +2184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2197,26 +2197,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-74b979c6-0d3f-41c3-9eab-21e2c08eb610
+      - req-b303d944-109e-450d-99f2-dcecd7905786
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:28:09.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:38:02.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:28:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:38:02.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:28:04.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:54.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:28:09.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:52.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:28:09.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:54.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000
@@ -2231,7 +2231,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2244,9 +2244,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-455c5b86-19af-444e-b96e-fc5c99bd093e
+      - req-2d6aabba-d243-45bb-b502-a4afd342a3b1
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/1",
@@ -2260,7 +2260,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=2
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-18e3c166-9216-4797-b4d5-c253502179ff
+      - req-51f2788e-554f-48c3-9578-19b0a5b0de51
       Date:
-      - Mon, 09 Apr 2018 16:28:12 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/3",
@@ -2304,7 +2304,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=4
@@ -2319,7 +2319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2332,9 +2332,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-c2244368-02a3-41f2-a137-b06abaa11277
+      - req-d7d0de69-d50a-4bc1-8315-7225bfb6f087
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/5",
@@ -2349,7 +2349,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=6
@@ -2364,7 +2364,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2377,14 +2377,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-528c90cd-4f48-4dd1-8118-937a1d9c4843
+      - req-6d7cf3cf-aeea-489f-a90f-5b65b84e60dd
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000
@@ -2399,7 +2399,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2412,9 +2412,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-7c5c67c8-1f35-485c-8f10-c8f6f4b3f8af
+      - req-0b3cefae-8e51-43ec-ad1a-51ee46ff2a7d
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/1",
@@ -2428,7 +2428,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=2
@@ -2443,7 +2443,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2456,9 +2456,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-8daf978f-ea1a-4fe1-bf8e-874ff7690ca9
+      - req-57eb9027-71f4-4496-879e-dcc9d82046f2
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/3",
@@ -2472,7 +2472,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=4
@@ -2487,7 +2487,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2500,9 +2500,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-a7239128-b052-43b3-ad50-23ae7e1fec4a
+      - req-4a925638-9317-48dc-8f13-1c4b6c524824
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/5",
@@ -2517,7 +2517,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=6
@@ -2532,7 +2532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2545,14 +2545,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e56abfdf-9455-4f10-b8b7-91c859ed56b6
+      - req-9f4c6b4a-898b-4ad2-ace8-45e61471c209
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000
@@ -2567,7 +2567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2580,9 +2580,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-96708d25-6cc8-4fe6-b47f-d5f651067de3
+      - req-d457cec0-0971-4673-b064-4739649e897c
       Date:
-      - Mon, 09 Apr 2018 16:28:13 GMT
+      - Thu, 19 Apr 2018 17:38:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/1",
@@ -2596,7 +2596,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=2
@@ -2611,7 +2611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2624,9 +2624,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-220e564d-8d45-40a7-b3db-3c8e17371f18
+      - req-8a38a14c-0a75-4cea-a4f7-8da2e4b7aec2
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/3",
@@ -2640,7 +2640,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=4
@@ -2655,7 +2655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2668,9 +2668,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-f12d21ee-81f4-4669-a88c-71ba82ac4a99
+      - req-38db19fe-838f-45d8-8fe9-41210c93040c
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/5",
@@ -2685,7 +2685,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=6
@@ -2700,7 +2700,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2713,9 +2713,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-c7740a77-76e7-4035-bfa0-505dda81b5b8
+      - req-9c199d9f-09e7-4d52-9e3c-90e3ec59034c
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2725,7 +2725,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000
@@ -2740,7 +2740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2753,9 +2753,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-15708445-689f-48c8-8f9e-6d4c80a56ae5
+      - req-3ba32ab0-0613-4c34-80e5-16c8dbfc3d62
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/1",
@@ -2769,7 +2769,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=2
@@ -2784,7 +2784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2797,9 +2797,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-fba265d7-ab5e-4ac7-8655-fc9af8e3ceb1
+      - req-c4fc86c5-daa9-48cf-bb31-179c74f26b3a
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/3",
@@ -2813,7 +2813,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=4
@@ -2828,7 +2828,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2841,9 +2841,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-7118679b-5df3-4df6-a0b7-b9b3422f8c1a
+      - req-0b0f74f3-c110-4440-9df2-963fbe3ae56f
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/5",
@@ -2858,7 +2858,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=6
@@ -2873,7 +2873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2886,14 +2886,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-c646ceb0-95c2-42cf-80d9-4c2250066d26
+      - req-4a25545a-d1c2-403a-85e4-f91c8c10d088
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000
@@ -2908,7 +2908,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2921,9 +2921,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-8195bfe4-3e06-4eb3-95a3-9d9442a6823b
+      - req-52272163-501e-4d96-8cef-ace14f403784
       Date:
-      - Mon, 09 Apr 2018 16:28:14 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2937,7 +2937,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=2
@@ -2952,7 +2952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2965,9 +2965,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-ffcf705e-40f6-4572-a3bc-dd06f614fef6
+      - req-69b7a1e0-184b-4ce8-8fa5-2a7804ffa82b
       Date:
-      - Mon, 09 Apr 2018 16:28:15 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2981,7 +2981,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=4
@@ -2996,7 +2996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3009,9 +3009,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-b5074261-6c33-4bd7-a428-cff94ffd5631
+      - req-162e7a65-0d18-4c2c-ab67-a2c4fec743f3
       Date:
-      - Mon, 09 Apr 2018 16:28:15 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -3026,7 +3026,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=6
@@ -3041,7 +3041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3054,14 +3054,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-cfa9d096-94f9-4887-8524-0168b4b04387
+      - req-720be182-540d-4ae9-97f2-d0d6f15526e2
       Date:
-      - Mon, 09 Apr 2018 16:28:15 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000
@@ -3076,7 +3076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3089,9 +3089,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-b53f7cd3-885b-4df7-85e3-c1e41fe48271
+      - req-f7447925-7647-4049-830d-2782704f2c5e
       Date:
-      - Mon, 09 Apr 2018 16:28:15 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/1",
@@ -3105,7 +3105,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=2
@@ -3120,7 +3120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3133,9 +3133,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-545042bd-b491-46b5-973b-17f0dd1cfc8e
+      - req-4c396fc5-2c6d-46aa-b787-c61c37f8b296
       Date:
-      - Mon, 09 Apr 2018 16:28:15 GMT
+      - Thu, 19 Apr 2018 17:38:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/3",
@@ -3149,7 +3149,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=4
@@ -3164,7 +3164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3177,9 +3177,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-90dfea75-6c87-45cb-b630-c34db46abe60
+      - req-6d25183e-a26a-4ec0-8a5b-a4864e145d61
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/5",
@@ -3194,7 +3194,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=6
@@ -3209,7 +3209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3222,14 +3222,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-9070ad4f-9cb4-43bb-b826-b1e33935fa32
+      - req-7f4d14b3-cc07-4f2a-9dd4-ccffb9e94756
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000
@@ -3244,7 +3244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3257,9 +3257,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-6b8206ac-b2f0-43fd-ac3a-a219f59e8d2a
+      - req-3fb96f7e-de5f-4134-8080-ce6502ab3ea4
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/1",
@@ -3273,7 +3273,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=2
@@ -3288,7 +3288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3301,9 +3301,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-6f6d3c5d-7b09-4b57-b023-8381518cb3a7
+      - req-0fe9df58-f82f-4f4a-b18a-3d47411d5f1d
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/3",
@@ -3317,7 +3317,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=4
@@ -3332,7 +3332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3345,9 +3345,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-79a0d992-0842-4d27-bea6-8ae91bf50e66
+      - req-07e1cf28-1e1b-4861-8c88-72820f0e2de6
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/5",
@@ -3362,7 +3362,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=6
@@ -3377,7 +3377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3390,14 +3390,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-989a87d5-ed7e-4131-9ff9-f8948b9bb9cb
+      - req-107c2f5f-a726-487a-91df-401e6ede8d09
       Date:
-      - Mon, 09 Apr 2018 16:28:16 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -3412,7 +3412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3425,15 +3425,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-442d2b53-f456-48b9-b01b-a897695e25d7
+      - req-c12936ca-d171-4503-a026-ab88c155dc8b
       Date:
-      - Mon, 09 Apr 2018 16:28:17 GMT
+      - Thu, 19 Apr 2018 17:38:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3451,15 +3451,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:17 GMT
+      - Thu, 19 Apr 2018 17:38:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 53ea50ce90014750ad9ca62a05e09ca1
+      - e128e913a00c4339a4d6fa7040bf6cff
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3b8bcd92-465d-4fc3-a262-08af8eca7273
+      - req-4aa8936d-d821-4963-ba1a-329c045ec069
       Content-Length:
       - '7311'
       Connection:
@@ -3471,7 +3471,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:17.391829Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:07.279650Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3550,10 +3550,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d2iPHwUDRRKqUxb-5U35QQ"],
-        "issued_at": "2018-04-09T16:28:17.391898Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Gsb-A8vaSxqi-KonIEuUSw"],
+        "issued_at": "2018-04-19T17:38:07.279719Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -3568,7 +3568,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53ea50ce90014750ad9ca62a05e09ca1
+      - e128e913a00c4339a4d6fa7040bf6cff
   response:
     status:
       code: 300
@@ -3579,7 +3579,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:28:17 GMT
+      - Thu, 19 Apr 2018 17:38:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -3592,7 +3592,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3610,15 +3610,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:17 GMT
+      - Thu, 19 Apr 2018 17:38:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d9eb35771083481d816b43d71c9af8d2
+      - cc501547aac54c2ba80559a970967a46
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3e1fa00d-a317-431f-8375-72c7822a864f
+      - req-d3f7a359-3d3f-441b-90e8-3ca4ac370f43
       Content-Length:
       - '7278'
       Connection:
@@ -3630,7 +3630,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:17.847117Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:07.654879Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3709,10 +3709,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["W94FdrpRTMeDbfsPs2WZrg"],
-        "issued_at": "2018-04-09T16:28:17.847187Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NBlkWptXQlixxvswQ0kNJQ"],
+        "issued_at": "2018-04-19T17:38:07.654953Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3727,7 +3727,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9eb35771083481d816b43d71c9af8d2
+      - cc501547aac54c2ba80559a970967a46
   response:
     status:
       code: 200
@@ -3738,9 +3738,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4cbcfaac-e181-44f0-a059-4b74d57857e5
+      - req-ccaa235c-acf9-4fc0-932c-5b7d79bb8b83
       Date:
-      - Mon, 09 Apr 2018 16:28:18 GMT
+      - Thu, 19 Apr 2018 17:38:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3782,7 +3782,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3797,7 +3797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9eb35771083481d816b43d71c9af8d2
+      - cc501547aac54c2ba80559a970967a46
   response:
     status:
       code: 200
@@ -3808,14 +3808,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-59ff819d-90ac-41ea-b535-62f21ed7068b
+      - req-c112f647-511a-43a8-a516-690818028690
       Date:
-      - Mon, 09 Apr 2018 16:28:18 GMT
+      - Thu, 19 Apr 2018 17:38:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3833,15 +3833,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:18 GMT
+      - Thu, 19 Apr 2018 17:38:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee9d2513586d4205a1e4d4876fde279b
+      - 126977c19cd94bfb889d4733224da32e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-86d2a3fe-baa0-4e11-b8e3-2555201de186
+      - req-8b31e347-ed70-4698-8a85-a9c1b33bf9c5
       Content-Length:
       - '7278'
       Connection:
@@ -3853,7 +3853,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:18.729057Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:08.464176Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3932,10 +3932,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MB3FNwlTQnyA-BiiemjCZw"],
-        "issued_at": "2018-04-09T16:28:18.729140Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IYXLNS8fQqeMhyktmbZmyw"],
+        "issued_at": "2018-04-19T17:38:08.464245Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3950,7 +3950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee9d2513586d4205a1e4d4876fde279b
+      - 126977c19cd94bfb889d4733224da32e
   response:
     status:
       code: 200
@@ -3961,9 +3961,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f2ef1dc3-3032-4f80-9655-c5de82736e59
+      - req-96d80f38-9b43-49bb-8f2e-eaeea6d518e0
       Date:
-      - Mon, 09 Apr 2018 16:28:19 GMT
+      - Thu, 19 Apr 2018 17:38:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -4005,7 +4005,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4020,7 +4020,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee9d2513586d4205a1e4d4876fde279b
+      - 126977c19cd94bfb889d4733224da32e
   response:
     status:
       code: 200
@@ -4031,14 +4031,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f785f23e-cb82-4cb6-9666-14c56855ab9d
+      - req-bd31d0a6-fd46-45fd-b17a-fc5c74357bc2
       Date:
-      - Mon, 09 Apr 2018 16:28:19 GMT
+      - Thu, 19 Apr 2018 17:38:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4056,15 +4056,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:19 GMT
+      - Thu, 19 Apr 2018 17:38:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a3820030a7647a182105fef0f9e37bf
+      - '049b5704ffe84117937b613a99c7a7d5'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43a2b44b-8bf3-4da3-adcd-3228077da71a
+      - req-769ec71e-c145-4938-a566-b0dde1dd1339
       Content-Length:
       - '7264'
       Connection:
@@ -4076,7 +4076,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:19.519628Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:09.161587Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4155,10 +4155,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9gzzGOfCRjay8AkVLty9-g"],
-        "issued_at": "2018-04-09T16:28:19.519690Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ygtTh4O4TzyzZkc4wIragA"],
+        "issued_at": "2018-04-19T17:38:09.161655Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -4173,7 +4173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a3820030a7647a182105fef0f9e37bf
+      - '049b5704ffe84117937b613a99c7a7d5'
   response:
     status:
       code: 200
@@ -4184,9 +4184,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c49b5241-1a8c-4e74-b592-2ab5acbab1e6
+      - req-ee089568-0df2-43ae-b01f-29e422af34d2
       Date:
-      - Mon, 09 Apr 2018 16:28:19 GMT
+      - Thu, 19 Apr 2018 17:38:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -4228,7 +4228,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4243,7 +4243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a3820030a7647a182105fef0f9e37bf
+      - '049b5704ffe84117937b613a99c7a7d5'
   response:
     status:
       code: 200
@@ -4254,14 +4254,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3afd282b-eb09-434e-90b5-67a6425c9f46
+      - req-ff2050fe-5068-47f9-9f5c-1b3e83179562
       Date:
-      - Mon, 09 Apr 2018 16:28:19 GMT
+      - Thu, 19 Apr 2018 17:38:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4279,15 +4279,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:20 GMT
+      - Thu, 19 Apr 2018 17:38:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 771bebbf27e44b1e934ad28ad010aee0
+      - ed1ebaa1b63f417a8ad1359cf4816703
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40e1b00b-8d84-47df-891d-1101853b2dba
+      - req-a7be2896-9de0-4352-936c-17df59c0e065
       Content-Length:
       - '7278'
       Connection:
@@ -4299,7 +4299,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:20.319372Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:09.863002Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4378,10 +4378,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ri3CmJO3Qf-usnAGJR-DOg"],
-        "issued_at": "2018-04-09T16:28:20.319441Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G8QuNVwlSdmcqK4YVXZEng"],
+        "issued_at": "2018-04-19T17:38:09.863070Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -4396,7 +4396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 771bebbf27e44b1e934ad28ad010aee0
+      - ed1ebaa1b63f417a8ad1359cf4816703
   response:
     status:
       code: 200
@@ -4407,9 +4407,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9b6629de-fc15-4a72-ab0a-34be6685d114
+      - req-efc23985-85e2-486b-83b7-c092a16e8e43
       Date:
-      - Mon, 09 Apr 2018 16:28:20 GMT
+      - Thu, 19 Apr 2018 17:38:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -4451,7 +4451,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4466,7 +4466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 771bebbf27e44b1e934ad28ad010aee0
+      - ed1ebaa1b63f417a8ad1359cf4816703
   response:
     status:
       code: 200
@@ -4477,14 +4477,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6f7f8580-a171-4d99-9660-748324ee659e
+      - req-3281e6c1-36b3-4a26-91e3-ffb6bc4e5a7a
       Date:
-      - Mon, 09 Apr 2018 16:28:20 GMT
+      - Thu, 19 Apr 2018 17:38:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -4499,7 +4499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53ea50ce90014750ad9ca62a05e09ca1
+      - e128e913a00c4339a4d6fa7040bf6cff
   response:
     status:
       code: 200
@@ -4510,9 +4510,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3edf6319-bb04-477c-8991-cdf03c986d55
+      - req-2aa01e21-95de-42eb-8f57-0fc198061acd
       Date:
-      - Mon, 09 Apr 2018 16:28:21 GMT
+      - Thu, 19 Apr 2018 17:38:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -4554,7 +4554,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4569,7 +4569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53ea50ce90014750ad9ca62a05e09ca1
+      - e128e913a00c4339a4d6fa7040bf6cff
   response:
     status:
       code: 200
@@ -4580,14 +4580,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-70b80509-42f4-489d-ae28-ac5939584c93
+      - req-cb4f5542-cc44-461a-8e06-7e0617d7a711
       Date:
-      - Mon, 09 Apr 2018 16:28:21 GMT
+      - Thu, 19 Apr 2018 17:38:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4605,15 +4605,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:21 GMT
+      - Thu, 19 Apr 2018 17:38:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 12fe7d4353534edd86159067b6fdb101
+      - afb8811ce8df48448a4f8c8c607615f8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7b8c5ee-d36a-4fd4-b21d-9d469f065173
+      - req-56644018-8733-46e8-a6e6-086533e5468b
       Content-Length:
       - '7265'
       Connection:
@@ -4625,7 +4625,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:21.783866Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:11.027208Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4704,10 +4704,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YhNMdACoSoW8o9Tn-oXgjw"],
-        "issued_at": "2018-04-09T16:28:21.783937Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SZva-CgjTbmVrq_7gWpB2Q"],
+        "issued_at": "2018-04-19T17:38:11.027272Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -4722,7 +4722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12fe7d4353534edd86159067b6fdb101
+      - afb8811ce8df48448a4f8c8c607615f8
   response:
     status:
       code: 200
@@ -4733,9 +4733,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1b1ef7d3-4458-48b5-85b7-9c835a5fad08
+      - req-39acd822-214a-4d90-934c-d58bcedd94c2
       Date:
-      - Mon, 09 Apr 2018 16:28:22 GMT
+      - Thu, 19 Apr 2018 17:38:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -4777,7 +4777,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4792,7 +4792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12fe7d4353534edd86159067b6fdb101
+      - afb8811ce8df48448a4f8c8c607615f8
   response:
     status:
       code: 200
@@ -4803,14 +4803,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-68d637c8-d696-4b3f-9c0e-2df7ef4ca78f
+      - req-d709edca-03fb-41e0-8589-a3ba43ef3ccd
       Date:
-      - Mon, 09 Apr 2018 16:28:22 GMT
+      - Thu, 19 Apr 2018 17:38:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4828,15 +4828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:22 GMT
+      - Thu, 19 Apr 2018 17:38:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7a4dbcb97afe4334ae7f438c302627ed
+      - d4cf48bc88194aa2a48677f5b95dea3b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fc4e09e6-f5fb-4c8f-838e-9b7e9adaf73e
+      - req-393c76ff-6e98-496f-a36c-bfcd8f59c026
       Content-Length:
       - '7278'
       Connection:
@@ -4848,7 +4848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:22.868248Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:11.914260Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4927,10 +4927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sxuyEQxwS9aBIFIPS82ARg"],
-        "issued_at": "2018-04-09T16:28:22.868312Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JyoYgvW7StGnr0MZNRpT9g"],
+        "issued_at": "2018-04-19T17:38:11.914326Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -4945,7 +4945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a4dbcb97afe4334ae7f438c302627ed
+      - d4cf48bc88194aa2a48677f5b95dea3b
   response:
     status:
       code: 200
@@ -4956,9 +4956,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8ba783aa-9ac2-4487-be6c-980da7adf1a2
+      - req-efe3e713-8589-4d4d-90f1-2d9de54fac7b
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -5000,7 +5000,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -5015,7 +5015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a4dbcb97afe4334ae7f438c302627ed
+      - d4cf48bc88194aa2a48677f5b95dea3b
   response:
     status:
       code: 200
@@ -5026,14 +5026,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-00859533-78d1-4803-b4e6-ce9e060825d3
+      - req-9d5bc953-ccf4-4e5b-a243-dc2d05bd1a49
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -5048,7 +5048,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5061,9 +5061,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-806de125-f1c8-4f6c-ba1d-e0f4c54dcba8
+      - req-29388110-3db0-4ee8-af68-b55e14337949
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5073,7 +5073,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5088,7 +5088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5101,9 +5101,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-27a136a8-2748-4b61-8711-f26d1164c14c
+      - req-b40bec58-dd68-402f-a75e-907664ab03bf
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5113,7 +5113,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -5128,7 +5128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5141,9 +5141,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-18f4f543-9cbc-4008-be9b-08def50e4e81
+      - req-cd8bc4f8-6378-4582-94c7-14f9a9f2346d
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5153,7 +5153,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5168,7 +5168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5181,9 +5181,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-dac53739-2487-470c-a22d-87a331d53740
+      - req-a100795a-77ec-4ee4-b53e-11df7e4ae6cc
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5193,7 +5193,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -5208,7 +5208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5221,9 +5221,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-96a1a852-516d-4a1b-9cc9-1c6cfdcea8c6
+      - req-ccc0480b-25a9-49cc-9ca5-25b286dcf048
       Date:
-      - Mon, 09 Apr 2018 16:28:23 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5233,7 +5233,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5248,7 +5248,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5261,9 +5261,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-983eeb81-161f-43b1-8b9d-1bfdeec3d2ba
+      - req-2a34f0dd-9305-4590-9ab5-615a84f45072
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5273,7 +5273,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -5288,7 +5288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5301,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-15eec768-1a70-42ad-9d0a-18a69d30a59c
+      - req-929875a9-56fd-4f5e-9847-98140f9e0862
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5313,7 +5313,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5328,7 +5328,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5341,9 +5341,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2077b605-cf59-48e3-a44a-b4c1459e2abe
+      - req-43e2427d-c1be-4ed4-b96a-3c134355f4ab
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5353,7 +5353,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -5368,7 +5368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5381,9 +5381,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-3affc4a2-dadd-4dad-bdd9-82d36ecc20b4
+      - req-6ac68a42-4885-43f5-9ff0-1e1af99d5c99
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5393,7 +5393,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5408,7 +5408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5421,9 +5421,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-7b56bf5b-b1f3-4625-88ec-4c68a5c45f59
+      - req-fd4ef79d-1b80-4604-ae25-ed9ccfb18c53
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5433,7 +5433,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -5448,7 +5448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5461,9 +5461,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-42a26eee-86fd-4ffd-8626-4a23a02104c0
+      - req-295de5cd-b41f-41ee-8536-74ea363da4fb
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5473,7 +5473,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5488,7 +5488,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5501,9 +5501,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-210eb391-5720-4212-bdc4-e4d8235c910d
+      - req-7748b9a2-e0a0-4aa1-ab9e-19e04189636d
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5513,7 +5513,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -5528,7 +5528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5541,9 +5541,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f56734c9-da43-4b50-9401-efa68d60cc8c
+      - req-95e33f8c-761d-4097-a736-2c3885c4ddbf
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5553,7 +5553,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5568,7 +5568,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5581,9 +5581,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ab162e7a-8b3d-40c8-b67a-9fcf27429eb6
+      - req-ccf1d32c-cbb4-447d-99d1-66544c29e81d
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5593,7 +5593,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5611,15 +5611,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:24 GMT
+      - Thu, 19 Apr 2018 17:38:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fc5ee90e2b924d9fa99a2d76fde1b5dd
+      - 5fd38385489f4888aa6ca9edfb5b912b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3dca3404-730f-430d-b222-493f185768d1
+      - req-e74dea25-900e-4ba8-b949-e19aa900ecbd
       Content-Length:
       - '7311'
       Connection:
@@ -5631,7 +5631,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:25.140500Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:13.969264Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5710,10 +5710,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rpotc_lfQm-uFjjntYcDqQ"],
-        "issued_at": "2018-04-09T16:28:25.140568Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7t8pregPQ36ZE20z4mihLA"],
+        "issued_at": "2018-04-19T17:38:13.969335Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5731,15 +5731,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:25 GMT
+      - Thu, 19 Apr 2018 17:38:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 69363c0e479a46248bcf73ff1738091d
+      - 96ad087c166340749e7d147b2ebeecc1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b9524930-4bcd-40c5-b8a7-0ca4703f9eae
+      - req-39fc9eb6-a718-44c0-95f1-e149488741fa
       Content-Length:
       - '7278'
       Connection:
@@ -5751,7 +5751,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:25.473014Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:14.390671Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5830,10 +5830,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Uf5Lgy7wTt6tHSq8_mZTMw"],
-        "issued_at": "2018-04-09T16:28:25.473079Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2TGDBrr-SdOqM5D2i22ZzA"],
+        "issued_at": "2018-04-19T17:38:14.390742Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5848,7 +5848,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69363c0e479a46248bcf73ff1738091d
+      - 96ad087c166340749e7d147b2ebeecc1
   response:
     status:
       code: 200
@@ -5859,14 +5859,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0b49a44a-7c73-4fc3-9b43-7b217551a365
+      - req-73ff1617-3c09-4f47-903f-4d40f1e71424
       Date:
-      - Mon, 09 Apr 2018 16:28:25 GMT
+      - Thu, 19 Apr 2018 17:38:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5884,15 +5884,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:25 GMT
+      - Thu, 19 Apr 2018 17:38:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 467400b6a21c42dc9e575485189ce8f8
+      - 3340bcb70ae240dc8d7b247622d9d793
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-473c7cad-37ec-4467-8b37-85d6491b30fe
+      - req-f6be1002-6e56-4012-b594-e1b7c6ff0323
       Content-Length:
       - '7278'
       Connection:
@@ -5904,7 +5904,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:26.076123Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:14.899048Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5983,10 +5983,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6YcNB7OjQFCyKjt4ikYa2A"],
-        "issued_at": "2018-04-09T16:28:26.076195Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3G9vae69RsSq43nceLzYSw"],
+        "issued_at": "2018-04-19T17:38:14.899115Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -6001,7 +6001,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 467400b6a21c42dc9e575485189ce8f8
+      - 3340bcb70ae240dc8d7b247622d9d793
   response:
     status:
       code: 200
@@ -6012,14 +6012,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-64033984-2528-453e-a553-db9e076501dd
+      - req-1d51d33b-8207-4837-84b4-e387da4a62f1
       Date:
-      - Mon, 09 Apr 2018 16:28:26 GMT
+      - Thu, 19 Apr 2018 17:38:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6037,15 +6037,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:26 GMT
+      - Thu, 19 Apr 2018 17:38:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-471d20eb-b6d1-4afe-a6d7-9e08943e2231
+      - req-bf98ddcf-e9ff-4e67-b488-f5bb739f1c5f
       Content-Length:
       - '7264'
       Connection:
@@ -6057,7 +6057,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:26.612615Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:15.428606Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6136,10 +6136,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YqGP1h1cS_OVcRlFVZbZ_A"],
-        "issued_at": "2018-04-09T16:28:26.612674Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O9DpARpiQpeKPKgMTVbmNA"],
+        "issued_at": "2018-04-19T17:38:15.428680Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -6154,7 +6154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6165,9 +6165,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-c1a3742e-a28b-4423-b10c-9833200ba6ba
+      - req-8771e034-d9e8-4e05-9a94-577217c37aaa
       Date:
-      - Mon, 09 Apr 2018 16:28:26 GMT
+      - Thu, 19 Apr 2018 17:38:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6201,7 +6201,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -6216,7 +6216,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6227,14 +6227,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-60a352ef-b8aa-4550-8d31-ddc06a096d5a
+      - req-cd802826-3fe6-4c69-a05d-2cdaa36b3416
       Date:
-      - Mon, 09 Apr 2018 16:28:27 GMT
+      - Thu, 19 Apr 2018 17:38:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6252,15 +6252,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:27 GMT
+      - Thu, 19 Apr 2018 17:38:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 246c81c4a7f64976a94b7559561636fc
+      - 480bd68133cb4abc80117ad0f8399aed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dd8ae353-c59f-4ebf-bf10-b5e250508c69
+      - req-2da9cb49-8f6c-4958-9014-a3d222864fee
       Content-Length:
       - '7278'
       Connection:
@@ -6272,7 +6272,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:27.463155Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:16.142047Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6351,10 +6351,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["drsMdKTIS8KkDuXkQUbY_Q"],
-        "issued_at": "2018-04-09T16:28:27.463219Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mob4xEWORaKPK_6J3f6SKA"],
+        "issued_at": "2018-04-19T17:38:16.142118Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -6369,7 +6369,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 246c81c4a7f64976a94b7559561636fc
+      - 480bd68133cb4abc80117ad0f8399aed
   response:
     status:
       code: 200
@@ -6380,14 +6380,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c6a83d18-a88e-434b-bd2c-d97a312b0df4
+      - req-a0a73f46-0425-407d-bbd6-553f74ab34f3
       Date:
-      - Mon, 09 Apr 2018 16:28:27 GMT
+      - Thu, 19 Apr 2018 17:38:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -6402,7 +6402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc5ee90e2b924d9fa99a2d76fde1b5dd
+      - 5fd38385489f4888aa6ca9edfb5b912b
   response:
     status:
       code: 200
@@ -6413,14 +6413,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-22315e5e-57b3-4f8e-a185-c64de218264c
+      - req-e6e7eb12-9d69-404d-9fc6-0966c2b6da4c
       Date:
-      - Mon, 09 Apr 2018 16:28:27 GMT
+      - Thu, 19 Apr 2018 17:38:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6438,15 +6438,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:28 GMT
+      - Thu, 19 Apr 2018 17:38:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 30e2bb572a5d4b9a8cee1dfc72a76cec
+      - 1832a573160f448abcee498a3f8db361
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d0a9e29-7c42-46c6-b4e5-60f4deb5348c
+      - req-92d8e5de-785e-47d7-bcac-31a2c1854c3c
       Content-Length:
       - '7265'
       Connection:
@@ -6458,7 +6458,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:28.270108Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:16.960135Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6537,10 +6537,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LbpxHMdTQgutBsj0a8FhLA"],
-        "issued_at": "2018-04-09T16:28:28.270194Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BQbZlnaHSSiE8Iya1ml7FQ"],
+        "issued_at": "2018-04-19T17:38:16.960224Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -6555,7 +6555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30e2bb572a5d4b9a8cee1dfc72a76cec
+      - 1832a573160f448abcee498a3f8db361
   response:
     status:
       code: 200
@@ -6566,14 +6566,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-876d8adc-173f-4f07-9d48-f0fead8d377e
+      - req-1372cb89-1ac2-4fd7-9620-0a16f23fe9b5
       Date:
-      - Mon, 09 Apr 2018 16:28:28 GMT
+      - Thu, 19 Apr 2018 17:38:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6591,15 +6591,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:28 GMT
+      - Thu, 19 Apr 2018 17:38:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cbe5cc12a36243029fb00cdfed5a7da7
+      - 7180a7d4014c4dc08cff9d96fff8fbf9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-23420cca-a8c7-4a8c-99d7-bb321e34face
+      - req-fad0f682-b287-4c71-9583-0c40758af356
       Content-Length:
       - '7278'
       Connection:
@@ -6611,7 +6611,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:28.806669Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:17.487658Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6690,10 +6690,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["neG8eFRgRdeQtzMmhXBdpA"],
-        "issued_at": "2018-04-09T16:28:28.806732Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gl2J1yZGR9uikXuGPqlqtA"],
+        "issued_at": "2018-04-19T17:38:17.487728Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -6708,7 +6708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cbe5cc12a36243029fb00cdfed5a7da7
+      - 7180a7d4014c4dc08cff9d96fff8fbf9
   response:
     status:
       code: 200
@@ -6719,14 +6719,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-527b8d30-c342-4dd9-bdb7-3912128a3f20
+      - req-55b16ddb-fae2-4923-9521-bab5d839f38b
       Date:
-      - Mon, 09 Apr 2018 16:28:29 GMT
+      - Thu, 19 Apr 2018 17:38:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -6741,7 +6741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6752,9 +6752,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7bd6bbe5-a9be-4023-b06b-2f06aed53cd2
+      - req-d3474c76-ddc8-4f25-bd35-e5c3e0a9c84a
       Date:
-      - Mon, 09 Apr 2018 16:28:30 GMT
+      - Thu, 19 Apr 2018 17:38:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6781,7 +6781,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -6796,7 +6796,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6807,9 +6807,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-5d05a93f-4fdb-43e6-9ec1-aa91fadc3cb8
+      - req-d1f1956f-7701-4f0a-90bb-3323ea801c0d
       Date:
-      - Mon, 09 Apr 2018 16:28:30 GMT
+      - Thu, 19 Apr 2018 17:38:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6836,7 +6836,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -6851,7 +6851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6862,9 +6862,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a6704be0-b98d-44f6-a952-e0b43df3254e
+      - req-b810f64e-6c87-460f-840c-664703715837
       Date:
-      - Mon, 09 Apr 2018 16:28:31 GMT
+      - Thu, 19 Apr 2018 17:38:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6891,7 +6891,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -6906,7 +6906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -6917,9 +6917,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-689787d8-2cc9-4d9f-960b-c88c27e3157d
+      - req-450bc02f-ab95-469e-846d-c9b9394c383d
       Date:
-      - Mon, 09 Apr 2018 16:28:31 GMT
+      - Thu, 19 Apr 2018 17:38:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6975,7 +6975,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -6990,7 +6990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -7001,9 +7001,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a6c2fbcf-f896-4e1b-b2f2-6808361dce39
+      - req-16aff48e-d316-4a2d-ac5d-aa49782a0da5
       Date:
-      - Mon, 09 Apr 2018 16:28:31 GMT
+      - Thu, 19 Apr 2018 17:38:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7015,7 +7015,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -7030,7 +7030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7043,14 +7043,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-20672a44-89cc-4667-86d5-14d35955b751
+      - req-da8e21d6-128c-46ba-a535-03743a60006b
       Date:
-      - Mon, 09 Apr 2018 16:28:32 GMT
+      - Thu, 19 Apr 2018 17:38:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -7065,7 +7065,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7078,14 +7078,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-fead097c-b3e2-4a78-ad0b-fbed8d4446df
+      - req-03699d53-d25b-494f-999f-89142f0b4ff1
       Date:
-      - Mon, 09 Apr 2018 16:28:32 GMT
+      - Thu, 19 Apr 2018 17:38:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -7100,7 +7100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7113,9 +7113,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-0abbc84b-01a6-41a8-895e-88e1da934ecc
+      - req-23cb6f5d-6a74-4362-90a3-bf29c3355ad5
       Date:
-      - Mon, 09 Apr 2018 16:28:33 GMT
+      - Thu, 19 Apr 2018 17:38:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -7161,7 +7161,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -7176,7 +7176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7189,9 +7189,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-b642dda3-d1be-41c5-9bc7-07c32b5e3593
+      - req-5bea011c-e5b0-40be-99e9-1eebdf1e3b9c
       Date:
-      - Mon, 09 Apr 2018 16:28:33 GMT
+      - Thu, 19 Apr 2018 17:38:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -7237,7 +7237,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -7252,7 +7252,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7265,9 +7265,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-deff04e5-29ab-4911-8a6f-7584d261c9b6
+      - req-503c3f74-c4cc-499f-b6b9-b5d3bee1c275
       Date:
-      - Mon, 09 Apr 2018 16:28:34 GMT
+      - Thu, 19 Apr 2018 17:38:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -7315,7 +7315,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -7330,7 +7330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7343,9 +7343,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-60d03280-9733-4a85-86ee-4ae70f556b88
+      - req-e61a4208-d111-4a72-bd5d-7ff54abcad79
       Date:
-      - Mon, 09 Apr 2018 16:28:34 GMT
+      - Thu, 19 Apr 2018 17:38:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -7387,7 +7387,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -7402,7 +7402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7415,9 +7415,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-45ca48e4-c2ba-43b7-86aa-99f8644c8eeb
+      - req-5c044a5d-2dc3-48cf-86d3-79781887bbf3
       Date:
-      - Mon, 09 Apr 2018 16:28:35 GMT
+      - Thu, 19 Apr 2018 17:38:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -7440,7 +7440,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -7455,7 +7455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7468,14 +7468,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e45c03c9-697b-4743-9ae4-d91f4b19ed86
+      - req-764910e0-47e6-438e-a711-44a10a94ed6f
       Date:
-      - Mon, 09 Apr 2018 16:28:35 GMT
+      - Thu, 19 Apr 2018 17:38:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -7490,7 +7490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7503,14 +7503,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-6519cb0a-6d35-4fd0-9798-607055c6dff5
+      - req-f2a62f92-948e-4b22-b1e7-f19ecbb35dd6
       Date:
-      - Mon, 09 Apr 2018 16:28:35 GMT
+      - Thu, 19 Apr 2018 17:38:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -7525,7 +7525,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7538,14 +7538,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-3e5b5556-f1f8-402b-8203-d61d359475a4
+      - req-79855d50-d9e7-4fe2-a3ea-f7841543afc9
       Date:
-      - Mon, 09 Apr 2018 16:28:35 GMT
+      - Thu, 19 Apr 2018 17:38:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -7560,7 +7560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7573,14 +7573,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-bbf32d46-9db2-46b7-9be6-10fdf1865b52
+      - req-ac526203-9dce-4f48-92e6-2064c5c36655
       Date:
-      - Mon, 09 Apr 2018 16:28:36 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -7595,7 +7595,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -7606,9 +7606,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-1be121ec-2f1b-43a2-b073-8b63e07b0068
+      - req-a34450fc-af60-4b29-a444-98ab7df4ac57
       Date:
-      - Mon, 09 Apr 2018 16:28:36 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -7664,7 +7664,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -7679,7 +7679,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -7690,9 +7690,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1cdd520b-55d5-491e-aad1-3eca20291a83
+      - req-9413330a-381c-4967-9dfe-b71735259c1e
       Date:
-      - Mon, 09 Apr 2018 16:28:36 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7704,7 +7704,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -7719,7 +7719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -7730,9 +7730,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-402c36ee-caa3-47be-95d8-b62b1bc1b30e
+      - req-decc28ff-a31b-4101-a5f6-3ad71b617a9f
       Date:
-      - Mon, 09 Apr 2018 16:28:36 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -7788,7 +7788,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -7803,7 +7803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae76bc613a0d4827be3accabd6fe2d5c
+      - 2c540585f58b408da0904671781ba334
   response:
     status:
       code: 200
@@ -7814,9 +7814,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-8ddd4f11-9994-4612-a378-e4e12375df36
+      - req-cd4bc066-9270-4580-ad88-343250bcc1e7
       Date:
-      - Mon, 09 Apr 2018 16:28:36 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7828,7 +7828,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7843,7 +7843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31af7da643164655be2b5cc230435bbe
+      - cb8acb37d8824b3095570cf2895ec4b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7856,9 +7856,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-1bd23caa-f101-4f88-b2ca-47d6e6c2b0fa
+      - req-ee769202-4245-4843-906b-6b71e5ca264c
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7867,7 +7867,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7882,7 +7882,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06cff2e3769744ad9b677a762b125a8a
+      - 0574a6d1909748b19f282199dc685855
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7895,9 +7895,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-95a3547b-32bc-483d-a37f-56441b22bbb1
+      - req-89dc9909-af36-4a22-8426-6458e6402af0
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7906,7 +7906,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7921,7 +7921,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7934,9 +7934,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a7547c9c-685a-46a4-a709-4e67d5f59e01
+      - req-2189f905-49ed-4daa-ad72-b64b633f6f4d
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7945,7 +7945,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7960,7 +7960,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12697a466c45430a859ef84a6d654218
+      - '08fc8c2fffee4067ab652ab5376dacbf'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7973,9 +7973,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8212a022-2e36-476f-8cd9-75442b9f8703
+      - req-be6204af-618b-482f-a256-56a7682bcd04
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7984,7 +7984,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7999,7 +7999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8012,9 +8012,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-51104fa6-4ce9-469e-b4ff-ecff73e6f386
+      - req-7c5dcddc-5a62-4578-867b-e9ac89a1af25
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -8023,7 +8023,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -8038,7 +8038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3effc9ab3a04d628a4fbf724f7d7f00
+      - 0db9c27f70f74e24b73014c5ddf4958e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8051,9 +8051,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c2bf72a6-2d64-40f8-92c1-6345a0948d27
+      - req-3daaabda-95fd-4c12-85de-55b228e29472
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -8062,7 +8062,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8077,7 +8077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 128c348007e345d2945b533024e67add
+      - cafef6c0cdc249cea6d6da1e27ad821e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8090,9 +8090,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f5ee656e-f985-4c01-a601-cf6437acf13b
+      - req-a5607747-d045-4cae-9425-7d555f52df1a
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -8101,7 +8101,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8119,15 +8119,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:37 GMT
+      - Thu, 19 Apr 2018 17:38:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fc4b6d606c1e482c8c0f81fbec20fd5a
+      - cd37a37963ca43f6859b7e3f394d5a87
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6f908472-4a16-4d63-8076-2e1287f5d4fa
+      - req-538433b8-5c33-4ef1-8f95-82af5a17c220
       Content-Length:
       - '7278'
       Connection:
@@ -8139,7 +8139,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:38.219381Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:26.696371Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8218,10 +8218,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P1crB-pGQ3uJgJIGgLgsRw"],
-        "issued_at": "2018-04-09T16:28:38.219450Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Xm5G3CpQlKoyRuQULVR4g"],
+        "issued_at": "2018-04-19T17:38:26.696444Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8236,22 +8236,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc4b6d606c1e482c8c0f81fbec20fd5a
+      - cd37a37963ca43f6859b7e3f394d5a87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ebd282e1-7b76-43f1-be04-79c3ed0c18d9
+      - req-291c377c-8d35-47d5-9fe3-d22a8d8ac144
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ebd282e1-7b76-43f1-be04-79c3ed0c18d9
+      - req-291c377c-8d35-47d5-9fe3-d22a8d8ac144
       Date:
-      - Mon, 09 Apr 2018 16:28:38 GMT
+      - Thu, 19 Apr 2018 17:38:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8261,7 +8261,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8279,15 +8279,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:38 GMT
+      - Thu, 19 Apr 2018 17:38:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33075eaf10404e8588fa7f0ffe519c76
+      - 1915fd1301bd4bfea3ad3729502b024e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f2e6be1d-2ada-4d70-b248-958021c64600
+      - req-8c068ccd-e5cf-4d5a-87e1-a31b1fc4fcae
       Content-Length:
       - '7278'
       Connection:
@@ -8299,7 +8299,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:39.156106Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:27.650871Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8378,10 +8378,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d3lIQUV0Q82s9I9N6B56uA"],
-        "issued_at": "2018-04-09T16:28:39.156175Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dSQ_OCv2RvyputBO_56KWg"],
+        "issued_at": "2018-04-19T17:38:27.650933Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -8396,22 +8396,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33075eaf10404e8588fa7f0ffe519c76
+      - 1915fd1301bd4bfea3ad3729502b024e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1c95c6f0-db05-4141-a0cb-e0d41a89be9d
+      - req-109c560b-9fbb-4152-8cc8-00e7e3005358
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1c95c6f0-db05-4141-a0cb-e0d41a89be9d
+      - req-109c560b-9fbb-4152-8cc8-00e7e3005358
       Date:
-      - Mon, 09 Apr 2018 16:28:39 GMT
+      - Thu, 19 Apr 2018 17:38:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8421,7 +8421,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8439,15 +8439,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:39 GMT
+      - Thu, 19 Apr 2018 17:38:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-33281c5e-70ae-4395-bcf2-80293bbb8823
+      - req-23eeb836-30bb-4f59-9a33-9f047a0f9ba0
       Content-Length:
       - '7264'
       Connection:
@@ -8459,7 +8459,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:39.760292Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:28.594804Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8538,10 +8538,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5dmNdprzTvCvfBQ6DKNZRg"],
-        "issued_at": "2018-04-09T16:28:39.760341Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lIFGj9uzRMSzq_pW1ue6OA"],
+        "issued_at": "2018-04-19T17:38:28.594873Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -8556,22 +8556,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9089ec7a-b042-4a5f-bdf1-2fb7bcf36a4c
+      - req-977356bf-e809-4e3e-afe8-1caa99e04934
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9089ec7a-b042-4a5f-bdf1-2fb7bcf36a4c
+      - req-977356bf-e809-4e3e-afe8-1caa99e04934
       Date:
-      - Mon, 09 Apr 2018 16:28:40 GMT
+      - Thu, 19 Apr 2018 17:38:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8581,7 +8581,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8599,15 +8599,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:40 GMT
+      - Thu, 19 Apr 2018 17:38:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4fb0e40ede674e55aeb792d658a3b03f
+      - 740f709037ba4313a78c0b2b1f20d0c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5c2e62e4-d219-4971-aae8-cfd770a5b4f1
+      - req-798d1a86-c6e8-497e-89b0-7fef7afc1930
       Content-Length:
       - '7278'
       Connection:
@@ -8619,7 +8619,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:40.372467Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:29.549074Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8698,10 +8698,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dXbuvkn2SJOnqf2Osx8k3g"],
-        "issued_at": "2018-04-09T16:28:40.372514Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hz9IRLo8Rq-4EBlrAkDsaw"],
+        "issued_at": "2018-04-19T17:38:29.549139Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -8716,22 +8716,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb0e40ede674e55aeb792d658a3b03f
+      - 740f709037ba4313a78c0b2b1f20d0c5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c26e903-b7fc-46ff-b778-89797d3ebbf5
+      - req-91db8c24-a3fc-4384-be1d-31450a51dab7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9c26e903-b7fc-46ff-b778-89797d3ebbf5
+      - req-91db8c24-a3fc-4384-be1d-31450a51dab7
       Date:
-      - Mon, 09 Apr 2018 16:28:41 GMT
+      - Thu, 19 Apr 2018 17:38:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8741,7 +8741,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -8756,22 +8756,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76d3137b-23b7-46e9-802f-913afe0052eb
+      - req-e745b620-ede4-43b2-ac00-8fadef58dc2e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-76d3137b-23b7-46e9-802f-913afe0052eb
+      - req-e745b620-ede4-43b2-ac00-8fadef58dc2e
       Date:
-      - Mon, 09 Apr 2018 16:28:41 GMT
+      - Thu, 19 Apr 2018 17:38:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8781,7 +8781,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8799,15 +8799,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:41 GMT
+      - Thu, 19 Apr 2018 17:38:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3ef623d6ba864443bd5a4f0aa1ff7f1f
+      - eee8aa40388943319f676ae6566d96f5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a3fef3e8-5994-4dca-b568-8c16878af0c4
+      - req-4d1ced69-de69-4728-a591-d5277974bea1
       Content-Length:
       - '7265'
       Connection:
@@ -8819,7 +8819,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:42.114463Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:31.341749Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8898,10 +8898,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-D_uZhfCSE-__voVmY_o8w"],
-        "issued_at": "2018-04-09T16:28:42.114568Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Flv1d-4uRDWHbZQCDbexJQ"],
+        "issued_at": "2018-04-19T17:38:31.341847Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -8916,22 +8916,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ef623d6ba864443bd5a4f0aa1ff7f1f
+      - eee8aa40388943319f676ae6566d96f5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5fc81f4-b737-4814-b9f9-04dc277e91f4
+      - req-fa12233c-b198-4599-85d6-d11dd1427a37
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a5fc81f4-b737-4814-b9f9-04dc277e91f4
+      - req-fa12233c-b198-4599-85d6-d11dd1427a37
       Date:
-      - Mon, 09 Apr 2018 16:28:42 GMT
+      - Thu, 19 Apr 2018 17:38:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8941,7 +8941,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8959,15 +8959,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:42 GMT
+      - Thu, 19 Apr 2018 17:38:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 74c21912db2a4de3b3a54b6df0d7b566
+      - ef4e0c3d89e04a6b90c584cb60ff3c21
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a7f32ce2-30ff-4991-b08e-24d58dae6e7f
+      - req-89b86963-63da-48c6-b643-5b342742c290
       Content-Length:
       - '7278'
       Connection:
@@ -8979,7 +8979,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:43.058265Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:32.381675Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9058,10 +9058,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Fqg5qX3iQZKVRicI2xLNNQ"],
-        "issued_at": "2018-04-09T16:28:43.058334Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OreUS8UQRQSMo2CtLi_AKA"],
+        "issued_at": "2018-04-19T17:38:32.381745Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -9076,22 +9076,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74c21912db2a4de3b3a54b6df0d7b566
+      - ef4e0c3d89e04a6b90c584cb60ff3c21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16fd2299-85d5-44c5-b0c5-d4c142c27e19
+      - req-8a9b6b3d-f798-4cea-8ad0-a51ebe20bf0c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-16fd2299-85d5-44c5-b0c5-d4c142c27e19
+      - req-8a9b6b3d-f798-4cea-8ad0-a51ebe20bf0c
       Date:
-      - Mon, 09 Apr 2018 16:28:44 GMT
+      - Thu, 19 Apr 2018 17:38:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -9101,7 +9101,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9119,15 +9119,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:44 GMT
+      - Thu, 19 Apr 2018 17:38:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8932e81bd37e47f393d28071daac5aca
+      - 91df45f13c5d428990b889b83aa2d0b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a2bf2b40-7a3a-4dc9-a2e1-558fcf698439
+      - req-15929116-71cb-47ed-8d55-5c2598b70588
       Content-Length:
       - '7311'
       Connection:
@@ -9139,7 +9139,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:44.542257Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:34.033894Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9218,10 +9218,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dB2vNk4PT666HvCC3RXtfw"],
-        "issued_at": "2018-04-09T16:28:44.542373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XxpBTiC4QbaDJ39UQ0sYZA"],
+        "issued_at": "2018-04-19T17:38:34.033965Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -9236,7 +9236,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8932e81bd37e47f393d28071daac5aca
+      - 91df45f13c5d428990b889b83aa2d0b6
   response:
     status:
       code: 200
@@ -9247,13 +9247,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:28:44 GMT
+      - Thu, 19 Apr 2018 17:38:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9271,15 +9271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:44 GMT
+      - Thu, 19 Apr 2018 17:38:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8935a9e57a3d433884ead0a8c88dfdec
+      - 9a4fcedf909243428e9111a477d76f61
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e44c9a89-ee7a-4a37-9fc9-be547cde34e1
+      - req-3e0eb0d0-1e0f-430f-8cfc-0b8e521c5549
       Content-Length:
       - '7278'
       Connection:
@@ -9291,7 +9291,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:44.998012Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:34.525578Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9370,10 +9370,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OznEzkvKRKy-7S7ddBoBJw"],
-        "issued_at": "2018-04-09T16:28:44.998082Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["StV0M1QtSieiDH7OTaaing"],
+        "issued_at": "2018-04-19T17:38:34.525646Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -9388,7 +9388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8935a9e57a3d433884ead0a8c88dfdec
+      - 9a4fcedf909243428e9111a477d76f61
   response:
     status:
       code: 200
@@ -9399,16 +9399,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1910363b-9ab5-4612-9c91-7039d0c22cad
+      - req-942216c0-757c-4101-ad3e-d95b5116568e
       Date:
-      - Mon, 09 Apr 2018 16:28:45 GMT
+      - Thu, 19 Apr 2018 17:38:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9426,15 +9426,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:45 GMT
+      - Thu, 19 Apr 2018 17:38:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3ca92fc986447828de6c259f85409a9
+      - f9a8e4530d5840b6a9c7e1c89827bc2d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e8a0cb0f-098f-40ac-914f-e91b0d1b3ae4
+      - req-00307a37-3e85-4352-9316-3675c0dbb1e2
       Content-Length:
       - '7278'
       Connection:
@@ -9446,7 +9446,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:45.562515Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:35.038960Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9525,10 +9525,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5f9VX1A4RXyXBpYlnRyEIA"],
-        "issued_at": "2018-04-09T16:28:45.562581Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YjA6o8hTRoaKxZcag9C0oA"],
+        "issued_at": "2018-04-19T17:38:35.039035Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -9543,7 +9543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3ca92fc986447828de6c259f85409a9
+      - f9a8e4530d5840b6a9c7e1c89827bc2d
   response:
     status:
       code: 200
@@ -9554,16 +9554,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-13071de6-19c8-46c2-b468-e62059d60f72
+      - req-de6acf17-0b63-42ae-ba37-68fc6385ed12
       Date:
-      - Mon, 09 Apr 2018 16:28:45 GMT
+      - Thu, 19 Apr 2018 17:38:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9581,15 +9581,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:45 GMT
+      - Thu, 19 Apr 2018 17:38:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71c68eb22bf448ff9910e0abfb1036fd
+      - b61391ebd83a43a0b612080ef0a2d8eb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ef17cef-a44f-42bc-be85-8d5f18a846a6
+      - req-4720af9c-062f-4917-a636-b7efe9810316
       Content-Length:
       - '7264'
       Connection:
@@ -9601,7 +9601,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:46.136137Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:35.574652Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9680,10 +9680,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h2jycFY5QAaURgMDsndR0Q"],
-        "issued_at": "2018-04-09T16:28:46.136226Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SbpVSIsgRVuL8gxbgtylow"],
+        "issued_at": "2018-04-19T17:38:35.574750Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -9698,7 +9698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71c68eb22bf448ff9910e0abfb1036fd
+      - b61391ebd83a43a0b612080ef0a2d8eb
   response:
     status:
       code: 200
@@ -9709,16 +9709,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b200ff17-6b4e-486a-bab9-5186e751d84e
+      - req-bcb2b501-4944-4bb8-8711-fc09b3cd89db
       Date:
-      - Mon, 09 Apr 2018 16:28:46 GMT
+      - Thu, 19 Apr 2018 17:38:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9736,15 +9736,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:46 GMT
+      - Thu, 19 Apr 2018 17:38:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43f69d8e899f4bd2add03cc60d7693cf
+      - 6b5989392d04422ea98e07183d310ec5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11614d11-a711-4691-9545-907b2346af70
+      - req-3e004d05-fbae-400b-bd43-a5f65e6b2e51
       Content-Length:
       - '7278'
       Connection:
@@ -9756,7 +9756,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:46.693331Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:36.042839Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9835,10 +9835,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D5WmsSdsRAaYrR6yIZdYng"],
-        "issued_at": "2018-04-09T16:28:46.693400Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F4ca-satTrWNYvyJ2J-feg"],
+        "issued_at": "2018-04-19T17:38:36.042902Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -9853,7 +9853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43f69d8e899f4bd2add03cc60d7693cf
+      - 6b5989392d04422ea98e07183d310ec5
   response:
     status:
       code: 200
@@ -9864,16 +9864,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e6b07560-d586-4e8d-ab25-0d8c5cfbd357
+      - req-2201a202-ed37-4718-abe9-1c991f2421b2
       Date:
-      - Mon, 09 Apr 2018 16:28:46 GMT
+      - Thu, 19 Apr 2018 17:38:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -9888,7 +9888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8932e81bd37e47f393d28071daac5aca
+      - 91df45f13c5d428990b889b83aa2d0b6
   response:
     status:
       code: 200
@@ -9899,16 +9899,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-98c3ab6f-83b1-438a-adb0-af684a3d55c5
+      - req-c6296646-37fd-4128-94c8-a6ceef050024
       Date:
-      - Mon, 09 Apr 2018 16:28:47 GMT
+      - Thu, 19 Apr 2018 17:38:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9926,15 +9926,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:47 GMT
+      - Thu, 19 Apr 2018 17:38:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b6a9c5885b024b929cdb6e408f0dc410
+      - 9fc1fa97536e4f568029ec2b0106fb88
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78ce01d2-da6d-4c96-b060-94e2aa2e98d4
+      - req-3d3590ba-2d9c-467d-bdb5-925eb9efef5e
       Content-Length:
       - '7265'
       Connection:
@@ -9946,7 +9946,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:47.462955Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:36.723541Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10025,10 +10025,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uziRbrTzQwKPvIBpaowODA"],
-        "issued_at": "2018-04-09T16:28:47.463028Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["70azeI8tSdKtSDEdgp4SWg"],
+        "issued_at": "2018-04-19T17:38:36.723610Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -10043,7 +10043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6a9c5885b024b929cdb6e408f0dc410
+      - 9fc1fa97536e4f568029ec2b0106fb88
   response:
     status:
       code: 200
@@ -10054,16 +10054,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9392c501-b183-4feb-aa76-1688fa5cb72c
+      - req-edcce6a3-13b1-4bbb-8ad7-21142adc6025
       Date:
-      - Mon, 09 Apr 2018 16:28:47 GMT
+      - Thu, 19 Apr 2018 17:38:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10081,15 +10081,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:47 GMT
+      - Thu, 19 Apr 2018 17:38:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - efe69630398c4fbab43113d7568d3900
+      - eb8dbf49a29e45c3b14b86d9b8f7ff30
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1761201e-46af-4094-80fb-68b2d42cb91b
+      - req-dc7d3a62-7197-487f-8639-d6d279796457
       Content-Length:
       - '7278'
       Connection:
@@ -10101,7 +10101,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:48.065013Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:37.207589Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10180,10 +10180,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-fSmVqosQv2OAcYabgCuSQ"],
-        "issued_at": "2018-04-09T16:28:48.065104Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DGz65vQ7QUOZ81O4rdDF1A"],
+        "issued_at": "2018-04-19T17:38:37.207666Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -10198,7 +10198,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - efe69630398c4fbab43113d7568d3900
+      - eb8dbf49a29e45c3b14b86d9b8f7ff30
   response:
     status:
       code: 200
@@ -10209,16 +10209,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-595cf36d-53de-4a9f-a232-172f89986fe5
+      - req-d2147615-faa1-400d-9966-2d8957124e69
       Date:
-      - Mon, 09 Apr 2018 16:28:48 GMT
+      - Thu, 19 Apr 2018 17:38:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10233,7 +10233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10246,9 +10246,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a79d89a2-a4bf-45b4-af99-ba952c40247e
+      - req-ebb09ea8-7a7d-449e-a92c-d8dc8347b08e
       Date:
-      - Mon, 09 Apr 2018 16:28:48 GMT
+      - Thu, 19 Apr 2018 17:38:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10271,7 +10271,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10286,7 +10286,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10299,9 +10299,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-6db92d78-7814-4c0c-87ab-5e2f72a2555b
+      - req-d30dc3af-e321-4d7a-8f53-5a6dd8b6f049
       Date:
-      - Mon, 09 Apr 2018 16:28:48 GMT
+      - Thu, 19 Apr 2018 17:38:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10324,7 +10324,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10339,7 +10339,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10352,9 +10352,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ffb0fef3-0ea3-4578-9290-221d8defc606
+      - req-86f358f5-264c-4996-a3a3-f5d1d75d3836
       Date:
-      - Mon, 09 Apr 2018 16:28:49 GMT
+      - Thu, 19 Apr 2018 17:38:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10377,7 +10377,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10392,7 +10392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10405,9 +10405,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-4f44a00b-fb65-4027-b739-40d877b8c254
+      - req-cc3e4d24-6228-4123-b564-46b467dc6de1
       Date:
-      - Mon, 09 Apr 2018 16:28:49 GMT
+      - Thu, 19 Apr 2018 17:38:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10430,7 +10430,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10445,7 +10445,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10458,9 +10458,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-2d8462e2-1bb1-4841-8eac-3e3cea776262
+      - req-12cfd0af-e5e2-4ab4-9ee0-b6ee56b63a9a
       Date:
-      - Mon, 09 Apr 2018 16:28:49 GMT
+      - Thu, 19 Apr 2018 17:38:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10483,7 +10483,43 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 741c48329f844f8db228ec3715fef086
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-609f2fcf-3156-42d1-9f06-1187ee243443
+      Date:
+      - Thu, 19 Apr 2018 17:38:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
+        "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:38:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10498,7 +10534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10511,9 +10547,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-5a48a5e8-8c56-4c08-8808-88c2bbd5aedc
+      - req-e3072c00-4f0d-4552-89eb-2464c0b4af79
       Date:
-      - Mon, 09 Apr 2018 16:28:49 GMT
+      - Thu, 19 Apr 2018 17:38:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10536,7 +10572,43 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 741c48329f844f8db228ec3715fef086
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-b09d3e42-4ef8-431a-8bd6-e21e1e9a6c30
+      Date:
+      - Thu, 19 Apr 2018 17:38:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
+        "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:38:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10551,7 +10623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10564,9 +10636,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-808697a5-00ac-45b7-a619-0951740cb44f
+      - req-2c24c7ac-898d-4a05-9d70-5392bd9adf1e
       Date:
-      - Mon, 09 Apr 2018 16:28:50 GMT
+      - Thu, 19 Apr 2018 17:38:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10589,7 +10661,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10604,7 +10676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10617,9 +10689,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-6fda7583-04ca-4ecd-a94f-9c60652246ab
+      - req-1650b8bb-601d-4d5a-af21-7905f3735163
       Date:
-      - Mon, 09 Apr 2018 16:28:50 GMT
+      - Thu, 19 Apr 2018 17:38:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10642,7 +10714,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -10657,7 +10729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fba7ce24cbb46c0a37977781b7f9dbf
+      - 741c48329f844f8db228ec3715fef086
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10670,9 +10742,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-610928bb-4095-41c1-9e61-b52e9af74407
+      - req-a97ba13c-2c35-4562-8fb3-7db7a8f5e4e5
       Date:
-      - Mon, 09 Apr 2018 16:28:50 GMT
+      - Thu, 19 Apr 2018 17:38:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -10695,7 +10767,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10713,15 +10785,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:50 GMT
+      - Thu, 19 Apr 2018 17:38:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cd09be6ac6c445799e2bf4b8511d7f2a
+      - d1604925cedd436db551c3278e99a61b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-608da9bd-6e94-4fc4-b207-068cab08010c
+      - req-8eca27f5-e3bc-45e4-9d30-0af6f77870c9
       Content-Length:
       - '7311'
       Connection:
@@ -10733,7 +10805,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:50.793813Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:41.198201Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10812,16 +10884,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jRe-xCcMS4eq8VJGLWpBVg"],
-        "issued_at": "2018-04-09T16:28:50.793852Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rn94skikQ_OWo6rGuvbX1Q"],
+        "issued_at": "2018-04-19T17:38:41.198319Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"cd09be6ac6c445799e2bf4b8511d7f2a"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"d1604925cedd436db551c3278e99a61b"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10833,15 +10905,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:50 GMT
+      - Thu, 19 Apr 2018 17:38:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 56d5b93cbea549d2aec0bc2dbca129da
+      - f0d24b086493429b85508d2b5351cc1f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f4bb591a-27c2-4fbf-acaa-f015b7dce880
+      - req-b367393c-eaf8-4f60-b737-05ae68b7ea6a
       Content-Length:
       - '7346'
       Connection:
@@ -10853,7 +10925,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:50.793813Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:41.198201Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10932,10 +11004,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bPDnaV1KTti3-iCI0MObMw",
-        "jRe-xCcMS4eq8VJGLWpBVg"], "issued_at": "2018-04-09T16:28:51.006210Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0lLtQsGtSX6nnAwDPiqNMA",
+        "Rn94skikQ_OWo6rGuvbX1Q"], "issued_at": "2018-04-19T17:38:41.462803Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10953,15 +11025,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:51 GMT
+      - Thu, 19 Apr 2018 17:38:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aef932a795b14be6a61b37f1e58eb5ef
+      - 904d48dc70e04ecca0516bd8e952c329
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-04591b29-129d-42e7-b798-6e922889f261
+      - req-f21868fb-9489-47b1-9e92-5af9e50adeb8
       Content-Length:
       - '7311'
       Connection:
@@ -10973,7 +11045,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:51.247060Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:41.816134Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11052,16 +11124,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4zSsXX5JTgqzvwX787ZeCw"],
-        "issued_at": "2018-04-09T16:28:51.247098Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZoxarIYOS2KouW5ZBFpV9Q"],
+        "issued_at": "2018-04-19T17:38:41.816218Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"aef932a795b14be6a61b37f1e58eb5ef"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"904d48dc70e04ecca0516bd8e952c329"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11073,15 +11145,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:51 GMT
+      - Thu, 19 Apr 2018 17:38:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f96853d8962e4d57b68e5c0946913b94
+      - 3692a6767c6248f7b289c48306748651
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4065cfb5-e941-45e7-b1d5-d23cb53ef176
+      - req-d14fd0a3-deff-4052-99e1-8ffaca009973
       Content-Length:
       - '7346'
       Connection:
@@ -11093,7 +11165,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:51.247060Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:41.816134Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11172,10 +11244,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9r5tAq2wTvOEAjDjSaQYWA",
-        "4zSsXX5JTgqzvwX787ZeCw"], "issued_at": "2018-04-09T16:28:51.455921Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rd6mQaYET1WL70edJSfoqQ",
+        "ZoxarIYOS2KouW5ZBFpV9Q"], "issued_at": "2018-04-19T17:38:42.087241Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -11190,7 +11262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07fc1b5c22c74031a141ab99fdb4a880
+      - 011eef6541f244a0855b9c0974017794
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -11203,14 +11275,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-d61b796e-41fa-4484-b05f-d9d5a6d52b0e
+      - req-0e76cab1-4bbe-430e-a084-50ebecdcf3b5
       Date:
-      - Mon, 09 Apr 2018 16:28:51 GMT
+      - Thu, 19 Apr 2018 17:38:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -11225,27 +11297,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc4b6d606c1e482c8c0f81fbec20fd5a
+      - cd37a37963ca43f6859b7e3f394d5a87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-115abd4b-f214-49f1-abc2-5424a6e68f24
+      - req-7c2a116f-3ef3-439d-8188-87d1284ce09b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-115abd4b-f214-49f1-abc2-5424a6e68f24
+      - req-7c2a116f-3ef3-439d-8188-87d1284ce09b
       Date:
-      - Mon, 09 Apr 2018 16:28:51 GMT
+      - Thu, 19 Apr 2018 17:38:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -11260,27 +11332,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33075eaf10404e8588fa7f0ffe519c76
+      - 1915fd1301bd4bfea3ad3729502b024e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc3158dd-182c-41a3-8b8c-9d4281eb9c37
+      - req-fe2df6d7-9a57-4711-8ae2-5e49f674eeea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cc3158dd-182c-41a3-8b8c-9d4281eb9c37
+      - req-fe2df6d7-9a57-4711-8ae2-5e49f674eeea
       Date:
-      - Mon, 09 Apr 2018 16:28:51 GMT
+      - Thu, 19 Apr 2018 17:38:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -11295,22 +11367,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26aece2b-7bb5-4e37-ac25-e3b8f8dfd178
+      - req-f19008c0-c148-41bd-a98e-b63218cbc626
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-26aece2b-7bb5-4e37-ac25-e3b8f8dfd178
+      - req-f19008c0-c148-41bd-a98e-b63218cbc626
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11343,7 +11415,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -11358,22 +11430,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07816633-7d78-4065-9c96-47f9f59bf005
+      - req-4fd2f54a-4436-4dfd-a183-58f4d2b76310
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-07816633-7d78-4065-9c96-47f9f59bf005
+      - req-4fd2f54a-4436-4dfd-a183-58f4d2b76310
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -11390,7 +11462,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -11405,27 +11477,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb0e40ede674e55aeb792d658a3b03f
+      - 740f709037ba4313a78c0b2b1f20d0c5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b165671f-a390-404f-9511-a36f1812aa9b
+      - req-6fec30af-6e3a-4c62-8e33-7d9f46c5514f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b165671f-a390-404f-9511-a36f1812aa9b
+      - req-6fec30af-6e3a-4c62-8e33-7d9f46c5514f
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -11440,27 +11512,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce170a8a-17e7-4a48-82f0-b5287d9a51a7
+      - req-32742acd-67c8-40c6-b387-d22094b46898
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ce170a8a-17e7-4a48-82f0-b5287d9a51a7
+      - req-32742acd-67c8-40c6-b387-d22094b46898
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -11475,27 +11547,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ef623d6ba864443bd5a4f0aa1ff7f1f
+      - eee8aa40388943319f676ae6566d96f5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-310cf3fc-46d7-49e1-aa4a-fca26c08420e
+      - req-2c0664c9-e85a-41c4-90d1-44f7a26558e0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-310cf3fc-46d7-49e1-aa4a-fca26c08420e
+      - req-2c0664c9-e85a-41c4-90d1-44f7a26558e0
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -11510,27 +11582,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74c21912db2a4de3b3a54b6df0d7b566
+      - ef4e0c3d89e04a6b90c584cb60ff3c21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2d47e24d-0d48-4293-abe4-cb433cf55786
+      - req-6f2f23c7-7e3e-4b03-9d5e-e6659b5a72d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2d47e24d-0d48-4293-abe4-cb433cf55786
+      - req-6f2f23c7-7e3e-4b03-9d5e-e6659b5a72d0
       Date:
-      - Mon, 09 Apr 2018 16:28:52 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -11545,27 +11617,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc4b6d606c1e482c8c0f81fbec20fd5a
+      - cd37a37963ca43f6859b7e3f394d5a87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6278c3c2-0036-402b-bb2c-49f125c1cf82
+      - req-568b124d-af97-49e6-84c2-c5e99064acd7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6278c3c2-0036-402b-bb2c-49f125c1cf82
+      - req-568b124d-af97-49e6-84c2-c5e99064acd7
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -11580,27 +11652,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc4b6d606c1e482c8c0f81fbec20fd5a
+      - cd37a37963ca43f6859b7e3f394d5a87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18f9a903-c3bb-4ac2-8ca8-3c7a26ffbb26
+      - req-d4b2d560-0cdd-43b3-902e-377779ce76da
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-18f9a903-c3bb-4ac2-8ca8-3c7a26ffbb26
+      - req-d4b2d560-0cdd-43b3-902e-377779ce76da
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -11615,27 +11687,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33075eaf10404e8588fa7f0ffe519c76
+      - 1915fd1301bd4bfea3ad3729502b024e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-806658f6-07b6-4036-95f9-bf4c3de8cebd
+      - req-88996922-92cc-47e9-bd23-25fccfb3217a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-806658f6-07b6-4036-95f9-bf4c3de8cebd
+      - req-88996922-92cc-47e9-bd23-25fccfb3217a
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -11650,27 +11722,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33075eaf10404e8588fa7f0ffe519c76
+      - 1915fd1301bd4bfea3ad3729502b024e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-257582cd-f8e1-4988-8d6a-ebf60747db0b
+      - req-2e8a475e-8ab6-4df0-bef7-8bd8e8b2ab83
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-257582cd-f8e1-4988-8d6a-ebf60747db0b
+      - req-2e8a475e-8ab6-4df0-bef7-8bd8e8b2ab83
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -11685,22 +11757,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c5aac9b8-3e48-4984-95ce-399977333b4c
+      - req-7382b392-f435-459c-ba89-96d2edc3156f
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-c5aac9b8-3e48-4984-95ce-399977333b4c
+      - req-7382b392-f435-459c-ba89-96d2edc3156f
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11715,7 +11787,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -11730,22 +11802,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 023fe4c220874954943cb57047628819
+      - f296bd25af8141f59f20dfb4a4bf6220
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4872dac3-6611-4702-afad-580cabe711fa
+      - req-6c72a4b2-f8cf-4bab-8470-2bda03f3e4b6
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-4872dac3-6611-4702-afad-580cabe711fa
+      - req-6c72a4b2-f8cf-4bab-8470-2bda03f3e4b6
       Date:
-      - Mon, 09 Apr 2018 16:28:53 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11760,7 +11832,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -11775,27 +11847,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb0e40ede674e55aeb792d658a3b03f
+      - 740f709037ba4313a78c0b2b1f20d0c5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-72155292-07c6-4350-96b9-4f8f78d538f5
+      - req-dc055f73-bf1a-4182-b1d3-47f58319492f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-72155292-07c6-4350-96b9-4f8f78d538f5
+      - req-dc055f73-bf1a-4182-b1d3-47f58319492f
       Date:
-      - Mon, 09 Apr 2018 16:28:54 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -11810,27 +11882,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb0e40ede674e55aeb792d658a3b03f
+      - 740f709037ba4313a78c0b2b1f20d0c5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6479ba42-7442-42c3-87a9-abb3e32e0a36
+      - req-90c0e924-d71a-4e45-a220-149ea9a8528d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6479ba42-7442-42c3-87a9-abb3e32e0a36
+      - req-90c0e924-d71a-4e45-a220-149ea9a8528d
       Date:
-      - Mon, 09 Apr 2018 16:28:54 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -11845,27 +11917,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa405ba9-dd76-41ab-8002-284d0b27f625
+      - req-1366d4b5-85d7-4f04-b0b8-bf59fdfb78c8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fa405ba9-dd76-41ab-8002-284d0b27f625
+      - req-1366d4b5-85d7-4f04-b0b8-bf59fdfb78c8
       Date:
-      - Mon, 09 Apr 2018 16:28:54 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -11880,27 +11952,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 876c3b7816614b228297d6c838315a89
+      - ab9e1a3e9bf54a33aef953da1f674c68
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76bddb0f-4d87-4879-981d-4ddaa25aa9b8
+      - req-714a13d9-4664-48cc-b29e-83a8597a7c9a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-76bddb0f-4d87-4879-981d-4ddaa25aa9b8
+      - req-714a13d9-4664-48cc-b29e-83a8597a7c9a
       Date:
-      - Mon, 09 Apr 2018 16:28:54 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -11915,27 +11987,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ef623d6ba864443bd5a4f0aa1ff7f1f
+      - eee8aa40388943319f676ae6566d96f5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-15cd3b4b-833c-40aa-b8c3-ae4ed153f4eb
+      - req-f78d47d9-a039-4a09-8fb0-678ccb7df3e9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-15cd3b4b-833c-40aa-b8c3-ae4ed153f4eb
+      - req-f78d47d9-a039-4a09-8fb0-678ccb7df3e9
       Date:
-      - Mon, 09 Apr 2018 16:28:55 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -11950,27 +12022,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ef623d6ba864443bd5a4f0aa1ff7f1f
+      - eee8aa40388943319f676ae6566d96f5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6f41d01f-5235-473e-b4cb-3ec011a3f853
+      - req-d9dfda42-29d2-436e-81d0-1e0810ac0fd6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6f41d01f-5235-473e-b4cb-3ec011a3f853
+      - req-d9dfda42-29d2-436e-81d0-1e0810ac0fd6
       Date:
-      - Mon, 09 Apr 2018 16:28:55 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11985,27 +12057,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74c21912db2a4de3b3a54b6df0d7b566
+      - ef4e0c3d89e04a6b90c584cb60ff3c21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28d50f8c-fb03-4858-80dc-50ab9888b8d9
+      - req-2470c9df-2893-4ee2-8240-43dd33a1c3c4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-28d50f8c-fb03-4858-80dc-50ab9888b8d9
+      - req-2470c9df-2893-4ee2-8240-43dd33a1c3c4
       Date:
-      - Mon, 09 Apr 2018 16:28:55 GMT
+      - Thu, 19 Apr 2018 17:38:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -12020,27 +12092,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74c21912db2a4de3b3a54b6df0d7b566
+      - ef4e0c3d89e04a6b90c584cb60ff3c21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd62076c-71c2-47c9-a044-eedcf013f6a6
+      - req-fe8c10b2-77be-4180-8ceb-8db21f778423
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fd62076c-71c2-47c9-a044-eedcf013f6a6
+      - req-fe8c10b2-77be-4180-8ceb-8db21f778423
       Date:
-      - Mon, 09 Apr 2018 16:28:55 GMT
+      - Thu, 19 Apr 2018 17:38:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12058,15 +12130,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:56 GMT
+      - Thu, 19 Apr 2018 17:38:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c665d78a08e846aa95fed3b5df65d27f
+      - 0d66d21d615f46f3bb83d365c11aa516
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-869f307e-ab90-4012-b5ec-148a5fefc812
+      - req-34d4b3ad-20d9-4294-8665-f62c9d5d8d4b
       Content-Length:
       - '7311'
       Connection:
@@ -12078,7 +12150,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:56.861798Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:47.857158Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12157,10 +12229,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2syeZK1ORqiIwAhAfpbYJw"],
-        "issued_at": "2018-04-09T16:28:56.861869Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BBtQk1FvQFK666qzEjMwEA"],
+        "issued_at": "2018-04-19T17:38:47.857225Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12178,15 +12250,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:56 GMT
+      - Thu, 19 Apr 2018 17:38:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b9052d0e-771f-4f98-a212-7d984ce7a9ae
+      - req-8d2d6bfc-2291-4c1b-8b3f-d241b4088fc9
       Content-Length:
       - '7311'
       Connection:
@@ -12198,7 +12270,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:57.252072Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:48.179940Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12277,10 +12349,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["byMY6NBkSnqJTC03-lCnmQ"],
-        "issued_at": "2018-04-09T16:28:57.252127Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QaTyAUS2TZi2BOt6_bO9rw"],
+        "issued_at": "2018-04-19T17:38:48.180009Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -12295,7 +12367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -12306,12 +12378,22 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-9ac4b5ab-d83d-4de2-95ad-fcfc1384ef59
+      - req-58d69b28-6acc-47cf-b0a8-d189cfc817b7
       Date:
-      - Mon, 09 Apr 2018 16:28:57 GMT
+      - Thu, 19 Apr 2018 17:38:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
         "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -12356,29 +12438,19 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        13}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12396,15 +12468,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:57 GMT
+      - Thu, 19 Apr 2018 17:38:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f0c255c4b75749c6961b56c95595776b
+      - 239c5b22981d495bb83619c4163eb388
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c6839bc8-2317-46a6-b5dc-adf8a2c5d985
+      - req-84dde686-37d7-4eea-b014-f4652bc27690
       Content-Length:
       - '7311'
       Connection:
@@ -12416,7 +12488,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:28:57.947245Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:38:48.788564Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12495,10 +12567,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w7_B6J1BRdm2BRw00VAVUg"],
-        "issued_at": "2018-04-09T16:28:57.947370Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ellIeZCxQNyRLXYNEza3WA"],
+        "issued_at": "2018-04-19T17:38:48.788633Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12516,15 +12588,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:58 GMT
+      - Thu, 19 Apr 2018 17:38:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4994f59daabe4604ab7a8a8ada178ea4
+      - f1952a7399ad4d939f0899b17b79958c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a751aa68-7fdf-4a13-a0dd-c944519ee3ce
+      - req-f5e6aea7-57bb-4b07-a5fd-7bef46709dd5
       Content-Length:
       - '297'
       Connection:
@@ -12533,12 +12605,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:28:58.186613Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:38:48.993415Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iwfMLmvpTHS0KWYAKdhGjA"],
-        "issued_at": "2018-04-09T16:28:58.186699Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EL28abFGRY2RNL2Jo1vxqw"],
+        "issued_at": "2018-04-19T17:38:48.993474Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -12553,20 +12625,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4994f59daabe4604ab7a8a8ada178ea4
+      - f1952a7399ad4d939f0899b17b79958c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:58 GMT
+      - Thu, 19 Apr 2018 17:38:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d9a5dd1b-f3ca-4fde-9f8f-518c90d478f5
+      - req-198c9256-90b8-4378-b72b-f55bc92a2fc1
       Content-Length:
       - '2457'
       Connection:
@@ -12599,13 +12671,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"4994f59daabe4604ab7a8a8ada178ea4"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"f1952a7399ad4d939f0899b17b79958c"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12617,15 +12689,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:58 GMT
+      - Thu, 19 Apr 2018 17:38:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8136da6b49d348b0a310db0f12bb76d1
+      - 2c88da2c0dd54dd6827057e199e9eab9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4707b07f-ab65-4020-997c-d1a342d73fb2
+      - req-60ee5543-7950-4cae-bfd0-67cc840faf03
       Content-Length:
       - '7313'
       Connection:
@@ -12637,7 +12709,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:58.186613Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:48.993415Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12716,10 +12788,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hmRXec3JRY2ib13OotZXsw",
-        "iwfMLmvpTHS0KWYAKdhGjA"], "issued_at": "2018-04-09T16:28:58.966564Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5n8TnTnQR5iRwskxlV_Qog",
+        "EL28abFGRY2RNL2Jo1vxqw"], "issued_at": "2018-04-19T17:38:49.406819Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12734,20 +12806,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8136da6b49d348b0a310db0f12bb76d1
+      - 2c88da2c0dd54dd6827057e199e9eab9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:59 GMT
+      - Thu, 19 Apr 2018 17:38:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7b2cc219-59c4-462a-a66a-3ce4276550ea
+      - req-26f1b176-00e5-45f2-a6ac-ae2a9776d989
       Content-Length:
       - '2179'
       Connection:
@@ -12780,7 +12852,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12798,15 +12870,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:59 GMT
+      - Thu, 19 Apr 2018 17:38:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4d50ccb876a4466a1ff5c5c7d9fde3a
+      - e45a0afe95da40488dd668d084af21d7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-36101a69-f117-433a-a1af-c879a00007ee
+      - req-96e1448e-c5bc-4095-83fc-919b9b1b2920
       Content-Length:
       - '7278'
       Connection:
@@ -12818,7 +12890,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:59.379049Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:50.925625Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12897,10 +12969,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fJ_kpHHNT82kj_Vp3u_IbA"],
-        "issued_at": "2018-04-09T16:28:59.379086Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KDBlAw_TQx-qV1yTCsJbrA"],
+        "issued_at": "2018-04-19T17:38:50.925694Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12918,15 +12990,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:59 GMT
+      - Thu, 19 Apr 2018 17:38:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 20d32e6812f94e1f903ad66a25c3a8cd
+      - 34b0539831d4499fa4b0bc7ea2dfd907
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-48195517-33f2-474f-af7c-30fe821b358c
+      - req-ad8878b1-e358-4be2-9479-24496e707eda
       Content-Length:
       - '7278'
       Connection:
@@ -12938,7 +13010,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:28:59.692416Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:51.226252Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13017,10 +13089,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L3Q_I0HkQtK_g3FDxMVsjA"],
-        "issued_at": "2018-04-09T16:28:59.692480Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uctbhpaoQpmishDJljZiwg"],
+        "issued_at": "2018-04-19T17:38:51.226319Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:28:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13038,15 +13110,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:28:59 GMT
+      - Thu, 19 Apr 2018 17:38:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 042af7ce55914e4ca856a8d9c6dd9016
+      - fd2c7aaff2684accbc068d05059553a2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8df89c4a-c30f-44d9-8613-2c69fa7a175e
+      - req-53945e5e-8d2f-452a-918d-5ffcc3971957
       Content-Length:
       - '7264'
       Connection:
@@ -13058,7 +13130,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:00.130664Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:51.563559Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13137,10 +13209,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DM-dFzyxSHKOKlfIkF1CqQ"],
-        "issued_at": "2018-04-09T16:29:00.130740Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vDHESAYQS1SZ36uqV6j2Ww"],
+        "issued_at": "2018-04-19T17:38:51.563629Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13158,15 +13230,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:00 GMT
+      - Thu, 19 Apr 2018 17:38:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7417a558e43043ddb1fc0595bde74848
+      - 374bc52063b74e4e82d359a4c2e3d8b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df14a618-b61f-459c-a106-c34052bd1a01
+      - req-31d38c1d-1eef-46bd-aee7-7729df8bf8c7
       Content-Length:
       - '7278'
       Connection:
@@ -13178,7 +13250,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:00.468176Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:51.861135Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13257,10 +13329,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CBe2jFmORCSm0Er86I6WVg"],
-        "issued_at": "2018-04-09T16:29:00.468253Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fl6tAv2HSm-t-lbyU4uuTw"],
+        "issued_at": "2018-04-19T17:38:51.861219Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13278,15 +13350,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:00 GMT
+      - Thu, 19 Apr 2018 17:38:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 55c6fe5c9d7f4f4bbbcef6657ea02f43
+      - 5643c6ffed3147a19dcfbc6342009f1d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-abc879bc-243c-4276-8d58-a9b057ef5700
+      - req-a3664941-c75c-49f0-abf1-43498dd83854
       Content-Length:
       - '7265'
       Connection:
@@ -13298,7 +13370,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:00.790021Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:52.178803Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13377,10 +13449,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nRFAwBL1TO6BwedeaXeIjQ"],
-        "issued_at": "2018-04-09T16:29:00.790085Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dRtk5b1-QaW-DtT-iiVjWQ"],
+        "issued_at": "2018-04-19T17:38:52.178876Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13398,15 +13470,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:00 GMT
+      - Thu, 19 Apr 2018 17:38:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3c51a93bc884421182f68464389dcecf
+      - 565abf3c6bf64a6f8498ab069ff05621
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e76b4caf-7c74-4c8e-89e5-ad0718321682
+      - req-ad4f3797-9b32-417b-acf7-0eca3ae71fba
       Content-Length:
       - '7278'
       Connection:
@@ -13418,7 +13490,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:01.113541Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:52.611150Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13497,10 +13569,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SGrkGGBlStOr2puH-Se4Fw"],
-        "issued_at": "2018-04-09T16:29:01.113609Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Sw0-JetGQca1nrgEnKOAsg"],
+        "issued_at": "2018-04-19T17:38:52.611228Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13518,15 +13590,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:01 GMT
+      - Thu, 19 Apr 2018 17:38:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - af72bb770a99478288c8188fbaa42ff5
+      - 6fdcf07b78004e30ac27ab4026979a34
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7b361efb-6245-41d9-8fd9-293c92e5eecf
+      - req-ac16ce83-27e3-45b3-8444-f04c54d15227
       Content-Length:
       - '7278'
       Connection:
@@ -13538,7 +13610,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:01.431681Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:52.926227Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13617,10 +13689,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LuHOmP3_Tii-JzCWX0DQXQ"],
-        "issued_at": "2018-04-09T16:29:01.431740Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nh5admnLRXuGOxtO-Gc9vQ"],
+        "issued_at": "2018-04-19T17:38:52.926292Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -13635,7 +13707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af72bb770a99478288c8188fbaa42ff5
+      - 6fdcf07b78004e30ac27ab4026979a34
   response:
     status:
       code: 200
@@ -13646,14 +13718,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-69d5e850-dbf7-43d4-94f9-983f7c98d4f3
+      - req-7b09e8d4-a14d-4bfc-a301-95378995bb49
       Date:
-      - Mon, 09 Apr 2018 16:29:01 GMT
+      - Thu, 19 Apr 2018 17:38:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13671,15 +13743,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:01 GMT
+      - Thu, 19 Apr 2018 17:38:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 599f8fc40f2d49ca954709ea630bd0e2
+      - a86d07a653f04b3ab23c9e0fd681ba74
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-93f9384f-4dad-49c1-aa49-d78c35f0c301
+      - req-81f937c6-02fc-4b95-bc0a-99bea7001e16
       Content-Length:
       - '7278'
       Connection:
@@ -13691,7 +13763,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:02.097246Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:53.522038Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13770,10 +13842,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2cYra8kKRJOmT2US-0Kjcw"],
-        "issued_at": "2018-04-09T16:29:02.097327Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jEnMG1h8RSyYr8ikoB7Mvw"],
+        "issued_at": "2018-04-19T17:38:53.522134Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -13788,7 +13860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 599f8fc40f2d49ca954709ea630bd0e2
+      - a86d07a653f04b3ab23c9e0fd681ba74
   response:
     status:
       code: 200
@@ -13799,14 +13871,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-122fe7f5-81c6-4730-a580-0d8697c91d2b
+      - req-ea927fdf-43ea-4d11-ac4b-2b2e75dd983a
       Date:
-      - Mon, 09 Apr 2018 16:29:02 GMT
+      - Thu, 19 Apr 2018 17:38:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13824,15 +13896,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:02 GMT
+      - Thu, 19 Apr 2018 17:38:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f7b058e-9397-485e-8a6e-92cc18c97fd2
+      - req-7bd9b3fe-676e-4c7b-9868-cedfa6a5a2d0
       Content-Length:
       - '7264'
       Connection:
@@ -13844,7 +13916,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:02.627133Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:54.301108Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13923,10 +13995,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_C_VOOR9QoKQwf66sTvAxw"],
-        "issued_at": "2018-04-09T16:29:02.627213Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vIizwdXVR1e8eaLTuhe-9A"],
+        "issued_at": "2018-04-19T17:38:54.301204Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -13941,7 +14013,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -13952,9 +14024,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-fd56486b-c681-4a79-9e68-0b85f2ccc20b
+      - req-d5b908af-69f8-456d-a939-23ec63a1c691
       Date:
-      - Mon, 09 Apr 2018 16:29:02 GMT
+      - Thu, 19 Apr 2018 17:38:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -13988,7 +14060,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -14003,7 +14075,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14014,14 +14086,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-99df0195-c689-4ca4-a0ab-5f1f58e4fef6
+      - req-346f6d95-78dc-4d15-9407-869f091ac6cd
       Date:
-      - Mon, 09 Apr 2018 16:29:03 GMT
+      - Thu, 19 Apr 2018 17:38:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14039,15 +14111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:03 GMT
+      - Thu, 19 Apr 2018 17:38:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 10ed365fb19a4df4a02667cd5f6942d6
+      - 236235e98b984aa6bb9bfbfb29f1e0d4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e48dd8fe-6881-4dd8-a021-03c46e6995e2
+      - req-891d9497-a7c3-44e5-8686-e3634c151a2a
       Content-Length:
       - '7278'
       Connection:
@@ -14059,7 +14131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:03.443108Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:55.177534Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14138,10 +14210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JUwB_d6XQMSTTUlT7qOuhw"],
-        "issued_at": "2018-04-09T16:29:03.443174Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jss6ewHRTtCD62Ems_FSag"],
+        "issued_at": "2018-04-19T17:38:55.177592Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -14156,7 +14228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10ed365fb19a4df4a02667cd5f6942d6
+      - 236235e98b984aa6bb9bfbfb29f1e0d4
   response:
     status:
       code: 200
@@ -14167,14 +14239,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7ffa293b-a14f-4202-b786-0cdea953390b
+      - req-210dbd7e-7e29-428c-af19-1ee96d7e64e1
       Date:
-      - Mon, 09 Apr 2018 16:29:03 GMT
+      - Thu, 19 Apr 2018 17:38:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -14189,7 +14261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0c255c4b75749c6961b56c95595776b
+      - 239c5b22981d495bb83619c4163eb388
   response:
     status:
       code: 200
@@ -14200,14 +14272,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-195a07bd-5110-4fbd-a1ed-112a2e41c615
+      - req-f53ae6ce-0643-4b7d-96fd-c6b9f5db3220
       Date:
-      - Mon, 09 Apr 2018 16:29:03 GMT
+      - Thu, 19 Apr 2018 17:38:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14225,15 +14297,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:04 GMT
+      - Thu, 19 Apr 2018 17:38:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c5e7366598c41b5beed30f7f51320db
+      - 61c042d0f42c4a48a1f3557fd7228c33
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf239331-7527-4fff-a9b9-7c0299e7ec6e
+      - req-b90d04ab-7272-4033-b438-6d52d6f6b6f4
       Content-Length:
       - '7265'
       Connection:
@@ -14245,7 +14317,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:04.253628Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:56.012038Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14324,10 +14396,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Im9KFIg1QmyjXs_kdb4tEw"],
-        "issued_at": "2018-04-09T16:29:04.253692Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LRs6LjfiRcu2wENJ3S87DA"],
+        "issued_at": "2018-04-19T17:38:56.012104Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -14342,7 +14414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c5e7366598c41b5beed30f7f51320db
+      - 61c042d0f42c4a48a1f3557fd7228c33
   response:
     status:
       code: 200
@@ -14353,14 +14425,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0dedef48-df32-491c-82ad-e98c6c8bc293
+      - req-2a27cb14-6638-4e4e-88c0-05829d32e670
       Date:
-      - Mon, 09 Apr 2018 16:29:04 GMT
+      - Thu, 19 Apr 2018 17:38:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14378,15 +14450,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:04 GMT
+      - Thu, 19 Apr 2018 17:38:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 75cfdab24d0c4622be29b3ccabfde1da
+      - 765719a1bf7d4e49839af40153f73e4c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c2489eee-1867-40df-aff1-4a26771b6508
+      - req-8f019f1b-1c44-465f-a6fd-2bae3a19e94d
       Content-Length:
       - '7278'
       Connection:
@@ -14398,7 +14470,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:04.853340Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:38:56.741343Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14477,10 +14549,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c0mDv-JrSZOLtCE4NBe-kw"],
-        "issued_at": "2018-04-09T16:29:04.853412Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GMy8WuBrQ4eldxga6m7Ddw"],
+        "issued_at": "2018-04-19T17:38:56.741413Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -14495,7 +14567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75cfdab24d0c4622be29b3ccabfde1da
+      - 765719a1bf7d4e49839af40153f73e4c
   response:
     status:
       code: 200
@@ -14506,14 +14578,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-041a7640-fa1b-423c-9368-0d2857e0cbe4
+      - req-6d07f531-5b91-45da-835a-497605568a98
       Date:
-      - Mon, 09 Apr 2018 16:29:05 GMT
+      - Thu, 19 Apr 2018 17:38:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -14528,7 +14600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14539,9 +14611,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c1267336-9be4-4db0-960d-f93b0f66fac0
+      - req-5f55c963-864f-499a-b80e-183d254828ec
       Date:
-      - Mon, 09 Apr 2018 16:29:05 GMT
+      - Thu, 19 Apr 2018 17:38:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14568,7 +14640,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -14583,7 +14655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14594,9 +14666,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8f83d2d3-35af-4a87-a5d3-b2d1e3181989
+      - req-df7f9644-9a16-42bc-bd84-45470ad6af49
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14623,7 +14695,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -14638,7 +14710,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14649,9 +14721,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-57738422-a4cf-449e-aeeb-6f3e83bc7693
+      - req-30c0a959-15f9-4733-bd10-b5b42d643692
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14678,7 +14750,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -14693,7 +14765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14704,9 +14776,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c114716e-c42c-413b-aa57-629139eee97e
+      - req-83027b55-83a9-442c-acfe-913ded546002
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14718,7 +14790,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -14733,7 +14805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14744,9 +14816,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fa37e96d-a9f8-4f4c-b968-3d3f1c5959cf
+      - req-82dccd09-9814-4e55-9450-b779060ce544
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14758,7 +14830,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -14773,7 +14845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 925563b8aab543c78dfd16efb2901db9
+      - eee6e1ab93904ee4ac4d5cf786623e97
   response:
     status:
       code: 200
@@ -14784,9 +14856,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ea7242f1-7df6-4fe1-9a81-4843f5a39449
+      - req-0d7200a6-4f20-4150-8da9-7737be707a62
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14798,7 +14870,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:38:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14816,15 +14888,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:06 GMT
+      - Thu, 19 Apr 2018 17:38:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0ca21dbb-b999-4211-9af7-8a0287f400eb
+      - req-20f37785-60f9-4ff0-970b-289b66e57d6d
       Content-Length:
       - '7278'
       Connection:
@@ -14836,7 +14908,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:07.019963Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:00.017888Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14915,10 +14987,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Gbrqe9doR-ix_9ToVwCH_g"],
-        "issued_at": "2018-04-09T16:29:07.020003Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9MsJC6CeRb2sRagEz_7sZQ"],
+        "issued_at": "2018-04-19T17:39:00.017961Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14933,7 +15005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -14944,9 +15016,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9a80b0c7-7687-4f67-afa2-9084183d5ee4
+      - req-c31e50f1-77d6-4439-af9e-a34f4fa460f1
       Date:
-      - Mon, 09 Apr 2018 16:29:07 GMT
+      - Thu, 19 Apr 2018 17:39:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
@@ -15051,7 +15123,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15066,7 +15138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -15077,13 +15149,43 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-65c36189-5e26-45fc-b814-fa39f044d639
+      - req-b02db088-f050-4764-b1c7-2f66b0eccdf0
       Date:
-      - Mon, 09 Apr 2018 16:29:07 GMT
+      - Thu, 19 Apr 2018 17:39:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -15135,55 +15237,25 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15201,15 +15273,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:07 GMT
+      - Thu, 19 Apr 2018 17:39:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-127a7d1c-4495-402f-b9bc-64c39ebf81ef
+      - req-bc0e869e-1a0a-4c4c-9df2-43dceacd3501
       Content-Length:
       - '7278'
       Connection:
@@ -15221,7 +15293,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:07.714745Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:00.810644Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15300,10 +15372,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fOClf5NRTluNDS9Osw48aQ"],
-        "issued_at": "2018-04-09T16:29:07.714833Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hXu0jwkjR-CF5Rk9LbLx1g"],
+        "issued_at": "2018-04-19T17:39:00.810676Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15318,7 +15390,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -15329,273 +15401,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-eb71d85e-cd29-4677-ac2f-392a5806b06d
+      - req-c327aa36-80f5-4c29-9d31-cdc25dc9f419
       Date:
-      - Mon, 09 Apr 2018 16:29:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-03617eea-e665-4808-9b7a-caf614a977a6
-      Date:
-      - Mon, 09 Apr 2018 16:29:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-57dece67-a9b3-4ba8-a680-47b91dae8491
-      Date:
-      - Mon, 09 Apr 2018 16:29:08 GMT
+      - Thu, 19 Apr 2018 17:39:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -15699,7 +15507,140 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4bd7d25ab07e445d8815e5186767ae2e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3cb2bc69-9186-4de3-aec5-20df57ced345
+      Date:
+      - Thu, 19 Apr 2018 17:39:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:39:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15717,15 +15658,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:08 GMT
+      - Thu, 19 Apr 2018 17:39:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-73d456f7-c735-46dc-8ed7-e41c6a963b63
+      - req-b06b30d4-1710-4d2f-97e9-ada37bf8cca8
       Content-Length:
       - '7264'
       Connection:
@@ -15737,7 +15678,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:08.537493Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:01.578522Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15816,10 +15757,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_bFKVTnTTFOmsAu1sNixGg"],
-        "issued_at": "2018-04-09T16:29:08.537550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MdKXSR-OQUaWq4JgoED4dw"],
+        "issued_at": "2018-04-19T17:39:01.578599Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15834,7 +15775,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -15845,64 +15786,23 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0313cfe3-6170-4386-acbd-90542c5bcd2c
+      - req-02e62a67-9627-4432-abac-5296184a5889
       Date:
-      - Mon, 09 Apr 2018 16:29:08 GMT
+      - Thu, 19 Apr 2018 17:39:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -15938,23 +15838,64 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:01 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -15966,7 +15907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -15977,9 +15918,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c8afebd6-5109-487f-80ab-d018833b67cb
+      - req-7320a8d4-1916-4b7b-8703-9f8e40c59ce8
       Date:
-      - Mon, 09 Apr 2018 16:29:08 GMT
+      - Thu, 19 Apr 2018 17:39:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
@@ -16084,139 +16025,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c555442a-2e99-419f-8ff5-69b9b72f069d
-      Date:
-      - Mon, 09 Apr 2018 16:29:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16234,15 +16043,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:09 GMT
+      - Thu, 19 Apr 2018 17:39:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6e3d68e6-cee1-4d80-bd89-05582c873565
+      - req-7f9e1276-21a6-4c72-a602-4c0259e3ffe4
       Content-Length:
       - '7278'
       Connection:
@@ -16254,7 +16063,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:09.342120Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:02.436072Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16333,10 +16142,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4qPaVcRMR2eUdOjl4FXkuA"],
-        "issued_at": "2018-04-09T16:29:09.342158Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MZ8VmQDASZ2NmLueQSW7Yg"],
+        "issued_at": "2018-04-19T17:39:02.436128Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16351,7 +16160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -16362,42 +16171,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dd75887e-ed00-4596-a497-3f2c408f43e6
+      - req-426e56a0-6e7c-4a26-94c1-36091990769f
       Date:
-      - Mon, 09 Apr 2018 16:29:09 GMT
+      - Thu, 19 Apr 2018 17:39:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
@@ -16455,23 +16234,53 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:02 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -16483,7 +16292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -16494,9 +16303,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-89041755-c498-4042-a295-502359cccc71
+      - req-f1d24fb8-f1a9-42d0-8979-c763e23e666c
       Date:
-      - Mon, 09 Apr 2018 16:29:09 GMT
+      - Thu, 19 Apr 2018 17:39:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -16600,139 +16409,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fdf172aa-3d1a-4cf2-a537-a71d9b231daf
-      Date:
-      - Mon, 09 Apr 2018 16:29:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16747,7 +16424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -16758,161 +16435,23 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-403899e8-19aa-4ada-9a97-44d529994643
+      - req-12a3b68c-4a2b-49aa-ad21-94767f636798
       Date:
-      - Mon, 09 Apr 2018 16:29:10 GMT
+      - Thu, 19 Apr 2018 17:39:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-52f7e5f2-af48-409f-94ec-0d5c6d0574f6
-      Date:
-      - Mon, 09 Apr 2018 16:29:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
         "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -16984,20 +16523,25 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -17012,7 +16556,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -17023,13 +16567,54 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7c54ba51-2bf3-4212-be78-b9bf7fbbab5b
+      - req-683dc3a2-5a87-4ccb-ab16-9a5fc29de41d
       Date:
-      - Mon, 09 Apr 2018 16:29:10 GMT
+      - Thu, 19 Apr 2018 17:39:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -17075,61 +16660,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17147,15 +16691,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:10 GMT
+      - Thu, 19 Apr 2018 17:39:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d909afef-6d3c-4470-97e4-46024af9200f
+      - req-e33e20e2-3d7a-430d-8435-616f4acd9678
       Content-Length:
       - '7265'
       Connection:
@@ -17167,7 +16711,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:10.622531Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:03.634083Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17246,10 +16790,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8e9h2NpfTY--Gsg4NT5btg"],
-        "issued_at": "2018-04-09T16:29:10.622571Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zYlwjuf7R5eM2s6wiYRbnQ"],
+        "issued_at": "2018-04-19T17:39:03.634155Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -17264,7 +16808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -17275,141 +16819,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e3c2bbfb-dc68-4ba4-8b67-f3f565b60b29
+      - req-6ec485c3-05bc-4491-ae74-457b938d5185
       Date:
-      - Mon, 09 Apr 2018 16:29:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a0deb404-9285-412c-b445-ccef488288fb
-      Date:
-      - Mon, 09 Apr 2018 16:29:11 GMT
+      - Thu, 19 Apr 2018 17:39:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -17513,7 +16925,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -17528,7 +16940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -17539,13 +16951,54 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2447ac1d-e6e0-4220-890d-5790e47a3809
+      - req-eda54f64-70ef-464a-a38b-787c7238811c
       Date:
-      - Mon, 09 Apr 2018 16:29:11 GMT
+      - Thu, 19 Apr 2018 17:39:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -17591,61 +17044,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17663,15 +17075,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:11 GMT
+      - Thu, 19 Apr 2018 17:39:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dfd28576-b88d-45c6-b542-d7d2ca650844
+      - req-b90e8375-7132-43ad-b367-371e21a1f63b
       Content-Length:
       - '7278'
       Connection:
@@ -17683,7 +17095,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:11.536935Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:04.423613Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17762,10 +17174,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F7qere1XTdyhMc7C4q4STQ"],
-        "issued_at": "2018-04-09T16:29:11.536971Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8pmWw2EDRpqLQ4GVbA1kUw"],
+        "issued_at": "2018-04-19T17:39:04.423685Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -17780,7 +17192,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -17791,418 +17203,159 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b686f03c-78e0-430b-8a9b-b9e15a824c79
+      - req-c6f72926-04c4-4b59-ad67-2fe45d1e39b8
       Date:
-      - Mon, 09 Apr 2018 16:29:11 GMT
+      - Thu, 19 Apr 2018 17:39:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f95c0c81-92df-434b-a07d-cca716044cf4
-      Date:
-      - Mon, 09 Apr 2018 16:29:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5c9e6540-392c-4973-a345-b7721ae39c01
-      Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4ab280af-af5c-47c6-ad40-522adbe26795
-      Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
         "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:39:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4d16a2f6beda40d88652ce92c54e6cc2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f5cc3acf-49aa-4f69-a00a-8398eb068245
+      Date:
+      - Thu, 19 Apr 2018 17:39:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
@@ -18275,158 +17428,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8f1d68a4-eb03-465f-bb0b-9653b9a58bac
-      Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18441,7 +17456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -18452,9 +17467,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-072fec31-60c6-48fa-8553-531bfcb7163e
+      - req-8f1fcf9f-a8d5-4b57-9fa1-69ca8c6f1abf
       Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
+      - Thu, 19 Apr 2018 17:39:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18496,7 +17511,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18511,7 +17526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -18522,9 +17537,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4f5c6235-0fdc-4fa7-905b-9dcefede90fb
+      - req-ad786212-a31a-4b34-89f9-ec0fc073ee59
       Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18566,7 +17581,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18581,7 +17596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -18592,9 +17607,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7a7ddc2a-f484-46ba-a591-171d87603b33
+      - req-07ac2b6b-9701-4f4b-bbb8-88e44262b4f3
       Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18636,7 +17651,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18651,7 +17666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -18662,9 +17677,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-18050f2a-f0f5-4c25-8e7f-ec251c67569b
+      - req-935b2a8a-c924-472e-b7ec-667c60d73a80
       Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18706,7 +17721,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18721,7 +17736,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -18732,9 +17747,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-d3b41568-85f6-454e-a76e-515a3a6debfc
+      - req-0538bb54-91bb-45bd-9808-020bb870f98b
       Date:
-      - Mon, 09 Apr 2018 16:29:12 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18776,7 +17791,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18791,7 +17806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -18802,9 +17817,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-74507665-c16a-4318-9ce1-0fc0862ffac5
+      - req-e9024568-38ad-4b50-8a16-39c019b64acc
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18846,7 +17861,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18861,7 +17876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -18872,9 +17887,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9bb252c0-b359-40cd-8040-9b0636022109
+      - req-a5548ceb-76e8-4ddb-b21a-a719b42a306d
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18916,7 +17931,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18931,7 +17946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -18942,9 +17957,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5860a751-6c24-4110-a4a5-3280bc343096
+      - req-ff9648cb-5e4a-4e9d-ab64-ba2dd9f24b23
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18986,7 +18001,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19001,7 +18016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -19012,9 +18027,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6477f557-a0d8-4db1-9a50-03745fba9b33
+      - req-efba25f7-eb27-49df-8e8b-494a3309315b
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19056,7 +18071,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19071,7 +18086,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -19082,9 +18097,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-09442d32-2af7-4f5b-825d-8b4d564cc2b7
+      - req-981b5b55-2053-4a35-8033-0f5a951fd06b
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19126,7 +18141,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19141,7 +18156,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -19152,9 +18167,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7c916685-67a4-4e7c-b621-93709b740c5d
+      - req-9c13ceba-c058-46cd-ac87-9efeba5da898
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19196,7 +18211,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19211,7 +18226,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -19222,9 +18237,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3dc1a903-37e7-4f6c-b2b7-31ce97b5cec9
+      - req-afe82b5c-4bf1-46fa-919e-2a8ef258dcd0
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19266,7 +18281,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19281,7 +18296,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -19292,9 +18307,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bc6560f1-c823-4981-a4b4-7c1213835c2d
+      - req-040c7d6e-d4ef-461a-9943-93c2d604409b
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19336,7 +18351,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19351,7 +18366,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -19362,9 +18377,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-31f63668-38dd-40f9-85f4-a66f401d2d66
+      - req-f2f31fe4-bf68-4430-b0da-b8360747f886
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19406,7 +18421,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19421,7 +18436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -19432,9 +18447,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9a1b7d1d-17fb-47a1-a1a7-f47ec6d33c9b
+      - req-d64f8cbb-e6b1-46f5-acf2-43638d1a52d3
       Date:
-      - Mon, 09 Apr 2018 16:29:13 GMT
+      - Thu, 19 Apr 2018 17:39:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19837,7 +18852,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19852,7 +18867,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -19863,9 +18878,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b27716f5-be98-4f06-b543-9f1fbffd451f
+      - req-bd2f5a0f-87db-405c-92cd-08d2ae66a02b
       Date:
-      - Mon, 09 Apr 2018 16:29:14 GMT
+      - Thu, 19 Apr 2018 17:39:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20268,7 +19283,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20283,7 +19298,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -20294,9 +19309,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6a6804b0-d4a0-4ecf-b469-4cbe69447202
+      - req-c236ee5a-6f75-4614-82ea-d501a5f90828
       Date:
-      - Mon, 09 Apr 2018 16:29:14 GMT
+      - Thu, 19 Apr 2018 17:39:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20699,7 +19714,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20714,7 +19729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -20725,9 +19740,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b203077c-1b54-41a6-af24-64cab509ce89
+      - req-e4bb6482-21fc-48fe-8018-638df55375d4
       Date:
-      - Mon, 09 Apr 2018 16:29:14 GMT
+      - Thu, 19 Apr 2018 17:39:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21130,7 +20145,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21145,7 +20160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -21156,9 +20171,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ceaa97d3-95db-4cf2-a961-b6ef4208d0db
+      - req-8813d647-bc39-4daa-a750-865e09de148c
       Date:
-      - Mon, 09 Apr 2018 16:29:15 GMT
+      - Thu, 19 Apr 2018 17:39:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21561,7 +20576,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21576,7 +20591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -21587,9 +20602,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d984594e-ea2e-42a4-a2a1-4a1d0704cd7f
+      - req-f46d40e3-de7b-411f-ba7c-443fec3759e8
       Date:
-      - Mon, 09 Apr 2018 16:29:15 GMT
+      - Thu, 19 Apr 2018 17:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21992,7 +21007,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22007,7 +21022,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -22018,9 +21033,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c8a98a3f-b5c9-415e-a80b-7e7e8293e0e4
+      - req-ffb72872-da09-4ec1-832e-355cbb0b887e
       Date:
-      - Mon, 09 Apr 2018 16:29:15 GMT
+      - Thu, 19 Apr 2018 17:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22423,7 +21438,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22438,7 +21453,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -22449,9 +21464,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-57bf7dd8-586c-463d-bb12-03ce573da796
+      - req-2053b57f-c49e-4962-a73e-52f51d68cbb4
       Date:
-      - Mon, 09 Apr 2018 16:29:16 GMT
+      - Thu, 19 Apr 2018 17:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22854,7 +21869,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22869,7 +21884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -22880,9 +21895,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b3fc62c5-010f-48d9-8afa-3ee689cd513b
+      - req-f46b0a3a-68d6-4513-8449-8e8262358e2c
       Date:
-      - Mon, 09 Apr 2018 16:29:16 GMT
+      - Thu, 19 Apr 2018 17:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23285,7 +22300,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -23300,7 +22315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -23311,9 +22326,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-2d898aa1-1286-464e-9415-44d7a1c18159
+      - req-91f1755c-4a7a-478f-9f46-eec853fe14b6
       Date:
-      - Mon, 09 Apr 2018 16:29:16 GMT
+      - Thu, 19 Apr 2018 17:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23716,7 +22731,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -23731,7 +22746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -23742,9 +22757,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d8f8e77a-abac-4fcb-91cf-96c71d51aa99
+      - req-8394028d-99c4-4210-b0d7-43685c45c5f6
       Date:
-      - Mon, 09 Apr 2018 16:29:17 GMT
+      - Thu, 19 Apr 2018 17:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24147,7 +23162,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -24162,7 +23177,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -24173,9 +23188,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-77a7b794-8c60-4f7b-89e9-e9a917d9f57b
+      - req-872f67be-ef6b-404e-a309-2cded5e89ddf
       Date:
-      - Mon, 09 Apr 2018 16:29:17 GMT
+      - Thu, 19 Apr 2018 17:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24578,7 +23593,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -24593,7 +23608,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -24604,9 +23619,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ed72bad5-ff60-416e-a2c4-993c4bec57af
+      - req-6be4b3a7-3026-4bf5-83cc-44473dee965f
       Date:
-      - Mon, 09 Apr 2018 16:29:17 GMT
+      - Thu, 19 Apr 2018 17:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -25009,7 +24024,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -25024,7 +24039,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -25035,9 +24050,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9506a68d-c5aa-4d2e-8cc7-c66a1b8886ca
+      - req-c881da55-d940-48de-9195-8527a8e512ac
       Date:
-      - Mon, 09 Apr 2018 16:29:17 GMT
+      - Thu, 19 Apr 2018 17:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -25440,7 +24455,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25455,7 +24470,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -25466,9 +24481,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f51c509b-69ae-4cc4-aef1-249bdccdcdff
+      - req-12852977-23f2-4cd0-9fc5-a1105532e1af
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25500,7 +24515,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25515,7 +24530,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -25526,9 +24541,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1df01dc4-2ae6-4084-9c42-6d0129e52d38
+      - req-a0ab2cfc-3e9e-47de-aa84-2eeca5c02f3a
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25560,7 +24575,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25575,7 +24590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -25586,9 +24601,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e36999d8-e715-47f7-98bd-36b6195d58d1
+      - req-53310194-27db-420e-a0aa-c8306d1ae47f
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25620,7 +24635,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25635,7 +24650,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -25646,9 +24661,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-40719577-a7bc-44e3-bdfb-bc81787b76de
+      - req-c99837fa-74a1-44d0-897b-b753fad35faa
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25680,7 +24695,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25695,7 +24710,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -25706,9 +24721,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5e06adf6-d1a0-46fc-87a7-f9008f1af456
+      - req-8865cba1-7554-47db-b5e4-d537bbebedd7
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25740,7 +24755,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25755,7 +24770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -25766,9 +24781,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-27984ff3-91f9-4757-83b1-c445a56c40af
+      - req-19a76934-6a2a-4bf5-abbf-e4de19e74da7
       Date:
-      - Mon, 09 Apr 2018 16:29:18 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25800,7 +24815,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25815,7 +24830,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -25826,9 +24841,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a280beb8-0197-428f-b2f0-679571a04fc2
+      - req-41ac9d50-8dcc-45fc-9b55-345cbd1e723b
       Date:
-      - Mon, 09 Apr 2018 16:29:19 GMT
+      - Thu, 19 Apr 2018 17:39:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25860,7 +24875,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25875,7 +24890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -25886,9 +24901,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e0c60d5b-bab3-4588-8095-332ba3601e69
+      - req-fe6c3564-3274-45e9-b2cf-4f31d056b9d1
       Date:
-      - Mon, 09 Apr 2018 16:29:19 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25920,7 +24935,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25935,7 +24950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -25946,9 +24961,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5dbdc46d-04f0-4ecb-b73e-0017a290597f
+      - req-b64f1cf9-066e-4cf8-9fb2-a65b82e1ab09
       Date:
-      - Mon, 09 Apr 2018 16:29:19 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25980,7 +24995,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25995,7 +25010,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -26006,9 +25021,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d1c88ebd-2546-42b9-a668-f6d4481719c4
+      - req-b2e42027-a5f5-4767-b0ea-f7e438ada540
       Date:
-      - Mon, 09 Apr 2018 16:29:19 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26040,7 +25055,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -26055,7 +25070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -26066,9 +25081,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fe3260b5-9760-48cc-877c-a003d57d5584
+      - req-2b502df0-c7bc-4fe7-9439-91f29816b25d
       Date:
-      - Mon, 09 Apr 2018 16:29:19 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26100,7 +25115,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26115,7 +25130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -26126,9 +25141,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-153ff23d-7585-4093-b7df-b3e64f491d17
+      - req-a31cfa5f-d02c-4fe3-8d13-aa5aac70972f
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26160,7 +25175,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -26175,7 +25190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -26186,9 +25201,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-87e16502-aed7-4804-ae77-2d8654be7f0f
+      - req-b617d0a6-0f2a-44ef-afe4-9129a22d557b
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26220,7 +25235,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26235,7 +25250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -26246,9 +25261,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b549a8e3-5cb2-4a71-a2c2-9d3db6242494
+      - req-ecd6bb63-2a6c-48f4-a9ac-29cf62b55a29
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26280,7 +25295,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26295,7 +25310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26306,9 +25321,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2cb0a411-561e-409a-a255-8c5bcda32b19
+      - req-ceac6bc8-5c87-4633-a30f-c8faeb7f5033
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26343,7 +25358,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26358,7 +25373,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26369,9 +25384,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-628d27aa-3dee-46f2-b0e9-e26163ce6609
+      - req-b0138e8d-9d40-4015-b0c3-b5f07b91ad72
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26414,7 +25429,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26429,7 +25444,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26440,9 +25455,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-66a945bb-6a92-4fd1-b161-48caf3ff2f4d
+      - req-36ab681f-fdcc-4450-b1c6-654a82353f28
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26485,7 +25500,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26500,7 +25515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26511,9 +25526,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-c12e8aa0-6430-486b-9116-67d62a005a8c
+      - req-6bb2f855-f121-4646-9bfe-d0eefe8ef50c
       Date:
-      - Mon, 09 Apr 2018 16:29:20 GMT
+      - Thu, 19 Apr 2018 17:39:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26620,7 +25635,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26635,7 +25650,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26646,9 +25661,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-90d922d6-ca68-4935-9d23-63108915e73a
+      - req-6e1e8bc7-65f6-4838-b8bf-5e4304352367
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26690,7 +25705,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26705,7 +25720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18c5e6fd9c845e2a089936435b2a1c7
+      - 830001f9b67c4010bdb638edd92368b9
   response:
     status:
       code: 200
@@ -26716,15 +25731,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-afb1b060-e8ae-4adf-8342-15f89351a423
+      - req-f5375216-9a20-49a6-978e-9589390acb4e
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26739,7 +25754,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -26750,9 +25765,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-48c2cfc4-9bbc-41ec-9434-6d9bd1779245
+      - req-526aeb64-b767-4c4b-a1ce-5da118569b04
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26787,7 +25802,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26802,7 +25817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -26813,9 +25828,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-3938cae4-01f3-4bcc-abe6-8d6baf7c4ce5
+      - req-cc58ae21-69bc-4719-a12b-c568cda77a28
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26858,7 +25873,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26873,7 +25888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -26884,9 +25899,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c61b83fb-c8a0-4240-af74-43f911be8768
+      - req-340f9cff-f18d-4f41-b7c6-473fcf4e4e27
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26929,7 +25944,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26944,7 +25959,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -26955,9 +25970,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-64b89570-59d4-42c3-b1cd-bb5f711aaa32
+      - req-b2e40e4e-12a2-4704-91a2-8c5a9024a283
       Date:
-      - Mon, 09 Apr 2018 16:29:21 GMT
+      - Thu, 19 Apr 2018 17:39:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27064,7 +26079,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27079,7 +26094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -27090,9 +26105,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bb1e69e0-616c-4399-9743-4168438d30bd
+      - req-a7d36ac7-1d03-4291-99f8-00182ae54bec
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27134,7 +26149,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27149,7 +26164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ca3a4a065b24a99bdbce10917b94f8d
+      - 4bd7d25ab07e445d8815e5186767ae2e
   response:
     status:
       code: 200
@@ -27160,15 +26175,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-7f3c7034-c4c9-463c-90e3-c4c8880513cc
+      - req-a8e1efb0-3ebe-4cb3-a921-ab76deca5900
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27183,7 +26198,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27194,9 +26209,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-df8c22c9-f919-4e90-aa90-e08c2ce7978a
+      - req-4ea66e6e-9d84-4839-914d-5ef6f8ffc7ea
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27231,7 +26246,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27246,7 +26261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27257,9 +26272,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d661d847-738b-48b4-8b90-6cb5eee5a75b
+      - req-4ceee141-1626-45ff-bde9-01c71b1b2485
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27302,7 +26317,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27317,7 +26332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27328,9 +26343,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0ed7f65a-b408-4829-b828-323cd361e5a5
+      - req-2e7c6f88-4513-4fca-bb96-295d83111e9b
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27373,7 +26388,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27388,7 +26403,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27399,9 +26414,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-54070888-4bbc-49bb-9e17-8b372321f7c3
+      - req-e12fb073-b6a2-4b88-affe-f1545fa9dc05
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27508,7 +26523,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27523,7 +26538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27534,9 +26549,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-01d4e63f-08a9-4540-bee4-671284714f4d
+      - req-e7496c8d-5a87-4a31-9b8a-4aa6ed2ff93a
       Date:
-      - Mon, 09 Apr 2018 16:29:22 GMT
+      - Thu, 19 Apr 2018 17:39:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27578,7 +26593,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27593,7 +26608,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d24f3d42c86f484a9a1d80be26da768d
+      - 950819973b3048f598e48481ddfbcec5
   response:
     status:
       code: 200
@@ -27604,15 +26619,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-a0320f69-7ca6-4b70-874d-2417290df9c9
+      - req-cd482bf5-2e57-4bc0-8f89-0f54232bdf30
       Date:
-      - Mon, 09 Apr 2018 16:29:23 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27627,7 +26642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -27638,9 +26653,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-00d87acf-ba34-4b0d-80a4-135ff5b7c02a
+      - req-d9490a1d-228d-46c1-b79b-2d7fd27df784
       Date:
-      - Mon, 09 Apr 2018 16:29:23 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27675,7 +26690,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27690,7 +26705,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -27701,9 +26716,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7803f31c-86e0-42e8-8bb9-049b0af23814
+      - req-49f213c5-5def-4ff7-a890-ba194db51804
       Date:
-      - Mon, 09 Apr 2018 16:29:23 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27746,7 +26761,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27761,7 +26776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -27772,9 +26787,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7a47bfef-a2e1-4350-85b7-ca72b2f436f4
+      - req-7d13f0f4-8389-421d-9e64-fa73129ed4bd
       Date:
-      - Mon, 09 Apr 2018 16:29:23 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27817,7 +26832,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27832,7 +26847,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -27843,9 +26858,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-d46eef55-b049-4d19-b2f7-02001d78587e
+      - req-458086c6-fdda-40e7-bff0-290572341239
       Date:
-      - Mon, 09 Apr 2018 16:29:23 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27952,7 +26967,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27967,7 +26982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -27978,9 +26993,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bf8a1645-e56e-43e1-96b9-a090415af0c8
+      - req-c401cb8d-ec20-4a95-876d-df7b53e19fa1
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28022,7 +27037,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28037,7 +27052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180ef45a61454541b9f58f00e8ff37cd
+      - cf3a9a025bac4d0da86182abb66baf82
   response:
     status:
       code: 200
@@ -28048,15 +27063,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-e3774b8b-229c-478e-b0e2-911ea8387bbd
+      - req-e87953d8-7a7b-4770-8a75-980b4f50912f
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28071,7 +27086,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28082,9 +27097,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-e5de30c7-ba08-4479-82df-238a8ce38945
+      - req-78f0bd95-be1a-4082-93c5-81420bbc4329
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28119,7 +27134,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28134,7 +27149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28145,9 +27160,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-11415cfd-3cdc-4957-bf99-8fff3b43e85e
+      - req-5dda0a0b-dd5c-46ea-b08f-f9b3f01fd6b5
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28190,7 +27205,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28205,7 +27220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28216,9 +27231,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b3a1462e-dee3-4933-9deb-728caa728ca1
+      - req-8218ced5-b92c-4897-9d4a-82afa99c2152
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28261,7 +27276,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28276,7 +27291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28287,9 +27302,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-c7265d6e-94a0-4e21-b860-978626fce815
+      - req-647e6bb6-de73-4f28-8469-59d6240291bb
       Date:
-      - Mon, 09 Apr 2018 16:29:24 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28396,7 +27411,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28411,7 +27426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28422,9 +27437,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4e37e487-9c78-4252-b33f-a2e28499d02a
+      - req-4a534653-c5be-4e8a-b2c7-0af7ccc706b1
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28466,7 +27481,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28481,7 +27496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b70fd738a07481c8fae2c5e499c70fa
+      - 10d520cfd80443ef82ba9243ab5420d2
   response:
     status:
       code: 200
@@ -28492,15 +27507,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-248343b1-83c4-4275-9e34-04c83a2add11
+      - req-d48d53ac-00e3-4f43-a2b9-dfdb44fad420
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28515,7 +27530,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28526,9 +27541,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-6872c3cc-901a-4771-87d3-f5c1779606f4
+      - req-0cf1ecfa-faa9-4ad3-9f72-f71fcad5e375
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28563,7 +27578,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28578,7 +27593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28589,9 +27604,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-64e34d3c-9723-44ab-a1c9-6405a0c67a82
+      - req-bd1fbe71-fab6-4fe9-a4be-ba6031838c28
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28634,7 +27649,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28649,7 +27664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28660,9 +27675,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9d4a8522-c161-4c6f-b61a-39f30ca5d7a0
+      - req-dc180e23-515d-42a0-bd9e-bbf18cd29418
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28705,7 +27720,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28720,7 +27735,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28731,9 +27746,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-2a82bfb5-07a8-4ec8-907e-2f3997d522f3
+      - req-d0fed12a-2aa7-4c64-b49e-621d56c9b675
       Date:
-      - Mon, 09 Apr 2018 16:29:25 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28840,7 +27855,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28855,7 +27870,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28866,9 +27881,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-622acd3d-10e5-46d7-a9a4-12cbb80d84c4
+      - req-f1862ad3-95c3-4a1e-8f12-6fb7c35b9e02
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28910,7 +27925,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28925,7 +27940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fff1ecb66c254c67b6c32bebc6374419
+      - 6900347cf40c4ff398920283d8881da1
   response:
     status:
       code: 200
@@ -28936,15 +27951,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-42942b12-d010-4f66-990a-8e100a878495
+      - req-be1470cc-629a-4bf4-9d3a-b2956e39bfa9
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28959,7 +27974,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -28970,9 +27985,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-74c501dc-3369-4d7e-92b3-064e8bf23547
+      - req-f4e7fa17-e28f-42ba-9530-c9e74da684d9
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -29007,7 +28022,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -29022,7 +28037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -29033,9 +28048,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-aca4acb0-d944-455d-8a6b-c42357094562
+      - req-32983d28-362e-47be-b172-d780b382fbcd
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -29078,7 +28093,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -29093,7 +28108,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -29104,9 +28119,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-65675c05-3da1-4b69-969a-0d56ddcf968d
+      - req-7fd62f65-1f00-4457-8e47-065eac917a35
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -29149,7 +28164,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -29164,7 +28179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -29175,9 +28190,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a90df567-242c-4fa8-8d1c-c423e187906c
+      - req-c87dcbf8-d2dc-4c62-8490-bcf5fa96678e
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -29284,7 +28299,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -29299,7 +28314,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -29310,9 +28325,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8555076d-9275-458d-bbf9-b049dcfa4128
+      - req-9b968045-0196-4042-a3bc-dec9e26e78a6
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -29354,7 +28369,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -29369,7 +28384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ed119641f014d90835ca7c5fb941f97
+      - 4d16a2f6beda40d88652ce92c54e6cc2
   response:
     status:
       code: 200
@@ -29380,15 +28395,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-46b278da-af78-472d-878f-d0adca1e240d
+      - req-77ba0647-bd22-4559-a262-2e197232fdc5
       Date:
-      - Mon, 09 Apr 2018 16:29:26 GMT
+      - Thu, 19 Apr 2018 17:39:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -29406,13 +28421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:27 GMT
+      - Thu, 19 Apr 2018 17:39:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-af179c6b-e8e4-4302-8350-cec44f276ad9
+      - req-192f6331-cdb7-4189-834c-9d68769655ed
       Content-Length:
       - '4227'
       Connection:
@@ -29421,10 +28436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:27.460311", "expires":
-        "2018-04-09T17:29:27Z", "id": "be7535cbe3fd4a56a3a9e77ad26e2736", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:19.134602", "expires":
+        "2018-04-19T18:39:19Z", "id": "57174a2c513443bfbc159df3065b4c8c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["YNuZZ5SjSt2XHIBND4Haww"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["R2leT_QnTxmycKZfkGYl4A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -29469,7 +28484,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -29487,13 +28502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:27 GMT
+      - Thu, 19 Apr 2018 17:39:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0d651a6-bb63-4bb3-b46d-bb2028aa2b3a
+      - req-ab70c14a-6bfe-497a-b07f-47921bed987f
       Content-Length:
       - '4227'
       Connection:
@@ -29502,10 +28517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:27.652630", "expires":
-        "2018-04-09T17:29:27Z", "id": "91f19e29a8004181a50f8e4238174c45", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:19.635987", "expires":
+        "2018-04-19T18:39:19Z", "id": "15d9a925fda4455f894866e0ae097295", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["FFeFZCpaSSSnT4HvkpZQWQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["d6iuF4faR9aknd7DSLjGIQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -29550,7 +28565,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -29568,13 +28583,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:27 GMT
+      - Thu, 19 Apr 2018 17:39:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a3b79815-0828-469c-909b-5d485dcd33be
+      - req-d1e770d0-6004-4e7a-83d2-0293aeffd501
       Content-Length:
       - '370'
       Connection:
@@ -29583,13 +28598,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:27.808433", "expires":
-        "2018-04-09T17:29:27Z", "id": "5309b989a2a142a4b0445aa5a1e62910", "audit_ids":
-        ["pnEBdAUxS7KjrTr1uA5Cdg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:19.835246", "expires":
+        "2018-04-19T18:39:19Z", "id": "5d889970d6d340ab8d0ffa796dbe1e29", "audit_ids":
+        ["YiSW2SjdS2uCoZTBmzVz9w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -29604,20 +28619,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5309b989a2a142a4b0445aa5a1e62910
+      - 5d889970d6d340ab8d0ffa796dbe1e29
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:27 GMT
+      - Thu, 19 Apr 2018 17:39:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e13d6133-dd9e-4082-8bd7-d6cf02fd76df
+      - req-abd5c7de-7f7a-41ac-bf01-5ec9c3df1459
       Content-Length:
       - '884'
       Connection:
@@ -29638,13 +28653,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"5309b989a2a142a4b0445aa5a1e62910"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"5d889970d6d340ab8d0ffa796dbe1e29"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29656,13 +28671,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ab4648ad-38cd-4bdc-a4ed-9c4bf1689b2d
+      - req-83160132-931c-4b84-9e18-9795e9d0a058
       Content-Length:
       - '4214'
       Connection:
@@ -29671,11 +28686,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:29.153930", "expires":
-        "2018-04-09T17:29:27Z", "id": "b1b65710e3d9445eb84c3bb5b557846a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:20.209082", "expires":
+        "2018-04-19T18:39:19Z", "id": "44175ecdb9bc4f75bcca555d6ec7315d", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["efzLxYalTO-xhuul783Nog",
-        "pnEBdAUxS7KjrTr1uA5Cdg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["FyrApFdsTfWZ0GsZScRmDQ",
+        "YiSW2SjdS2uCoZTBmzVz9w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -29720,7 +28735,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -29738,13 +28753,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f8aac87-ede4-457e-bab9-d053bcfe86bb
+      - req-d8eb22fb-3d9e-48bc-ab74-c4ed0b15637e
       Content-Length:
       - '370'
       Connection:
@@ -29753,13 +28768,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:29.308905", "expires":
-        "2018-04-09T17:29:29Z", "id": "c99611add51c46a389f8a5ef78cbc5c1", "audit_ids":
-        ["21nmuJX8RC2PqaMBFAs9FQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:20.459392", "expires":
+        "2018-04-19T18:39:20Z", "id": "101c007967fe4b009ef70a99a6e1fce9", "audit_ids":
+        ["4_JV2bHQTue242CsEUsClA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:20 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -29774,20 +28789,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99611add51c46a389f8a5ef78cbc5c1
+      - 101c007967fe4b009ef70a99a6e1fce9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4263eade-35e3-4851-9de9-aaddb6ffea75
+      - req-ddf9731a-c3aa-4212-a6a5-962feefa694b
       Content-Length:
       - '884'
       Connection:
@@ -29808,13 +28823,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c99611add51c46a389f8a5ef78cbc5c1"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"101c007967fe4b009ef70a99a6e1fce9"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29826,13 +28841,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-42f03079-2ec8-4946-9350-86c98a0ef243
+      - req-8eb33b8e-f7e8-481f-b2d6-388d0dedb017
       Content-Length:
       - '4214'
       Connection:
@@ -29841,11 +28856,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:29.605892", "expires":
-        "2018-04-09T17:29:29Z", "id": "d0f784c63f65403bab2919de19f2283d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:20.847236", "expires":
+        "2018-04-19T18:39:20Z", "id": "08c99359a09e47288b9f423e6a9ad88f", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["Cr2quQv1TnOHK_W6NAC1yg",
-        "21nmuJX8RC2PqaMBFAs9FQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["ZjjeQaWNQfm-LEzzup73jQ",
+        "4_JV2bHQTue242CsEUsClA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -29890,7 +28905,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:20 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -29905,20 +28920,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99611add51c46a389f8a5ef78cbc5c1
+      - 101c007967fe4b009ef70a99a6e1fce9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-585e3d94-0492-42a0-bd7c-c38615ee89a8
+      - req-08160998-6741-40a2-b718-a327d9843300
       Content-Length:
       - '884'
       Connection:
@@ -29939,7 +28954,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -29957,13 +28972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:29 GMT
+      - Thu, 19 Apr 2018 17:39:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ce29bdc-3720-4662-b2ea-5c36d693eb7c
+      - req-d6d886cd-3dc4-41de-8a8d-f900d926a0e9
       Content-Length:
       - '4188'
       Connection:
@@ -29972,10 +28987,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:29.948844", "expires":
-        "2018-04-09T17:29:29Z", "id": "f1b2b58d0af44d2bae7cc675cf152a75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:21.291029", "expires":
+        "2018-04-19T18:39:21Z", "id": "53e27dd59f764c7c957c0ba343916e2a", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["ciItqNbfRMeMdQFulDP3Fw"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["lS0ajGexTjyCamAK-s3YJQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -30020,7 +29035,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30038,13 +29053,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:30 GMT
+      - Thu, 19 Apr 2018 17:39:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d4d0795a-e44b-48b5-8b93-c1d11a93059c
+      - req-92bf3982-fbed-46bb-836b-89e43596d661
       Content-Length:
       - '4188'
       Connection:
@@ -30053,10 +29068,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:30.139715", "expires":
-        "2018-04-09T17:29:30Z", "id": "eec2349905a54250b3c2c853ccea2880", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:21.570522", "expires":
+        "2018-04-19T18:39:21Z", "id": "1cc5e5ac8460462892cb3db279eff8a7", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["B72Ycyz0SQOgBvG_WwTZYA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DQ1_VPg3TBePKbBbGeRUyQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -30101,7 +29116,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30119,13 +29134,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:30 GMT
+      - Thu, 19 Apr 2018 17:39:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8993f2a2-960c-4e7b-b0c6-6cc4eea4855a
+      - req-5716c085-adfc-496d-a6aa-ab9cd57fe15f
       Content-Length:
       - '4174'
       Connection:
@@ -30134,10 +29149,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:30.348270", "expires":
-        "2018-04-09T17:29:30Z", "id": "83cab65eae42482a885defbd971fa448", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:21.844041", "expires":
+        "2018-04-19T18:39:21Z", "id": "317c8fcba47b4b0ba5a78f5675fd5748", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hpsfQo8XRaOJ5cTQhLOPdg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kn-1UsODQmyOJ7tNncUSXQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -30182,7 +29197,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30200,13 +29215,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:30 GMT
+      - Thu, 19 Apr 2018 17:39:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47cca625-366a-4f05-862f-ce945e3fbe7f
+      - req-0d44ef92-acc0-45a5-ba01-a021ba7063d5
       Content-Length:
       - '4188'
       Connection:
@@ -30215,10 +29230,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:30.547868", "expires":
-        "2018-04-09T17:29:30Z", "id": "8cd5979fae4e4283bc68968b42ce433e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:22.160072", "expires":
+        "2018-04-19T18:39:22Z", "id": "dc67400a4b7d4102b37b0f873cba8783", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["xsv34QmjQWqcl6OnPr_7Cg"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["Hu_mkKuTQTqtdhe5mhhxxg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -30263,7 +29278,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30281,13 +29296,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:30 GMT
+      - Thu, 19 Apr 2018 17:39:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7e677542-6da3-4acf-8f0e-5cd61307480a
+      - req-9bc00a7e-0bef-4ae3-9851-b263e0608cda
       Content-Length:
       - '4175'
       Connection:
@@ -30296,10 +29311,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:30.749146", "expires":
-        "2018-04-09T17:29:30Z", "id": "21f8c5e61e1c456eb259b42f646aa8d1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:22.551988", "expires":
+        "2018-04-19T18:39:22Z", "id": "7b57be6e7d23451c9edce53917b80a0f", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["TMHVkhFLRU-wRIw4TYYFBQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tLxt2XdfQpOQaoh4Fz8ACA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -30344,7 +29359,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30362,13 +29377,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:30 GMT
+      - Thu, 19 Apr 2018 17:39:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-907e8809-9bbe-4266-903f-6d226d244474
+      - req-7e59d3f1-7c68-43dc-9ec0-73633482f7c7
       Content-Length:
       - '4188'
       Connection:
@@ -30377,10 +29392,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:30.956188", "expires":
-        "2018-04-09T17:29:30Z", "id": "952d3efb332a4f198f2df04740e24ac3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:22.805240", "expires":
+        "2018-04-19T18:39:22Z", "id": "03d48067a421426cba62918a0cb9badf", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["l7Po5xeoS-KrsboFV9kqzg"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["nnUcj1ShS-GjFEYgC5g7Pw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -30425,7 +29440,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30443,13 +29458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:31 GMT
+      - Thu, 19 Apr 2018 17:39:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b37ee27-1091-44ba-b4eb-f66ea99b489e
+      - req-6576c1da-ef58-4bd7-9e40-367039c9dafb
       Content-Length:
       - '4188'
       Connection:
@@ -30458,10 +29473,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:31.162956", "expires":
-        "2018-04-09T17:29:31Z", "id": "18dbc29a4a7840d1b631656bd31f7c55", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:23.165601", "expires":
+        "2018-04-19T18:39:23Z", "id": "ec67d72eef734f70a954235d4bd14174", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["ql-FP-5eQmi33N8ChWYq4w"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["QAsq1x5qTmmdLHsnq60Vyw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -30506,7 +29521,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -30521,27 +29536,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18dbc29a4a7840d1b631656bd31f7c55
+      - ec67d72eef734f70a954235d4bd14174
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6824acf7-d0cc-4669-92b5-3b2ba1ec9d6e
+      - req-2435e8b6-bbfc-437d-bdb3-a4e9f87ec5f4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6824acf7-d0cc-4669-92b5-3b2ba1ec9d6e
+      - req-2435e8b6-bbfc-437d-bdb3-a4e9f87ec5f4
       Date:
-      - Mon, 09 Apr 2018 16:29:31 GMT
+      - Thu, 19 Apr 2018 17:39:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30559,13 +29574,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:31 GMT
+      - Thu, 19 Apr 2018 17:39:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b826e531-ad99-46f2-ab98-988cc15802fd
+      - req-f851bd90-163a-4e4f-81cf-5fc56c69ee2f
       Content-Length:
       - '4188'
       Connection:
@@ -30574,10 +29589,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:31.657945", "expires":
-        "2018-04-09T17:29:31Z", "id": "5f5c04bdb3314ccebc327c61f340ad2d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:23.784718", "expires":
+        "2018-04-19T18:39:23Z", "id": "ffa34b108a174deba8c502a0c248d7f2", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["t2IGy62JS6OVNphaQQqiTQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["h3ejnLXeR2mDqYyVRC2L4Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -30622,7 +29637,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -30637,27 +29652,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f5c04bdb3314ccebc327c61f340ad2d
+      - ffa34b108a174deba8c502a0c248d7f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5daa41d2-7b78-4bc7-aa58-ad9ea7d2bf59
+      - req-283a3d83-d78f-4726-b527-949c45b00233
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5daa41d2-7b78-4bc7-aa58-ad9ea7d2bf59
+      - req-283a3d83-d78f-4726-b527-949c45b00233
       Date:
-      - Mon, 09 Apr 2018 16:29:31 GMT
+      - Thu, 19 Apr 2018 17:39:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30675,13 +29690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:32 GMT
+      - Thu, 19 Apr 2018 17:39:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a1aac97d-b323-4b7c-8c11-3814aa1244f6
+      - req-1b380392-b028-440f-9fb2-e509275038e9
       Content-Length:
       - '4174'
       Connection:
@@ -30690,10 +29705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:32.165960", "expires":
-        "2018-04-09T17:29:32Z", "id": "1d0bfcaeb07f47baaf6282520f8262f3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:24.462628", "expires":
+        "2018-04-19T18:39:24Z", "id": "06a038e42bf14dd09a5155e6dd999f23", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SP9E-SLkSQaLL0ZvM60Xcw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MD_s3TXpQHqAh1e-QqBHaQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -30738,7 +29753,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -30753,22 +29768,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1225bc2e-4c81-4c0b-9972-1b56ceed736f
+      - req-7601471e-bef9-4c1b-b30c-c457b48ce2b1
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-1225bc2e-4c81-4c0b-9972-1b56ceed736f
+      - req-7601471e-bef9-4c1b-b30c-c457b48ce2b1
       Date:
-      - Mon, 09 Apr 2018 16:29:32 GMT
+      - Thu, 19 Apr 2018 17:39:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -30801,7 +29816,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -30816,22 +29831,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d0e56cf-a966-4e68-9cf5-577d8a19a942
+      - req-780f89a8-c5eb-4bf1-b736-bf60b4dc857e
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-1d0e56cf-a966-4e68-9cf5-577d8a19a942
+      - req-780f89a8-c5eb-4bf1-b736-bf60b4dc857e
       Date:
-      - Mon, 09 Apr 2018 16:29:32 GMT
+      - Thu, 19 Apr 2018 17:39:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -30872,7 +29887,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -30887,22 +29902,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ec95a428-1893-42ad-8c9b-deadb01437e7
+      - req-7c092512-886e-48c0-bea3-fe68de786275
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-ec95a428-1893-42ad-8c9b-deadb01437e7
+      - req-7c092512-886e-48c0-bea3-fe68de786275
       Date:
-      - Mon, 09 Apr 2018 16:29:33 GMT
+      - Thu, 19 Apr 2018 17:39:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -30936,7 +29951,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -30951,27 +29966,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b592fd1b-a01f-4f4c-b3a8-542a0a3f1e98
+      - req-7d791976-aef1-4fab-ae2b-5667aff8eff1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b592fd1b-a01f-4f4c-b3a8-542a0a3f1e98
+      - req-7d791976-aef1-4fab-ae2b-5667aff8eff1
       Date:
-      - Mon, 09 Apr 2018 16:29:33 GMT
+      - Thu, 19 Apr 2018 17:39:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -30989,13 +30004,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:33 GMT
+      - Thu, 19 Apr 2018 17:39:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d36fca7-ffe7-4edf-85fc-63b609a12dba
+      - req-3afd7d35-68c9-4291-a162-0952377666d7
       Content-Length:
       - '4188'
       Connection:
@@ -31004,10 +30019,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:34.050268", "expires":
-        "2018-04-09T17:29:33Z", "id": "adebe182c4eb462f9b7cf0f8fffa9f94", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:26.113525", "expires":
+        "2018-04-19T18:39:26Z", "id": "c2c784e7fe024f5b9e0bc6dd422b2943", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["64c7OS4lTHmVD1dwnd0H9g"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["lxBarpTJQBmrOUlo01TCAQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -31052,7 +30067,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -31067,27 +30082,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adebe182c4eb462f9b7cf0f8fffa9f94
+      - c2c784e7fe024f5b9e0bc6dd422b2943
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-624944f1-2620-4ecc-85b9-dd79d33566f2
+      - req-a86b994f-8c9a-4a35-a013-b2a74ed03e25
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-624944f1-2620-4ecc-85b9-dd79d33566f2
+      - req-a86b994f-8c9a-4a35-a013-b2a74ed03e25
       Date:
-      - Mon, 09 Apr 2018 16:29:34 GMT
+      - Thu, 19 Apr 2018 17:39:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -31102,27 +30117,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91f19e29a8004181a50f8e4238174c45
+      - 15d9a925fda4455f894866e0ae097295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bc8a6592-b340-43fa-a275-ddecda81fb2f
+      - req-f1527f04-ba33-4ba1-baac-f9514185762e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bc8a6592-b340-43fa-a275-ddecda81fb2f
+      - req-f1527f04-ba33-4ba1-baac-f9514185762e
       Date:
-      - Mon, 09 Apr 2018 16:29:34 GMT
+      - Thu, 19 Apr 2018 17:39:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -31140,13 +30155,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:34 GMT
+      - Thu, 19 Apr 2018 17:39:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9691d0f4-2644-4dc9-81cc-f7b10bf62289
+      - req-187085bc-745c-464b-a995-a80091d5119f
       Content-Length:
       - '4175'
       Connection:
@@ -31155,10 +30170,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:35.117923", "expires":
-        "2018-04-09T17:29:35Z", "id": "7ccc55a6f4dd4e5f8d020fcb012dc274", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:27.141739", "expires":
+        "2018-04-19T18:39:27Z", "id": "43ec2c893cb24b0cb4ecff8f298ec21a", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hrgtr55rTZSqsOvM_iF5Mw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NWpb2gGtSpia-u_Le5W6nw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -31203,7 +30218,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -31218,27 +30233,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ccc55a6f4dd4e5f8d020fcb012dc274
+      - 43ec2c893cb24b0cb4ecff8f298ec21a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d1ccc0a-eacb-4e4d-b6f1-c16d5ea6abef
+      - req-c1757163-f382-4a7d-b79f-fe30b864f5f6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0d1ccc0a-eacb-4e4d-b6f1-c16d5ea6abef
+      - req-c1757163-f382-4a7d-b79f-fe30b864f5f6
       Date:
-      - Mon, 09 Apr 2018 16:29:35 GMT
+      - Thu, 19 Apr 2018 17:39:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -31256,13 +30271,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:35 GMT
+      - Thu, 19 Apr 2018 17:39:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a845954b-39ec-4b59-97f9-22f535691e58
+      - req-983c5ae9-7100-47db-8cc0-83ac793eb520
       Content-Length:
       - '4188'
       Connection:
@@ -31271,10 +30286,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:29:35.837980", "expires":
-        "2018-04-09T17:29:35Z", "id": "fcf079f30de0470dbd9549ddd25dcba8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:39:27.773178", "expires":
+        "2018-04-19T18:39:27Z", "id": "7decda3c702d4385a0051aee19120a3b", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["vEUHK42TQ4yDUS5VLfM4Lg"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["aEGhYvWGQDGAKoXzbVNUaA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -31319,7 +30334,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -31334,27 +30349,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcf079f30de0470dbd9549ddd25dcba8
+      - 7decda3c702d4385a0051aee19120a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a3d0f12-0e91-48cd-950e-7d93b56a9de4
+      - req-82738190-e7b7-468e-b879-7a663ec7bf75
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7a3d0f12-0e91-48cd-950e-7d93b56a9de4
+      - req-82738190-e7b7-468e-b879-7a663ec7bf75
       Date:
-      - Mon, 09 Apr 2018 16:29:36 GMT
+      - Thu, 19 Apr 2018 17:39:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -31369,27 +30384,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18dbc29a4a7840d1b631656bd31f7c55
+      - ec67d72eef734f70a954235d4bd14174
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d3d53ec-b304-43fc-96a5-85272b2d32f0
+      - req-3556ac82-5cc1-494d-a58c-e3a7bdbd72ff
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4d3d53ec-b304-43fc-96a5-85272b2d32f0
+      - req-3556ac82-5cc1-494d-a58c-e3a7bdbd72ff
       Date:
-      - Mon, 09 Apr 2018 16:29:36 GMT
+      - Thu, 19 Apr 2018 17:39:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -31404,27 +30419,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18dbc29a4a7840d1b631656bd31f7c55
+      - ec67d72eef734f70a954235d4bd14174
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1203818b-82a7-4c53-9b8f-f3cfe8380994
+      - req-0369f804-e933-4196-9a23-34c392ded4f1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1203818b-82a7-4c53-9b8f-f3cfe8380994
+      - req-0369f804-e933-4196-9a23-34c392ded4f1
       Date:
-      - Mon, 09 Apr 2018 16:29:36 GMT
+      - Thu, 19 Apr 2018 17:39:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -31439,27 +30454,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f5c04bdb3314ccebc327c61f340ad2d
+      - ffa34b108a174deba8c502a0c248d7f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed5fc5d2-e2c8-45e8-afd0-1005cdd3e926
+      - req-e9e53a43-fc96-4b68-841d-bffa29dee338
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ed5fc5d2-e2c8-45e8-afd0-1005cdd3e926
+      - req-e9e53a43-fc96-4b68-841d-bffa29dee338
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -31474,27 +30489,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f5c04bdb3314ccebc327c61f340ad2d
+      - ffa34b108a174deba8c502a0c248d7f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a262a93a-6c71-4a0a-8a9e-d8dd893a8183
+      - req-08effd14-d72d-4786-ad84-9e01686dafda
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a262a93a-6c71-4a0a-8a9e-d8dd893a8183
+      - req-08effd14-d72d-4786-ad84-9e01686dafda
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -31509,22 +30524,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4fc15b78-d742-4f47-97c8-2a8b4be8b47d
+      - req-965251cb-defd-4387-9447-ac5084df18b3
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-4fc15b78-d742-4f47-97c8-2a8b4be8b47d
+      - req-965251cb-defd-4387-9447-ac5084df18b3
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -31539,7 +30554,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -31554,22 +30569,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eeb02a91-ca16-4a2c-84b9-aa78aa1e58ec
+      - req-24ed721e-605c-4160-807b-d2dc034092ab
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-eeb02a91-ca16-4a2c-84b9-aa78aa1e58ec
+      - req-24ed721e-605c-4160-807b-d2dc034092ab
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -31584,7 +30599,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -31599,27 +30614,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adebe182c4eb462f9b7cf0f8fffa9f94
+      - c2c784e7fe024f5b9e0bc6dd422b2943
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-791b5c87-49cb-4d84-aea2-042d7429c808
+      - req-01c5e370-9ccb-4d92-994d-1a5e483329bd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-791b5c87-49cb-4d84-aea2-042d7429c808
+      - req-01c5e370-9ccb-4d92-994d-1a5e483329bd
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -31634,27 +30649,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adebe182c4eb462f9b7cf0f8fffa9f94
+      - c2c784e7fe024f5b9e0bc6dd422b2943
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-236bec9e-e555-41d5-8fba-199fd70ee612
+      - req-83e3efa6-4447-419c-a681-960bf96b2f80
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-236bec9e-e555-41d5-8fba-199fd70ee612
+      - req-83e3efa6-4447-419c-a681-960bf96b2f80
       Date:
-      - Mon, 09 Apr 2018 16:29:37 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -31669,27 +30684,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91f19e29a8004181a50f8e4238174c45
+      - 15d9a925fda4455f894866e0ae097295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b33be5e3-41f0-4d19-b6c8-10607f80d9c0
+      - req-24f8845c-94fe-4dcf-9476-9c5ff709316e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b33be5e3-41f0-4d19-b6c8-10607f80d9c0
+      - req-24f8845c-94fe-4dcf-9476-9c5ff709316e
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -31704,27 +30719,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91f19e29a8004181a50f8e4238174c45
+      - 15d9a925fda4455f894866e0ae097295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-051c269d-3713-4e0c-929c-33fae57c9708
+      - req-c5616c68-2e83-429c-bf96-9385c9768444
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-051c269d-3713-4e0c-929c-33fae57c9708
+      - req-c5616c68-2e83-429c-bf96-9385c9768444
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -31739,27 +30754,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ccc55a6f4dd4e5f8d020fcb012dc274
+      - 43ec2c893cb24b0cb4ecff8f298ec21a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0bf2ef8-0994-4a3b-92bb-71a905819795
+      - req-859f1ed0-b08b-4105-8938-6001ccab82d5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b0bf2ef8-0994-4a3b-92bb-71a905819795
+      - req-859f1ed0-b08b-4105-8938-6001ccab82d5
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -31774,27 +30789,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ccc55a6f4dd4e5f8d020fcb012dc274
+      - 43ec2c893cb24b0cb4ecff8f298ec21a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d25f73a7-7e78-4be0-a3ac-8e45bf4bf6ca
+      - req-fb4e82d3-e9f5-4cb3-b5dd-0f2bab057684
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d25f73a7-7e78-4be0-a3ac-8e45bf4bf6ca
+      - req-fb4e82d3-e9f5-4cb3-b5dd-0f2bab057684
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -31809,27 +30824,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcf079f30de0470dbd9549ddd25dcba8
+      - 7decda3c702d4385a0051aee19120a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9dc2f9cd-8ea2-4019-af0b-8eb9e20aafda
+      - req-acc7dc76-9d13-477f-90e8-289b2508d227
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9dc2f9cd-8ea2-4019-af0b-8eb9e20aafda
+      - req-acc7dc76-9d13-477f-90e8-289b2508d227
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -31844,27 +30859,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcf079f30de0470dbd9549ddd25dcba8
+      - 7decda3c702d4385a0051aee19120a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce3235b3-e4af-4a45-b8fc-b210f21f520b
+      - req-2f303b68-e1aa-411f-bf72-58f92ca025dc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ce3235b3-e4af-4a45-b8fc-b210f21f520b
+      - req-2f303b68-e1aa-411f-bf72-58f92ca025dc
       Date:
-      - Mon, 09 Apr 2018 16:29:38 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -31879,27 +30894,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18dbc29a4a7840d1b631656bd31f7c55
+      - ec67d72eef734f70a954235d4bd14174
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78d9b42e-ebda-4a71-89d2-000d59d8d64a
+      - req-bedd386a-025c-4412-9b71-eb3fc5613405
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-78d9b42e-ebda-4a71-89d2-000d59d8d64a
+      - req-bedd386a-025c-4412-9b71-eb3fc5613405
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -31914,27 +30929,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18dbc29a4a7840d1b631656bd31f7c55
+      - ec67d72eef734f70a954235d4bd14174
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e0f4ad35-21be-4bcd-9009-9b1d46914971
+      - req-0618d7e0-430b-4455-a9a1-81fee8cd2c37
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e0f4ad35-21be-4bcd-9009-9b1d46914971
+      - req-0618d7e0-430b-4455-a9a1-81fee8cd2c37
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -31949,27 +30964,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f5c04bdb3314ccebc327c61f340ad2d
+      - ffa34b108a174deba8c502a0c248d7f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-587dec80-7a1b-4e7f-8a97-0f6803a4157a
+      - req-f7400476-67c5-4c95-a524-80a521d9e76a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-587dec80-7a1b-4e7f-8a97-0f6803a4157a
+      - req-f7400476-67c5-4c95-a524-80a521d9e76a
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -31984,27 +30999,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f5c04bdb3314ccebc327c61f340ad2d
+      - ffa34b108a174deba8c502a0c248d7f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f695f478-7c68-469b-9d1c-b8b73bc6896a
+      - req-6d2a836b-2a96-458e-9ee6-62ad7169f6af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f695f478-7c68-469b-9d1c-b8b73bc6896a
+      - req-6d2a836b-2a96-458e-9ee6-62ad7169f6af
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -32019,27 +31034,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5eb2222c-09f3-4a01-ae47-27ff4d2da19a
+      - req-10981134-9889-4d7b-8569-1d49f7c68a17
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5eb2222c-09f3-4a01-ae47-27ff4d2da19a
+      - req-10981134-9889-4d7b-8569-1d49f7c68a17
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -32054,27 +31069,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d0bfcaeb07f47baaf6282520f8262f3
+      - 06a038e42bf14dd09a5155e6dd999f23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0229c66f-8bf9-43a6-bc11-9977cf25420e
+      - req-ceaabf35-1a2d-4952-b30e-a1226e400dd6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0229c66f-8bf9-43a6-bc11-9977cf25420e
+      - req-ceaabf35-1a2d-4952-b30e-a1226e400dd6
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -32089,27 +31104,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adebe182c4eb462f9b7cf0f8fffa9f94
+      - c2c784e7fe024f5b9e0bc6dd422b2943
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2cf36c4-ba8a-41fa-9250-ac9c8bc07b04
+      - req-27860c69-6eda-487b-8a66-bf5155eb1367
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f2cf36c4-ba8a-41fa-9250-ac9c8bc07b04
+      - req-27860c69-6eda-487b-8a66-bf5155eb1367
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -32124,27 +31139,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adebe182c4eb462f9b7cf0f8fffa9f94
+      - c2c784e7fe024f5b9e0bc6dd422b2943
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08477d95-a3d2-4f11-9d5d-ddeee065406d
+      - req-c9f00693-20c8-42aa-ab64-ebe3ed063532
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-08477d95-a3d2-4f11-9d5d-ddeee065406d
+      - req-c9f00693-20c8-42aa-ab64-ebe3ed063532
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -32159,27 +31174,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91f19e29a8004181a50f8e4238174c45
+      - 15d9a925fda4455f894866e0ae097295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e286a0ca-58b5-46ff-84fa-e5266ff42984
+      - req-70b5ecad-996d-4c7c-9b37-b4f0eb301c5b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e286a0ca-58b5-46ff-84fa-e5266ff42984
+      - req-70b5ecad-996d-4c7c-9b37-b4f0eb301c5b
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -32194,27 +31209,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91f19e29a8004181a50f8e4238174c45
+      - 15d9a925fda4455f894866e0ae097295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b87d0e8e-bd1d-4692-b5ae-60bb0dfe7c78
+      - req-afa63d6b-c2c7-4b34-9996-40465d6196e2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b87d0e8e-bd1d-4692-b5ae-60bb0dfe7c78
+      - req-afa63d6b-c2c7-4b34-9996-40465d6196e2
       Date:
-      - Mon, 09 Apr 2018 16:29:39 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -32229,27 +31244,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ccc55a6f4dd4e5f8d020fcb012dc274
+      - 43ec2c893cb24b0cb4ecff8f298ec21a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f1917b84-09e8-41b2-b591-3f2211dd6e18
+      - req-3249df92-594f-489c-ba7a-0e62d09257e1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f1917b84-09e8-41b2-b591-3f2211dd6e18
+      - req-3249df92-594f-489c-ba7a-0e62d09257e1
       Date:
-      - Mon, 09 Apr 2018 16:29:40 GMT
+      - Thu, 19 Apr 2018 17:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -32264,27 +31279,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ccc55a6f4dd4e5f8d020fcb012dc274
+      - 43ec2c893cb24b0cb4ecff8f298ec21a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61680f34-8a30-4c46-85f3-466e01d1e6a8
+      - req-ddb4130e-3487-4fd8-b6c8-e79fc7dd494a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-61680f34-8a30-4c46-85f3-466e01d1e6a8
+      - req-ddb4130e-3487-4fd8-b6c8-e79fc7dd494a
       Date:
-      - Mon, 09 Apr 2018 16:29:40 GMT
+      - Thu, 19 Apr 2018 17:39:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -32299,27 +31314,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcf079f30de0470dbd9549ddd25dcba8
+      - 7decda3c702d4385a0051aee19120a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4721f7a4-6702-4068-8e73-99e72cf9aa3c
+      - req-3a63f2c4-6c1f-480a-8e3b-aa025277ff8d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4721f7a4-6702-4068-8e73-99e72cf9aa3c
+      - req-3a63f2c4-6c1f-480a-8e3b-aa025277ff8d
       Date:
-      - Mon, 09 Apr 2018 16:29:40 GMT
+      - Thu, 19 Apr 2018 17:39:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -32334,27 +31349,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcf079f30de0470dbd9549ddd25dcba8
+      - 7decda3c702d4385a0051aee19120a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6051f430-5210-4d0b-b0bd-53ece6987ba8
+      - req-159cdcc6-4f96-4793-8d94-eb7051641089
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6051f430-5210-4d0b-b0bd-53ece6987ba8
+      - req-159cdcc6-4f96-4793-8d94-eb7051641089
       Date:
-      - Mon, 09 Apr 2018 16:29:40 GMT
+      - Thu, 19 Apr 2018 17:39:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32372,15 +31387,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:40 GMT
+      - Thu, 19 Apr 2018 17:39:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7cce602b4c24da7b37fa7f5318f5b90
+      - 17c42252405d42d699d9f328cfcedfcb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01e9850c-adae-478c-b9e7-4f9543abab74
+      - req-74c2773d-1f27-494d-9267-f45dda967a19
       Content-Length:
       - '7311'
       Connection:
@@ -32392,7 +31407,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:29:41.171446Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:32.709614Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32471,10 +31486,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XW8_TnyIRgyXpTeftt8Ckw"],
-        "issued_at": "2018-04-09T16:29:41.171525Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AGuavbcMRjaFjH72Zv0tVg"],
+        "issued_at": "2018-04-19T17:39:32.709679Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32492,15 +31507,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:41 GMT
+      - Thu, 19 Apr 2018 17:39:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - de32313962254528ba63fc7bc6b71303
+      - e956cb819a9346fabedff15b862739de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-65f2c63b-8cbe-45b9-9101-118da55b1a05
+      - req-7ff78317-14b5-4dde-a080-3d6ba6807ec0
       Content-Length:
       - '7311'
       Connection:
@@ -32512,7 +31527,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:29:41.799267Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:33.037264Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32591,10 +31606,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PqoM6PJRRm6Aki0fkiek0A"],
-        "issued_at": "2018-04-09T16:29:41.799367Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9UMPI4aeTDCfvWhfuNN-Hw"],
+        "issued_at": "2018-04-19T17:39:33.037325Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32612,15 +31627,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:41 GMT
+      - Thu, 19 Apr 2018 17:39:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 890caf68902544d5a144b6fba78cc72a
+      - fe728daecc6147afa0ce1fc42ec3d48c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf7b3fb2-aa47-42a5-8cc3-7f80563b5cc4
+      - req-3b04591c-e3cf-496d-ada2-b864f1f1bafa
       Content-Length:
       - '297'
       Connection:
@@ -32629,12 +31644,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:29:42.077483Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:39:33.237130Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GKIqFUCBSfWKSnAFQIyZsA"],
-        "issued_at": "2018-04-09T16:29:42.077552Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BeBYu_03TaqMNIPIOPzWLQ"],
+        "issued_at": "2018-04-19T17:39:33.237190Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -32649,20 +31664,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 890caf68902544d5a144b6fba78cc72a
+      - fe728daecc6147afa0ce1fc42ec3d48c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:42 GMT
+      - Thu, 19 Apr 2018 17:39:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b2683b3-250b-4512-a6bf-4bbcaf0a711d
+      - req-631ca347-eea8-4d6e-8b61-1187d018d17c
       Content-Length:
       - '2457'
       Connection:
@@ -32695,13 +31710,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"890caf68902544d5a144b6fba78cc72a"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"fe728daecc6147afa0ce1fc42ec3d48c"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -32713,15 +31728,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:42 GMT
+      - Thu, 19 Apr 2018 17:39:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e714a15a66e4c6a9b0e31cda9c46790
+      - 5519bcb0925b407498526231dc19a1ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1fb43d12-034b-4213-b65a-5ff22a8b2ca0
+      - req-f5ae72df-f770-4f52-9b6a-7504d346766a
       Content-Length:
       - '7313'
       Connection:
@@ -32733,7 +31748,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:42.077483Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:33.237130Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32812,10 +31827,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KRzSW7JSS8qX1eptQ0r_Ug",
-        "GKIqFUCBSfWKSnAFQIyZsA"], "issued_at": "2018-04-09T16:29:42.538253Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_atLpZ64TWWPrzqhFu-MQg",
+        "BeBYu_03TaqMNIPIOPzWLQ"], "issued_at": "2018-04-19T17:39:33.653586Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -32830,20 +31845,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e714a15a66e4c6a9b0e31cda9c46790
+      - 5519bcb0925b407498526231dc19a1ce
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:42 GMT
+      - Thu, 19 Apr 2018 17:39:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a7ed57a6-cab6-4928-9a78-7a7108d0646b
+      - req-2a16744d-24f8-4d6d-9ac8-328a0d37f156
       Content-Length:
       - '2179'
       Connection:
@@ -32876,7 +31891,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32894,15 +31909,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:42 GMT
+      - Thu, 19 Apr 2018 17:39:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ee109bc3c294f5294a1d2d42cb9cd62
+      - 89ec751cc1ec4a36992a652c7c51e867
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ba649c8-9469-4da5-97cd-b0731e352a99
+      - req-acf37f88-94bc-48f8-a4d0-c7020fc998d7
       Content-Length:
       - '7278'
       Connection:
@@ -32914,7 +31929,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:42.989310Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:34.102425Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32993,10 +32008,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yJax1lC6Rf-mbBj23H370g"],
-        "issued_at": "2018-04-09T16:29:42.989388Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wA_PZRSQRRCrtpyoZFxh4w"],
+        "issued_at": "2018-04-19T17:39:34.102502Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33014,15 +32029,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:43 GMT
+      - Thu, 19 Apr 2018 17:39:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3261529efc984684a80d712bfb0507e0
+      - f8593329381c44f781f21853eda53adc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8fa208ad-b18e-4d58-acc0-c6fb21df2c18
+      - req-8fd411dc-e2e7-477e-aa02-100234999b60
       Content-Length:
       - '7278'
       Connection:
@@ -33034,7 +32049,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:43.368065Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:34.512292Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33113,10 +32128,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["poUbLQ75Q4ORCPXxbxsToQ"],
-        "issued_at": "2018-04-09T16:29:43.368163Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vveGNjXJQ0uKsu1rqeAOsA"],
+        "issued_at": "2018-04-19T17:39:34.512369Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33134,15 +32149,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:43 GMT
+      - Thu, 19 Apr 2018 17:39:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc1faafe28834bb2bef0dbe3719575b4
+      - 6f577d601cf74509a198ab529b001858
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2d90a4f2-bbf4-44bd-884e-49ab3e863e16
+      - req-7f57d7a6-3ecf-4281-aded-d3c415d46195
       Content-Length:
       - '7264'
       Connection:
@@ -33154,7 +32169,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:43.765941Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:34.822480Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33233,10 +32248,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nz3xfRf6RVaUHdSl7BGnRw"],
-        "issued_at": "2018-04-09T16:29:43.766013Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F-UsGZejRhmEO9qvTUPiLg"],
+        "issued_at": "2018-04-19T17:39:34.822544Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33254,15 +32269,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:43 GMT
+      - Thu, 19 Apr 2018 17:39:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f86fa495751746099f9c105092e3ae58
+      - 8afa69b53fa14b9da5dbed7cefd8b4ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ae5dbc5-bcdf-411f-a4c0-2688b231770c
+      - req-14f94914-2494-4a57-af8e-11200d7647ea
       Content-Length:
       - '7278'
       Connection:
@@ -33274,7 +32289,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:44.157138Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:35.129576Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33353,10 +32368,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nEXwOJbLQESPAaU1uOMLVQ"],
-        "issued_at": "2018-04-09T16:29:44.157184Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ci2W8gBhRR-oaVQuDIW47g"],
+        "issued_at": "2018-04-19T17:39:35.129645Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33374,15 +32389,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:44 GMT
+      - Thu, 19 Apr 2018 17:39:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 984392e20f9a4c3d8f944b589254ce45
+      - d4c55bbd8dd349588fddf780a13ac05f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2a76ab13-c9cd-489f-bb8c-7102bb9ffbb1
+      - req-f0acce21-b215-4ced-b72b-a1a900531baf
       Content-Length:
       - '7265'
       Connection:
@@ -33394,7 +32409,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:44.400521Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:35.430244Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33473,10 +32488,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oaH4yA7TT4aLFLhfEkH8Gw"],
-        "issued_at": "2018-04-09T16:29:44.400566Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kd1wBWTHQQWfB8NGuj75eg"],
+        "issued_at": "2018-04-19T17:39:35.430307Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33494,15 +32509,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:44 GMT
+      - Thu, 19 Apr 2018 17:39:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 542893f76f564ad6af73b29a9b25eabf
+      - de7195069a894eb8a33568190d1ba1dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-44c42b4a-ec03-4552-a66f-35acd373ea44
+      - req-4f295b65-cf36-4f61-8bfe-a1c2e36660ae
       Content-Length:
       - '7278'
       Connection:
@@ -33514,7 +32529,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:44.800689Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:35.730153Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33593,10 +32608,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["boKOf5bcTbiT4TLEHs9SIQ"],
-        "issued_at": "2018-04-09T16:29:44.800795Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m4hW0RSGQbukORIvMbvdAQ"],
+        "issued_at": "2018-04-19T17:39:35.730245Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33614,15 +32629,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:44 GMT
+      - Thu, 19 Apr 2018 17:39:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2ed2ae75ae1748dea94d3a82891d058f
+      - 7a7d6dda7c1c4aaa9004b4a00312e489
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6325da87-855a-438a-b4f0-e5ad157c0bd6
+      - req-7c5e4785-0f51-4886-b7e1-609a5164ed5b
       Content-Length:
       - '7278'
       Connection:
@@ -33634,7 +32649,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:45.183673Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:36.037231Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33713,10 +32728,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x1jm8Ar4SVa_YCSI3BjdZw"],
-        "issued_at": "2018-04-09T16:29:45.183741Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m2_SetEGTcOsZgrZ6Kd0vg"],
+        "issued_at": "2018-04-19T17:39:36.037298Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -33731,7 +32746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed2ae75ae1748dea94d3a82891d058f
+      - 7a7d6dda7c1c4aaa9004b4a00312e489
   response:
     status:
       code: 200
@@ -33744,22 +32759,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291385.37200'
+      - '1524159576.22403'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291385.37200'
+      - '1524159576.22403'
       X-Trans-Id:
-      - tx3c925033442843ffaaf46-005acb94f9
+      - tx0767dc017a6f447c8b836-005ad8d458
       Date:
-      - Mon, 09 Apr 2018 16:29:45 GMT
+      - Thu, 19 Apr 2018 17:39:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33777,15 +32792,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:45 GMT
+      - Thu, 19 Apr 2018 17:39:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fb28452c3fba4e288b5f15b7bf10f565
+      - 8bf46b0e5a6444e193e303b8c286480f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c7a1dd35-1818-461e-9ab9-5f82cf64cf3e
+      - req-535c24e6-1c7d-44cb-a1f6-efd0520fa8cf
       Content-Length:
       - '7278'
       Connection:
@@ -33797,7 +32812,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:45.698270Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:36.637662Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33876,10 +32891,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fIha1-DHQNOaBejmjhA0HQ"],
-        "issued_at": "2018-04-09T16:29:45.698330Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VjbfnDsgQZCJn9uJNHMCxQ"],
+        "issued_at": "2018-04-19T17:39:36.637740Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -33894,7 +32909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb28452c3fba4e288b5f15b7bf10f565
+      - 8bf46b0e5a6444e193e303b8c286480f
   response:
     status:
       code: 200
@@ -33907,22 +32922,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291385.95611'
+      - '1524159576.81694'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291385.95611'
+      - '1524159576.81694'
       X-Trans-Id:
-      - txfd75ae570c4840d8bf073-005acb94f9
+      - txa3b28cf291f34b23bee9d-005ad8d458
       Date:
-      - Mon, 09 Apr 2018 16:29:45 GMT
+      - Thu, 19 Apr 2018 17:39:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33940,15 +32955,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:46 GMT
+      - Thu, 19 Apr 2018 17:39:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-697c8fd2-db3c-4cdf-baa7-8c557e603d0f
+      - req-250948af-0381-4140-9a1b-06af44adc98c
       Content-Length:
       - '7264'
       Connection:
@@ -33960,7 +32975,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:46.302801Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:37.106549Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34039,10 +33054,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1TaqbS3JQOqA_MrIonpi1A"],
-        "issued_at": "2018-04-09T16:29:46.302876Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Wj31ft5YTHqYYRwyjDpz8A"],
+        "issued_at": "2018-04-19T17:39:37.106616Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -34057,7 +33072,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
   response:
     status:
       code: 200
@@ -34086,15 +33101,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txecd9381a13424c279ede2-005acb94fa
+      - tx24077a8d23754f2bbbe6e-005ad8d459
       Date:
-      - Mon, 09 Apr 2018 16:29:46 GMT
+      - Thu, 19 Apr 2018 17:39:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -34109,7 +33124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
   response:
     status:
       code: 200
@@ -34138,14 +33153,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx6486345362d441aba3ea9-005acb94fa
+      - txe7cfdf5bcc1a40a2b0642-005ad8d459
       Date:
-      - Mon, 09 Apr 2018 16:29:46 GMT
+      - Thu, 19 Apr 2018 17:39:37 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34163,15 +33178,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:46 GMT
+      - Thu, 19 Apr 2018 17:39:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4a9cc122540a455aa54b5b12871a4aa3
+      - '0199930f739a47e1a5ee09bea118e768'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1f6d2d30-0927-4642-82c7-4ca34798f066
+      - req-95e13816-acb4-459a-b859-751107ffc337
       Content-Length:
       - '7278'
       Connection:
@@ -34183,7 +33198,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:46.913811Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:37.717736Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34262,10 +33277,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VCZzJdnyRKWk3NFBSldZJg"],
-        "issued_at": "2018-04-09T16:29:46.913889Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d3fZEvh-TsW1XbZ8jZEUgg"],
+        "issued_at": "2018-04-19T17:39:37.717851Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -34280,7 +33295,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a9cc122540a455aa54b5b12871a4aa3
+      - '0199930f739a47e1a5ee09bea118e768'
   response:
     status:
       code: 200
@@ -34293,22 +33308,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291387.12291'
+      - '1524159577.91069'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291387.12291'
+      - '1524159577.91069'
       X-Trans-Id:
-      - txc959dfeb0e2647f189cf0-005acb94fb
+      - txb6e24b20068246e19156a-005ad8d459
       Date:
-      - Mon, 09 Apr 2018 16:29:47 GMT
+      - Thu, 19 Apr 2018 17:39:37 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -34323,7 +33338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de32313962254528ba63fc7bc6b71303
+      - e956cb819a9346fabedff15b862739de
   response:
     status:
       code: 200
@@ -34336,22 +33351,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291387.32082'
+      - '1524159578.06707'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291387.32082'
+      - '1524159578.06707'
       X-Trans-Id:
-      - tx48e85680a12f422991a79-005acb94fb
+      - tx1e6175c0868f40f3bb4c3-005ad8d459
       Date:
-      - Mon, 09 Apr 2018 16:29:47 GMT
+      - Thu, 19 Apr 2018 17:39:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34369,15 +33384,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:47 GMT
+      - Thu, 19 Apr 2018 17:39:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 37140ce5f27b408fbc043b71bba5b7da
+      - cbd36012e1494a79a3fe954af1bdc526
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1a765922-191c-4938-9f8a-b2d060018209
+      - req-682dbd0f-73b7-43be-86df-2c0bd8947222
       Content-Length:
       - '7265'
       Connection:
@@ -34389,7 +33404,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:47.541425Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:38.383558Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34468,10 +33483,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rLQ_P0HmTqyLweCZ0DcyEA"],
-        "issued_at": "2018-04-09T16:29:47.541462Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VoMT_3AwTGK0aqKMMJdqzA"],
+        "issued_at": "2018-04-19T17:39:38.383643Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -34486,7 +33501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37140ce5f27b408fbc043b71bba5b7da
+      - cbd36012e1494a79a3fe954af1bdc526
   response:
     status:
       code: 200
@@ -34499,22 +33514,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291387.68297'
+      - '1524159578.60585'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291387.68297'
+      - '1524159578.60585'
       X-Trans-Id:
-      - tx9aeee98ab2e54b559f3ba-005acb94fb
+      - txf015d048483849089c2a6-005ad8d45a
       Date:
-      - Mon, 09 Apr 2018 16:29:47 GMT
+      - Thu, 19 Apr 2018 17:39:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34532,15 +33547,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:47 GMT
+      - Thu, 19 Apr 2018 17:39:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 819f89840e6e4ba683e3c1c3eadd9c3e
+      - c33702c1f18a47518a9f530163d45630
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ce42389-5a25-4d70-b20c-5b576b5376e8
+      - req-edbb8876-5128-493f-af9c-ad77942281c6
       Content-Length:
       - '7278'
       Connection:
@@ -34552,7 +33567,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:29:47.931679Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:38.921239Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34631,10 +33646,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GwsGXXyNSR6vfSeS4B8gvQ"],
-        "issued_at": "2018-04-09T16:29:47.931719Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["py3O4TkdTtSibnT_vgNTnA"],
+        "issued_at": "2018-04-19T17:39:38.921306Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -34649,7 +33664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 819f89840e6e4ba683e3c1c3eadd9c3e
+      - c33702c1f18a47518a9f530163d45630
   response:
     status:
       code: 200
@@ -34662,22 +33677,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291388.07106'
+      - '1524159579.11154'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291388.07106'
+      - '1524159579.11154'
       X-Trans-Id:
-      - tx4f87e73130c34b7092267-005acb94fc
+      - tx940b69b8c62f459181ac3-005ad8d45b
       Date:
-      - Mon, 09 Apr 2018 16:29:48 GMT
+      - Thu, 19 Apr 2018 17:39:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -34692,7 +33707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
   response:
     status:
       code: 200
@@ -34713,9 +33728,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txfa58d010cfc843d6bcdbc-005acb94fc
+      - tx9a0d4fb6f43e4f31aa089-005ad8d45b
       Date:
-      - Mon, 09 Apr 2018 16:29:48 GMT
+      - Thu, 19 Apr 2018 17:39:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -34725,7 +33740,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -34740,7 +33755,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
   response:
     status:
       code: 200
@@ -34761,14 +33776,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx42b49c6c05cb4be5948d1-005acb94fc
+      - tx22cc748ea5af4418a01ad-005ad8d45b
       Date:
-      - Mon, 09 Apr 2018 16:29:48 GMT
+      - Thu, 19 Apr 2018 17:39:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -34783,7 +33798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c49c28ffa474e03ad3a083942f64830
+      - b3b56e5c25af4e88b867fac1718b5b57
   response:
     status:
       code: 200
@@ -34804,12 +33819,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txcb1ef07143934bcb87be2-005acb94fc
+      - txebf25e10a1094876828d2-005ad8d45b
       Date:
-      - Mon, 09 Apr 2018 16:29:48 GMT
+      - Thu, 19 Apr 2018 17:39:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:29:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:29:59 GMT
+      - Thu, 19 Apr 2018 17:39:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-86da4f18-66b7-456e-b4e6-3f275e12af55
+      - req-118df41c-6287-4cc6-8889-3ab829a5efda
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:00.141345Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:51.337400Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mTaWifgGQ_-5kU1n25Xbjg"],
-        "issued_at": "2018-04-09T16:30:00.141391Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hvkoyF0zRqeRk_Z5w_Z-DA"],
+        "issued_at": "2018-04-19T17:39:51.337494Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:00 GMT
+      - Thu, 19 Apr 2018 17:39:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-1ba7c187-b5c3-4c3f-ad8e-918f050a4265
+      - req-b7f89d3e-3ecf-4165-81bb-e6f162bf7604
       Date:
-      - Mon, 09 Apr 2018 16:30:00 GMT
+      - Thu, 19 Apr 2018 17:39:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:00 GMT
+      - Thu, 19 Apr 2018 17:39:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b3d0f941-4d08-4f9b-8aa6-3db6347fcac4
+      - req-2a7287dd-8e55-4b4e-b21d-b14994aabdc4
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:00.665093Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:52.106501Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ohx8T6bEQ3SznGZISfItRg"],
-        "issued_at": "2018-04-09T16:30:00.665167Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yZhjlXs6SwGoRyu1vvedoA"],
+        "issued_at": "2018-04-19T17:39:52.106581Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-873d152e-a4ca-4308-b1a9-da133eaf860a
+      - req-d1769a0b-c322-41e7-8697-35c228c26f5b
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-873d152e-a4ca-4308-b1a9-da133eaf860a
+      - req-d1769a0b-c322-41e7-8697-35c228c26f5b
       Date:
-      - Mon, 09 Apr 2018 16:30:00 GMT
+      - Thu, 19 Apr 2018 17:39:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3df3b0c5-2629-439f-a6c1-14675f7794d3
+      - req-89d8d730-d384-499a-aa8b-cc7742ddd82d
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:29:59.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:39:42.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:30:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:39:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:29:54.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:39:44.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:29:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:39:42.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:29:59.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:39:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a9f69105-ee25-4a36-9ab4-0cbde6f1f72f
+      - req-058f600d-0f05-4507-98a7-b1ecb0a7230b
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:29:59.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:39:52.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:30:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:39:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:29:54.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:39:44.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:29:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:39:42.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:29:59.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:39:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-579d520d-1d6a-48fa-9433-e24c40d9dbc3
+      - req-f6c07f61-8711-4921-a10c-814ed5b7fd6d
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-b8f8fb15-7ec4-4aba-8ae1-bce58149d0fc
+      - req-aac1e9dc-4485-4786-96d4-269b69e5ff54
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-1c74ed69-9d33-4474-a4ab-e5cfbd6c6dbb
+      - req-c6701715-ca12-4c23-bc68-ab98c39f80c0
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-ca22abcb-9f41-4602-b5bd-6f77545afdc7
+      - req-7fdd767a-d71c-4e02-ba76-25b62667fc64
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +613,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8abb5ac80eb24dabbb0a2cc0e6ad44b5
+      - 1de507fcd57040ab95595442fd620a2f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-253a038e-dff9-45e4-8452-1ba748babb57
+      - req-73cc8c50-6ad0-4b70-b624-c353b83d9ca3
       Content-Length:
       - '7311'
       Connection:
@@ -651,7 +651,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:01.880731Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:53.527050Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -730,10 +730,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4L2e6cfhRLmBOnIfQza0tA"],
-        "issued_at": "2018-04-09T16:30:01.880789Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mgk3otuuQfGQN6rzxdtsWg"],
+        "issued_at": "2018-04-19T17:39:53.527112Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -748,20 +748,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8abb5ac80eb24dabbb0a2cc0e6ad44b5
+      - 1de507fcd57040ab95595442fd620a2f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:01 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4dcbe9ad-fcbc-4dbc-a22a-78e6faca97ca
+      - req-973395a3-3ed1-4da0-85a4-8446c03afb57
       Content-Length:
       - '2179'
       Connection:
@@ -794,7 +794,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -809,7 +809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -822,15 +822,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-501b55e4-e2f0-4750-bb85-c1dd5337c650
+      - req-93857096-9104-4114-a4ab-4ad98fb43898
       Date:
-      - Mon, 09 Apr 2018 16:30:02 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -848,15 +848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:02 GMT
+      - Thu, 19 Apr 2018 17:39:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a91a0e9d352844759287f188b0ac27c7
+      - b763b18bb02b4911861c55b0f9c0799f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9a8ca23b-a2a6-4175-adc1-525fbe6e6016
+      - req-6d0e100c-07a1-4a34-a9cc-a76b6b01a148
       Content-Length:
       - '7311'
       Connection:
@@ -868,7 +868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:02.363919Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:54.076484Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -947,10 +947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["89hWpbN9S7meFz3_VvXVNA"],
-        "issued_at": "2018-04-09T16:30:02.363958Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pfMNMY6tTZiBrDUouqq6RA"],
+        "issued_at": "2018-04-19T17:39:54.076553Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -965,7 +965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a91a0e9d352844759287f188b0ac27c7
+      - b763b18bb02b4911861c55b0f9c0799f
   response:
     status:
       code: 300
@@ -976,7 +976,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:30:02 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -989,7 +989,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a91a0e9d352844759287f188b0ac27c7
+      - b763b18bb02b4911861c55b0f9c0799f
   response:
     status:
       code: 200
@@ -1015,14 +1015,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2080f4d8-71e4-43f7-a44a-678014d2c4de
+      - req-55e46044-b72d-4b0f-94bd-5111de1d620d
       Date:
-      - Mon, 09 Apr 2018 16:30:02 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a91a0e9d352844759287f188b0ac27c7
+      - b763b18bb02b4911861c55b0f9c0799f
   response:
     status:
       code: 200
@@ -1048,9 +1048,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-456bd29e-057d-4b80-82fb-e80bffa0f479
+      - req-16f4da8b-cae6-4c90-bd57-e07a19dc6361
       Date:
-      - Mon, 09 Apr 2018 16:30:02 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1092,7 +1092,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -1107,7 +1107,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1120,9 +1120,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-8cb26e18-b303-4e56-85db-794b79b85d92
+      - req-1e31818a-27a6-487a-8904-3b311bc98c9e
       Date:
-      - Mon, 09 Apr 2018 16:30:03 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1132,7 +1132,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1147,7 +1147,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1160,9 +1160,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-128dcac4-a86c-4bf1-8073-cce6a308dbf2
+      - req-9acbf51b-81f2-45c2-aaa7-8bdf534cd132
       Date:
-      - Mon, 09 Apr 2018 16:30:03 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1172,7 +1172,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1190,15 +1190,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:03 GMT
+      - Thu, 19 Apr 2018 17:39:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 57bcbb380992409f852f29470105a335
+      - e2394297cc6147159f00dbf2c4c2f5e9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-86cd1a39-afa4-4157-9126-6064a965f4d9
+      - req-cdce7ac8-868a-4d05-a496-97a96b2ad289
       Content-Length:
       - '7311'
       Connection:
@@ -1210,7 +1210,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:03.479956Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:39:55.109524Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1289,10 +1289,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DqyuQSJ_S5iMu_G45wATtw"],
-        "issued_at": "2018-04-09T16:30:03.480027Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XTuuPcetTS2GNRx0Oc5OfA"],
+        "issued_at": "2018-04-19T17:39:55.109604Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1310,15 +1310,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:03 GMT
+      - Thu, 19 Apr 2018 17:39:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eca735f4fd2a46289232af672d1d89d8
+      - 422b36589c144589b60be8dc557e9d55
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da091514-7d94-48c1-b68e-2396b2eda821
+      - req-5329b9da-db9f-4b9e-b78a-774a508695f3
       Content-Length:
       - '297'
       Connection:
@@ -1327,12 +1327,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:30:03.736192Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:39:55.311589Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oA2dNoZrSo2Sa9_j3kH8TQ"],
-        "issued_at": "2018-04-09T16:30:03.736258Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AzZNMcEBSUuDSvlmVc2Gsw"],
+        "issued_at": "2018-04-19T17:39:55.311646Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:55 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1347,20 +1347,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca735f4fd2a46289232af672d1d89d8
+      - 422b36589c144589b60be8dc557e9d55
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:03 GMT
+      - Thu, 19 Apr 2018 17:39:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d998bb23-60bc-44d8-b7c2-afb30aa3d58a
+      - req-ad66b4e5-44e9-46e7-bb87-6316fc709cd9
       Content-Length:
       - '2457'
       Connection:
@@ -1393,13 +1393,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"eca735f4fd2a46289232af672d1d89d8"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"422b36589c144589b60be8dc557e9d55"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1411,15 +1411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:04 GMT
+      - Thu, 19 Apr 2018 17:39:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a371070aa184f80aea16402dfde2d22
+      - f0029a30d8d24b0a8a6e05992a78bdb8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c09ce05f-e8fd-4704-89e0-4810fd5b74ae
+      - req-00e21afc-0ca3-4fe7-98b1-4692d54d8186
       Content-Length:
       - '7313'
       Connection:
@@ -1431,7 +1431,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:03.736192Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:55.311589Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1510,10 +1510,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zxr0AbtbQ3aCyTeadB3_Sg",
-        "oA2dNoZrSo2Sa9_j3kH8TQ"], "issued_at": "2018-04-09T16:30:04.204614Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F7rorHq7RbKevXQn4jjnbQ",
+        "AzZNMcEBSUuDSvlmVc2Gsw"], "issued_at": "2018-04-19T17:39:55.734003Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1528,20 +1528,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a371070aa184f80aea16402dfde2d22
+      - f0029a30d8d24b0a8a6e05992a78bdb8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:04 GMT
+      - Thu, 19 Apr 2018 17:39:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7414e4c5-0da1-489b-9f2e-d0717d9877e2
+      - req-90476d55-46dd-467f-8f16-5febaf3ba6b2
       Content-Length:
       - '2179'
       Connection:
@@ -1574,7 +1574,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1592,15 +1592,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:04 GMT
+      - Thu, 19 Apr 2018 17:39:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 403cd072a21b486a9bd9a03e22159f5d
+      - 5005a307c0ca49b4ae0d4e8e484a5a30
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f15c42c-4835-4efe-8c2b-917b6e739895
+      - req-50237ecd-93d4-4b67-9700-b73f421b37ce
       Content-Length:
       - '7278'
       Connection:
@@ -1612,7 +1612,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:04.809288Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:56.227204Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1691,10 +1691,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["T8Ft9sq-SOOzsEFJ4EOI-g"],
-        "issued_at": "2018-04-09T16:30:04.809355Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yYn8EdVXQEKwnGxHW13LLA"],
+        "issued_at": "2018-04-19T17:39:56.227284Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1709,7 +1709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 403cd072a21b486a9bd9a03e22159f5d
+      - 5005a307c0ca49b4ae0d4e8e484a5a30
   response:
     status:
       code: 200
@@ -1720,7 +1720,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:04 GMT
+      - Thu, 19 Apr 2018 17:39:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1729,7 +1729,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1747,15 +1747,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:05 GMT
+      - Thu, 19 Apr 2018 17:39:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c1e06b621da4301b603a157ae21da20
+      - e6b693b4c5354ebc9b10292313d60314
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0f3a294a-b43c-44dc-88ff-6d583ac69e8f
+      - req-c037cbe7-5709-4b5d-b485-f115b18b7a95
       Content-Length:
       - '7278'
       Connection:
@@ -1767,7 +1767,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:05.254849Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:56.665135Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1846,10 +1846,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EiHMkSFvTu-_99Y5arKPnA"],
-        "issued_at": "2018-04-09T16:30:05.254916Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vPJn1UVoQM6M_Cm0gfzGfg"],
+        "issued_at": "2018-04-19T17:39:56.665214Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1864,7 +1864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c1e06b621da4301b603a157ae21da20
+      - e6b693b4c5354ebc9b10292313d60314
   response:
     status:
       code: 200
@@ -1875,7 +1875,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:05 GMT
+      - Thu, 19 Apr 2018 17:39:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1884,7 +1884,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1902,15 +1902,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:05 GMT
+      - Thu, 19 Apr 2018 17:39:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fa77d5ee5ea44d0db30a4daeea112863
+      - ac3ea0ef6ab0458e80b2a85153875c3e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7605d7d4-72d2-4f41-8f84-8f33c6208958
+      - req-0e184bd0-cbb5-42e2-b36f-476530597628
       Content-Length:
       - '7264'
       Connection:
@@ -1922,7 +1922,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:05.724932Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:57.060918Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2001,10 +2001,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4VSzKOnxRXmi00wCj2gyEw"],
-        "issued_at": "2018-04-09T16:30:05.724999Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g9cp2fkpT4aTj_yM2xdPbw"],
+        "issued_at": "2018-04-19T17:39:57.060983Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2019,7 +2019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa77d5ee5ea44d0db30a4daeea112863
+      - ac3ea0ef6ab0458e80b2a85153875c3e
   response:
     status:
       code: 200
@@ -2030,7 +2030,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:05 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2039,7 +2039,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2057,15 +2057,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:05 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9b98833b1f96499f90230c23caf0a135
+      - 6bf568dd9d224c0da7f0b436df13d214
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da5cd511-a333-4ad0-84fc-8d2af6a3b6c4
+      - req-ab6cffe6-3098-468b-84c9-8962b6ff84c1
       Content-Length:
       - '7278'
       Connection:
@@ -2077,7 +2077,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:06.165975Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:57.443863Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2156,10 +2156,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1LruAZsWT4O86jRhsp1p_g"],
-        "issued_at": "2018-04-09T16:30:06.166040Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["71gqOs4LQmKV7rjo4zSTCQ"],
+        "issued_at": "2018-04-19T17:39:57.443933Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2174,7 +2174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b98833b1f96499f90230c23caf0a135
+      - 6bf568dd9d224c0da7f0b436df13d214
   response:
     status:
       code: 200
@@ -2185,7 +2185,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:06 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2194,7 +2194,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2212,15 +2212,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:06 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e0d9343c85a84095bc2fc70804c0f8e3
+      - 003e1983cedc4555855054a6166af3bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5689c5b7-b81b-466e-ade5-97a20e6e20ee
+      - req-17559c21-3cb9-4837-98e6-f02ee46d954f
       Content-Length:
       - '7265'
       Connection:
@@ -2232,7 +2232,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:06.618697Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:57.807128Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2311,10 +2311,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DEl7SrkfSWWGCZc1y5hfnw"],
-        "issued_at": "2018-04-09T16:30:06.618838Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GgNffE9hRKq8cyhl5Ph76g"],
+        "issued_at": "2018-04-19T17:39:57.807196Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2329,7 +2329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0d9343c85a84095bc2fc70804c0f8e3
+      - 003e1983cedc4555855054a6166af3bd
   response:
     status:
       code: 200
@@ -2340,7 +2340,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:06 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2349,7 +2349,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2367,15 +2367,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:06 GMT
+      - Thu, 19 Apr 2018 17:39:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ea00e4c9bc7a47f19fe6aab3e22849b5
+      - a408c0ae0cd243c1b5b4392ea0f09118
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d1361af-41ba-42f3-922a-1e566529b9df
+      - req-52beb698-77de-4e56-b7f2-fda116089e79
       Content-Length:
       - '7278'
       Connection:
@@ -2387,7 +2387,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:07.038661Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:58.249020Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2466,10 +2466,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VUDPTMGIQJuT8np0lDgjzQ"],
-        "issued_at": "2018-04-09T16:30:07.038730Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5MFoCJV0TNuVesomtxxRQA"],
+        "issued_at": "2018-04-19T17:39:58.249104Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2484,7 +2484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea00e4c9bc7a47f19fe6aab3e22849b5
+      - a408c0ae0cd243c1b5b4392ea0f09118
   response:
     status:
       code: 200
@@ -2495,7 +2495,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:30:07 GMT
+      - Thu, 19 Apr 2018 17:39:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2504,7 +2504,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2522,15 +2522,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:07 GMT
+      - Thu, 19 Apr 2018 17:39:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ac0394f30b9346fea57ec5337dd517e1
+      - 39daec237ad14d01aa247283de00e09d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c1e37236-2e6b-4903-b02d-087381e9cd54
+      - req-354650c5-40ec-4328-b147-dadea3b99c09
       Content-Length:
       - '7278'
       Connection:
@@ -2542,7 +2542,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:07.547408Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:58.836677Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2621,10 +2621,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kbvNXHy5RAG17youeiMxbA"],
-        "issued_at": "2018-04-09T16:30:07.547523Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["REkssr0xRbKShcLPVYHgag"],
+        "issued_at": "2018-04-19T17:39:58.836756Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -2639,7 +2639,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ac0394f30b9346fea57ec5337dd517e1
+      - 39daec237ad14d01aa247283de00e09d
   response:
     status:
       code: 200
@@ -2650,14 +2650,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-85d1979f-a1e4-492c-b3a8-a463f0b3a482
+      - req-9e86cbc0-32de-4938-ab55-270020df39ec
       Date:
-      - Mon, 09 Apr 2018 16:30:07 GMT
+      - Thu, 19 Apr 2018 17:39:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2675,15 +2675,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:07 GMT
+      - Thu, 19 Apr 2018 17:39:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1c2b3356dc644c0685e0b188cc12c2c1
+      - 8d200155b5fd4801bd2ac44820ea074d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0595a64-3d0a-4d79-9e68-566d2445dbe3
+      - req-25516334-03ed-4b50-8ba5-f102274e52bb
       Content-Length:
       - '7278'
       Connection:
@@ -2695,7 +2695,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:08.131643Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:39:59.481846Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2774,10 +2774,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1jiPRDKqSeWkBbHgxLP9Fw"],
-        "issued_at": "2018-04-09T16:30:08.131710Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2b1i6xd8S9W4QUjecXm6Vw"],
+        "issued_at": "2018-04-19T17:39:59.481924Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -2792,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c2b3356dc644c0685e0b188cc12c2c1
+      - 8d200155b5fd4801bd2ac44820ea074d
   response:
     status:
       code: 200
@@ -2803,14 +2803,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a1f430a0-4882-47d2-abf0-35c1cc69416c
+      - req-79a3f2c0-1977-44be-a103-93afe63a34dc
       Date:
-      - Mon, 09 Apr 2018 16:30:08 GMT
+      - Thu, 19 Apr 2018 17:39:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:39:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2828,15 +2828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:08 GMT
+      - Thu, 19 Apr 2018 17:39:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc78ad30-69dc-4d6f-bde5-d7c3268510ea
+      - req-a24e48a0-6b06-402d-86c7-c41eb31baa82
       Content-Length:
       - '7264'
       Connection:
@@ -2848,7 +2848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:08.764041Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:00.084037Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2927,10 +2927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QRYS_2JsR1CF3Oma4xcLQw"],
-        "issued_at": "2018-04-09T16:30:08.764123Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hvRf-XOSSSyzZiRZxnubJA"],
+        "issued_at": "2018-04-19T17:40:00.084114Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -2945,7 +2945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -2956,9 +2956,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-af80982f-153d-4226-83b3-4455c469e389
+      - req-9ca35d25-ced6-4dac-9279-cbbaab30ddfb
       Date:
-      - Mon, 09 Apr 2018 16:30:09 GMT
+      - Thu, 19 Apr 2018 17:40:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2992,7 +2992,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -3007,7 +3007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3018,14 +3018,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c8dfa8d3-10eb-4a6e-aff9-e8c0ef8ff18d
+      - req-853f1850-bf4e-4dca-8e5c-d83977f18e9b
       Date:
-      - Mon, 09 Apr 2018 16:30:09 GMT
+      - Thu, 19 Apr 2018 17:40:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3043,15 +3043,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:09 GMT
+      - Thu, 19 Apr 2018 17:40:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 994cfeef160e4531b06e6ce2bbb3add4
+      - 4c9dc419bad94132b967a567e10623ed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fc12006c-c968-419f-9b86-b08867b91c84
+      - req-91eacbd2-5b1b-44be-bccb-27f407d3bec6
       Content-Length:
       - '7278'
       Connection:
@@ -3063,7 +3063,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:09.642064Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:00.856849Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3142,10 +3142,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Xdch1XwqRoSliTbeOnA4Wg"],
-        "issued_at": "2018-04-09T16:30:09.642159Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Sif2PKDS3WOlVZwOwW5MA"],
+        "issued_at": "2018-04-19T17:40:00.856892Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -3160,7 +3160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994cfeef160e4531b06e6ce2bbb3add4
+      - 4c9dc419bad94132b967a567e10623ed
   response:
     status:
       code: 200
@@ -3171,14 +3171,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-143eb1c9-7380-450b-b75d-3765607f6331
+      - req-cd900450-b39c-4acc-955a-ffd3d311450c
       Date:
-      - Mon, 09 Apr 2018 16:30:09 GMT
+      - Thu, 19 Apr 2018 17:40:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -3193,7 +3193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57bcbb380992409f852f29470105a335
+      - e2394297cc6147159f00dbf2c4c2f5e9
   response:
     status:
       code: 200
@@ -3204,14 +3204,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-af0b47b0-965e-4d8e-b5c5-ad5b18a0ca44
+      - req-1816062f-0cd1-40ec-9e01-ccd0fdd27396
       Date:
-      - Mon, 09 Apr 2018 16:30:10 GMT
+      - Thu, 19 Apr 2018 17:40:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3229,15 +3229,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:10 GMT
+      - Thu, 19 Apr 2018 17:40:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 456d29d7023b4726ad5050fc2fee29ef
+      - e6eb1557082b41d9a521d9729acdd2fc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df1be2b8-8c30-4008-892c-263ab4fddb30
+      - req-08988f3b-0534-42ae-a6af-4558b3c097ba
       Content-Length:
       - '7265'
       Connection:
@@ -3249,7 +3249,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:10.504700Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:01.475334Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3328,10 +3328,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c8vukzdMTZ62ODcif-pIPg"],
-        "issued_at": "2018-04-09T16:30:10.504823Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zA8JMfEGR12NhfZIA1Ga7w"],
+        "issued_at": "2018-04-19T17:40:01.475418Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -3346,7 +3346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 456d29d7023b4726ad5050fc2fee29ef
+      - e6eb1557082b41d9a521d9729acdd2fc
   response:
     status:
       code: 200
@@ -3357,14 +3357,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-504f9c40-9bb7-4c68-b98a-148989cf821f
+      - req-1d4cc18c-9319-4c84-b2b7-4cebd8968e9f
       Date:
-      - Mon, 09 Apr 2018 16:30:10 GMT
+      - Thu, 19 Apr 2018 17:40:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3382,15 +3382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:10 GMT
+      - Thu, 19 Apr 2018 17:40:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a02856ff07fc46dfb74194c626c77c1c
+      - 43af3d45e1464b2386e0ff6094c01af6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2018781f-cdd2-4d62-b448-4e53c8fe42bc
+      - req-269e417c-2aaa-474e-ad5c-9d8087ecebae
       Content-Length:
       - '7278'
       Connection:
@@ -3402,7 +3402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:11.045559Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:02.052290Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3481,10 +3481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lG_iAhvxTY6dcoyGvgDlWg"],
-        "issued_at": "2018-04-09T16:30:11.045629Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mHJJekR9TlCTziXPuoJX-g"],
+        "issued_at": "2018-04-19T17:40:02.052361Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a02856ff07fc46dfb74194c626c77c1c
+      - 43af3d45e1464b2386e0ff6094c01af6
   response:
     status:
       code: 200
@@ -3510,14 +3510,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-17827454-6c82-44be-a6e6-901c7fa19b4d
+      - req-1ffb5241-17be-4630-bc0e-88bfad2f47a7
       Date:
-      - Mon, 09 Apr 2018 16:30:11 GMT
+      - Thu, 19 Apr 2018 17:40:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3543,9 +3543,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-de03bd88-56b6-4570-812c-957b6d423a90
+      - req-5c0cd80b-d167-40a6-bc59-5866062d22a5
       Date:
-      - Mon, 09 Apr 2018 16:30:12 GMT
+      - Thu, 19 Apr 2018 17:40:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3572,7 +3572,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -3587,7 +3587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3598,9 +3598,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-95326bc5-d478-4d01-8de7-ab099b988941
+      - req-b6464208-b157-4601-94d8-d662b0fd0101
       Date:
-      - Mon, 09 Apr 2018 16:30:12 GMT
+      - Thu, 19 Apr 2018 17:40:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3627,7 +3627,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -3642,7 +3642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3653,9 +3653,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bc052b42-1f9a-44cf-a97b-31bb1aaabaaa
+      - req-2930a272-10a8-4ace-bd74-5c70ddc358b4
       Date:
-      - Mon, 09 Apr 2018 16:30:13 GMT
+      - Thu, 19 Apr 2018 17:40:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3682,7 +3682,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -3697,7 +3697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3708,9 +3708,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-711f8c27-af8b-48ce-a63b-e0b497d508ac
+      - req-e4be7a58-e849-4b64-a06b-a86bd8621de6
       Date:
-      - Mon, 09 Apr 2018 16:30:13 GMT
+      - Thu, 19 Apr 2018 17:40:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3766,7 +3766,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -3781,7 +3781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -3792,9 +3792,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a7cd273d-1769-4aa7-9acb-93dfabad166f
+      - req-0c6d5ebc-23ae-4fee-af63-f184e732b64f
       Date:
-      - Mon, 09 Apr 2018 16:30:13 GMT
+      - Thu, 19 Apr 2018 17:40:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3806,7 +3806,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -3821,7 +3821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3834,9 +3834,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-aaefa83c-356d-41b3-b013-a74cca82e9a4
+      - req-74e82b57-1488-4d6f-85c0-b5c63fcf1a89
       Date:
-      - Mon, 09 Apr 2018 16:30:13 GMT
+      - Thu, 19 Apr 2018 17:40:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -3882,7 +3882,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -3897,7 +3897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3910,9 +3910,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-7c5f2d68-b101-4d9a-b1f9-f894f3fefa30
+      - req-a3a4851c-e845-4a07-815e-b589cb7c7727
       Date:
-      - Mon, 09 Apr 2018 16:30:14 GMT
+      - Thu, 19 Apr 2018 17:40:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -3958,7 +3958,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -3973,7 +3973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3986,9 +3986,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-a620b643-ac7c-41b1-92d4-f1ec307df2b5
+      - req-fd0580ba-d942-4bf3-a46e-3c6406015a2f
       Date:
-      - Mon, 09 Apr 2018 16:30:15 GMT
+      - Thu, 19 Apr 2018 17:40:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -4036,7 +4036,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -4051,7 +4051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4064,9 +4064,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-53d59608-4953-440a-ac70-8e525ab54404
+      - req-f777bd81-c267-47b5-b393-e98cd254f357
       Date:
-      - Mon, 09 Apr 2018 16:30:16 GMT
+      - Thu, 19 Apr 2018 17:40:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -4108,7 +4108,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -4123,7 +4123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4136,9 +4136,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-4d6149a6-cdf0-4d50-910b-cb55dc8e8c83
+      - req-8a01145b-2481-43cb-975f-ea8a170fb302
       Date:
-      - Mon, 09 Apr 2018 16:30:16 GMT
+      - Thu, 19 Apr 2018 17:40:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -4161,7 +4161,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -4176,7 +4176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -4187,9 +4187,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c2dd328a-3292-47f5-b234-44f1e58393ea
+      - req-0e448aca-6e18-48e1-90eb-34a8f562a30f
       Date:
-      - Mon, 09 Apr 2018 16:30:16 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4245,7 +4245,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -4260,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -4271,9 +4271,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-bd12a4ff-155b-40b9-b688-12c2723ee307
+      - req-c10deda8-885b-4336-b481-73a5e0c7efaf
       Date:
-      - Mon, 09 Apr 2018 16:30:17 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4285,7 +4285,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -4300,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -4311,9 +4311,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8bca3e95-cad2-4efe-8b49-94de6f2a276e
+      - req-e396067f-a0a7-41ae-9072-43303a963c76
       Date:
-      - Mon, 09 Apr 2018 16:30:17 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4369,7 +4369,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -4384,7 +4384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb8ffa76de4f4f9ca10a70815ae9a714
+      - dc8891566e08422d8f0c860bef181fd2
   response:
     status:
       code: 200
@@ -4395,9 +4395,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-419af21f-3580-4180-ae1e-2bbb7edf2e68
+      - req-a5eb1f0c-5a1e-41d7-b6de-2f144d272954
       Date:
-      - Mon, 09 Apr 2018 16:30:17 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4409,7 +4409,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4424,7 +4424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 403cd072a21b486a9bd9a03e22159f5d
+      - 5005a307c0ca49b4ae0d4e8e484a5a30
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4437,9 +4437,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-55b7886a-6061-4e66-a8ec-236bc57c0044
+      - req-9d38784a-31bb-43a4-a960-33380b17c467
       Date:
-      - Mon, 09 Apr 2018 16:30:17 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4448,7 +4448,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4463,7 +4463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c1e06b621da4301b603a157ae21da20
+      - e6b693b4c5354ebc9b10292313d60314
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4476,9 +4476,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f770c817-6a07-4c84-a5e7-f7f12d2c3280
+      - req-9fab836e-a3af-43d8-9ddb-8d920b05304c
       Date:
-      - Mon, 09 Apr 2018 16:30:17 GMT
+      - Thu, 19 Apr 2018 17:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4487,7 +4487,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4502,7 +4502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa77d5ee5ea44d0db30a4daeea112863
+      - ac3ea0ef6ab0458e80b2a85153875c3e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4515,9 +4515,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-53245254-df36-4fa0-9195-f95867c2c15d
+      - req-5e96c814-fd0d-41c7-97a5-516a10f8f8a5
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4526,7 +4526,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4541,7 +4541,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b98833b1f96499f90230c23caf0a135
+      - 6bf568dd9d224c0da7f0b436df13d214
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4554,9 +4554,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3083a57b-3bc3-4b13-9628-8a66a3fab4d6
+      - req-ab82cd76-f6d5-4844-ad15-7690ad6bb47e
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4565,7 +4565,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4580,7 +4580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4593,9 +4593,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5c706898-3af7-4b79-afc0-19e80448ee13
+      - req-34cbe42c-dfcd-4f46-b5f2-e9c6821b6c41
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4604,7 +4604,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4619,7 +4619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0d9343c85a84095bc2fc70804c0f8e3
+      - 003e1983cedc4555855054a6166af3bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4632,9 +4632,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-cf083651-963c-4127-afb0-b0a27109f62c
+      - req-d472d982-6529-4c3d-a67e-963032f89089
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4643,7 +4643,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4658,7 +4658,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea00e4c9bc7a47f19fe6aab3e22849b5
+      - a408c0ae0cd243c1b5b4392ea0f09118
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7e49f92a-3bf4-411f-8e13-66abc15b3e6c
+      - req-400757b3-b89d-4b4a-84c8-681485a6aba7
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4682,7 +4682,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4700,15 +4700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:18 GMT
+      - Thu, 19 Apr 2018 17:40:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 87086a76da7c4a68b8ab6c3cb8258463
+      - 2cd179e5da0c4d5a8c111ce44d4414c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-713adf0e-d1ec-44a0-8489-feee4b950d5a
+      - req-0c221d0d-a63a-4e26-a14c-02637deda698
       Content-Length:
       - '7278'
       Connection:
@@ -4720,7 +4720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:19.006743Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:09.958954Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4799,10 +4799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J6N7hgVATc2p8RMmgdMyCg"],
-        "issued_at": "2018-04-09T16:30:19.006846Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tfdeFT_KTXuCxS6Bk7gAYQ"],
+        "issued_at": "2018-04-19T17:40:09.959020Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4817,22 +4817,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87086a76da7c4a68b8ab6c3cb8258463
+      - 2cd179e5da0c4d5a8c111ce44d4414c8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-14598a5c-b7c9-4dac-894a-0af0bb85fc27
+      - req-19c96125-3803-4fed-a17d-22cfc719b7eb
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-14598a5c-b7c9-4dac-894a-0af0bb85fc27
+      - req-19c96125-3803-4fed-a17d-22cfc719b7eb
       Date:
-      - Mon, 09 Apr 2018 16:30:19 GMT
+      - Thu, 19 Apr 2018 17:40:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4842,7 +4842,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4860,15 +4860,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:19 GMT
+      - Thu, 19 Apr 2018 17:40:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0f1a6e505cd94550b5f27217af6a5e5d
+      - 0f86200e245241f0940a98a9a38e9bcd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d2840584-393e-4639-a76c-b0e1b59b2c82
+      - req-d444305f-773f-4f85-baaf-8806ba9808c5
       Content-Length:
       - '7278'
       Connection:
@@ -4880,7 +4880,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:19.867806Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:11.000732Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4959,10 +4959,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["naWUIDQ8QQ6hXQ1P1NQF-w"],
-        "issued_at": "2018-04-09T16:30:19.867846Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["btXgmpcRQj-ssOM3AcT8fw"],
+        "issued_at": "2018-04-19T17:40:11.000837Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4977,22 +4977,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f1a6e505cd94550b5f27217af6a5e5d
+      - 0f86200e245241f0940a98a9a38e9bcd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c88705da-0f09-436e-94d0-25970198329d
+      - req-b0f52ae9-9a2e-44ac-a6e5-0a5974d73898
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c88705da-0f09-436e-94d0-25970198329d
+      - req-b0f52ae9-9a2e-44ac-a6e5-0a5974d73898
       Date:
-      - Mon, 09 Apr 2018 16:30:20 GMT
+      - Thu, 19 Apr 2018 17:40:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5002,7 +5002,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5020,15 +5020,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:20 GMT
+      - Thu, 19 Apr 2018 17:40:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 507f948ca89a4a0b8a8b8c19bfcc3738
+      - 6bda1dc7f4ea413b98908d8ba3360a23
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-391cfa1f-3d49-4f86-a14b-b77880ea2a98
+      - req-44cfd126-0195-4949-aa4c-cd70a6939666
       Content-Length:
       - '7264'
       Connection:
@@ -5040,7 +5040,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:20.444723Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:11.912800Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5119,10 +5119,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ILrKtSn5TmqdUsqFV_rMmA"],
-        "issued_at": "2018-04-09T16:30:20.444809Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hjQKI7UQSKetpNL9LiMYKQ"],
+        "issued_at": "2018-04-19T17:40:11.912865Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5137,22 +5137,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 507f948ca89a4a0b8a8b8c19bfcc3738
+      - 6bda1dc7f4ea413b98908d8ba3360a23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7c938c8-e947-4517-8783-d5e56ee09438
+      - req-3f96a66f-7e9e-4d4c-8351-5a42a097f6dd
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c7c938c8-e947-4517-8783-d5e56ee09438
+      - req-3f96a66f-7e9e-4d4c-8351-5a42a097f6dd
       Date:
-      - Mon, 09 Apr 2018 16:30:20 GMT
+      - Thu, 19 Apr 2018 17:40:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5162,7 +5162,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5180,15 +5180,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:20 GMT
+      - Thu, 19 Apr 2018 17:40:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e3e6ec71525144d5b6f5a3c7c6b87e36
+      - 546ad3ae9e5843ddbee3a41c1972eb4e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9af763cf-6504-4411-8a9f-c5aef8596245
+      - req-cb0c7108-144e-4aa4-82ef-b323586392e4
       Content-Length:
       - '7278'
       Connection:
@@ -5200,7 +5200,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:21.009468Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:12.943381Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5279,10 +5279,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5_8hnzjDRXyqDR5G_9l3pw"],
-        "issued_at": "2018-04-09T16:30:21.009502Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZY3kq2EYS3CKkIflxCU_nw"],
+        "issued_at": "2018-04-19T17:40:12.943427Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5297,22 +5297,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3e6ec71525144d5b6f5a3c7c6b87e36
+      - 546ad3ae9e5843ddbee3a41c1972eb4e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4f6e0c2-e98f-4b8e-aec2-3b49753bb2e0
+      - req-cacd3b45-6ca4-4370-af2e-007631880585
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a4f6e0c2-e98f-4b8e-aec2-3b49753bb2e0
+      - req-cacd3b45-6ca4-4370-af2e-007631880585
       Date:
-      - Mon, 09 Apr 2018 16:30:21 GMT
+      - Thu, 19 Apr 2018 17:40:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5322,7 +5322,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5337,22 +5337,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c611320a-b6f8-496f-8e2f-d8e7a980936f
+      - req-4467fb19-b8f4-4187-9341-edab4a5fdd13
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c611320a-b6f8-496f-8e2f-d8e7a980936f
+      - req-4467fb19-b8f4-4187-9341-edab4a5fdd13
       Date:
-      - Mon, 09 Apr 2018 16:30:21 GMT
+      - Thu, 19 Apr 2018 17:40:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5362,7 +5362,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5380,15 +5380,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:22 GMT
+      - Thu, 19 Apr 2018 17:40:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4d1145aff4a4c998fedee8d406ea2ea
+      - 283d4a97efb44a1c8492cbefaae8a082
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b3386f5-9ac7-4ca8-84e0-c7df281967e6
+      - req-08f38d57-bf5c-46fe-808d-40f10fd88952
       Content-Length:
       - '7265'
       Connection:
@@ -5400,7 +5400,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:22.196407Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:14.543458Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5479,10 +5479,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wN-X99DXSzW8HUJsENNnIw"],
-        "issued_at": "2018-04-09T16:30:22.196443Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mkR9-DAvT5SGMP8-au-ZGA"],
+        "issued_at": "2018-04-19T17:40:14.543531Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5497,22 +5497,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4d1145aff4a4c998fedee8d406ea2ea
+      - 283d4a97efb44a1c8492cbefaae8a082
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-977b310b-9da2-453f-8035-32c9b0b911fb
+      - req-a27ffef0-fba3-4c21-b2b5-3bedff0ffc78
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-977b310b-9da2-453f-8035-32c9b0b911fb
+      - req-a27ffef0-fba3-4c21-b2b5-3bedff0ffc78
       Date:
-      - Mon, 09 Apr 2018 16:30:22 GMT
+      - Thu, 19 Apr 2018 17:40:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5522,7 +5522,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5540,15 +5540,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:22 GMT
+      - Thu, 19 Apr 2018 17:40:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 96e665c968984afdb7796c4f1942aa3f
+      - 41f92fe96de544bba7793a08de0e0b39
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0df128d1-70c6-44f7-996c-62d874d38f58
+      - req-0f5248cf-4565-490e-a81d-5785f91ac5a0
       Content-Length:
       - '7278'
       Connection:
@@ -5560,7 +5560,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:22.798183Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:15.462249Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5639,10 +5639,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R5RkOucPRVaIxuA6DtwHXw"],
-        "issued_at": "2018-04-09T16:30:22.798222Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["poX-VHxJQMG2DS6f__FgKQ"],
+        "issued_at": "2018-04-19T17:40:15.462307Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5657,22 +5657,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96e665c968984afdb7796c4f1942aa3f
+      - 41f92fe96de544bba7793a08de0e0b39
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e4fb4965-a5d0-49bf-b3e4-630fd9da903e
+      - req-4736dfc9-e4fa-47ad-9e06-41975a9bbd1e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e4fb4965-a5d0-49bf-b3e4-630fd9da903e
+      - req-4736dfc9-e4fa-47ad-9e06-41975a9bbd1e
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5682,7 +5682,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5700,15 +5700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be156bd8b00d4544ada888e48a42ee2c
+      - d9cb212f2e694d769b7b4f10a8ed866c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c364cccc-395c-45d2-bd4a-1954d6eb362a
+      - req-1f3d50a1-bbe7-46d1-9e31-1e915321abe4
       Content-Length:
       - '7311'
       Connection:
@@ -5720,7 +5720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:23.414538Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:16.345564Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5799,10 +5799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eR00D7EUSumk826dX-ynEA"],
-        "issued_at": "2018-04-09T16:30:23.414573Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["81kG8fFnRrK9e9YbSybbdg"],
+        "issued_at": "2018-04-19T17:40:16.345631Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -5817,7 +5817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be156bd8b00d4544ada888e48a42ee2c
+      - d9cb212f2e694d769b7b4f10a8ed866c
   response:
     status:
       code: 200
@@ -5828,13 +5828,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5852,15 +5852,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2f6d25b561ce4d94aee28ef410629a84
+      - ca54df97f1b34d2fbc46ee46e2b1c2e4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-900e5936-bbc9-4b02-81fe-7a767aa6b3da
+      - req-1685233c-e291-4223-a21b-3a6dc7f0f124
       Content-Length:
       - '7278'
       Connection:
@@ -5872,7 +5872,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:23.727636Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:16.734494Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5951,10 +5951,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aPaVUeN-RL6Gtlc1s5Y1CA"],
-        "issued_at": "2018-04-09T16:30:23.727673Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L2sMNYO2S2CWCBXzo1ZGhA"],
+        "issued_at": "2018-04-19T17:40:16.734556Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5969,7 +5969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f6d25b561ce4d94aee28ef410629a84
+      - ca54df97f1b34d2fbc46ee46e2b1c2e4
   response:
     status:
       code: 200
@@ -5980,16 +5980,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-abec74a7-347c-4c1b-97d5-0e9f03d0d08e
+      - req-659feb42-061f-4d53-891a-4f208060fea3
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6007,15 +6007,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:23 GMT
+      - Thu, 19 Apr 2018 17:40:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 74e546e3572147d48096785dfd053d72
+      - c61230bc0d194a56a5d187b171223f0a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-be566b20-e83b-4fc4-8fdd-f088effa5402
+      - req-0a1af1cc-7379-4fd7-95c2-04059f06aa78
       Content-Length:
       - '7278'
       Connection:
@@ -6027,7 +6027,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:24.073587Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:18.342669Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6106,10 +6106,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SvwkaTNwRriohRT6TEqfWw"],
-        "issued_at": "2018-04-09T16:30:24.073623Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6An_rpE3SQy9YRacdKnKhQ"],
+        "issued_at": "2018-04-19T17:40:18.342739Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6124,7 +6124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74e546e3572147d48096785dfd053d72
+      - c61230bc0d194a56a5d187b171223f0a
   response:
     status:
       code: 200
@@ -6135,16 +6135,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fa5b853f-010e-498e-a768-a34f0d927bff
+      - req-da633abb-4b0a-4daf-9572-fcca3acf2088
       Date:
-      - Mon, 09 Apr 2018 16:30:24 GMT
+      - Thu, 19 Apr 2018 17:40:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6162,15 +6162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:24 GMT
+      - Thu, 19 Apr 2018 17:40:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e22d28bd94f948598743973d8e21ffa5
+      - 7a2f1ff49d864c78b2b7a64b7c966bcf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d872ab80-3d0c-4b1b-b79f-c962c81cc064
+      - req-675caf86-de36-43c7-959f-ed0ef57af41d
       Content-Length:
       - '7264'
       Connection:
@@ -6182,7 +6182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:24.419001Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:18.845021Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6261,10 +6261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["E9EjccLuRjaVn6a8lz33bw"],
-        "issued_at": "2018-04-09T16:30:24.419040Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_Gz-Gtm3RPeTsUzYmiW15Q"],
+        "issued_at": "2018-04-19T17:40:18.845090Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6279,7 +6279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e22d28bd94f948598743973d8e21ffa5
+      - 7a2f1ff49d864c78b2b7a64b7c966bcf
   response:
     status:
       code: 200
@@ -6290,16 +6290,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7096936c-5f7c-4617-93b9-b6b0668b336f
+      - req-01f41490-e5a3-463a-8dfa-80e305d03871
       Date:
-      - Mon, 09 Apr 2018 16:30:24 GMT
+      - Thu, 19 Apr 2018 17:40:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6317,15 +6317,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:24 GMT
+      - Thu, 19 Apr 2018 17:40:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ac99253a00264046bbf7ecc6fed4343e
+      - d304475413fa4de7a5dd9c231103db13
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4c52619d-c308-4147-a870-fd70cd3ef815
+      - req-585bd775-3412-4caa-9b1c-0a258008af7e
       Content-Length:
       - '7278'
       Connection:
@@ -6337,7 +6337,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:24.807066Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:19.292049Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6416,10 +6416,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ta5KChhUSFGiuHwYnwtE_g"],
-        "issued_at": "2018-04-09T16:30:24.807105Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kAU6Gp-wSbOHA0DA-xbqvQ"],
+        "issued_at": "2018-04-19T17:40:19.292111Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6434,7 +6434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ac99253a00264046bbf7ecc6fed4343e
+      - d304475413fa4de7a5dd9c231103db13
   response:
     status:
       code: 200
@@ -6445,16 +6445,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8d9ba03b-5924-4784-9837-00d024f4171a
+      - req-1f979eed-8683-4319-b131-4f90110c6b67
       Date:
-      - Mon, 09 Apr 2018 16:30:24 GMT
+      - Thu, 19 Apr 2018 17:40:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6469,7 +6469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be156bd8b00d4544ada888e48a42ee2c
+      - d9cb212f2e694d769b7b4f10a8ed866c
   response:
     status:
       code: 200
@@ -6480,16 +6480,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2f68be22-5325-4069-b665-ed909c1dcbfb
+      - req-4579b6bd-d724-4505-b511-8770f437306f
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6507,15 +6507,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2aff98df81654f6d90416769b809a20f
+      - b139b63c41c944318ebaba8ecb8055fe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cbc17a1a-1c10-489d-9a22-ff9a59bc6fee
+      - req-29262a1a-6639-4ac9-bc56-eb352f0ab67c
       Content-Length:
       - '7265'
       Connection:
@@ -6527,7 +6527,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:25.282299Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:19.888266Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6606,10 +6606,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VGnKXZINS56x2dbeAz9P7w"],
-        "issued_at": "2018-04-09T16:30:25.282335Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FyQTgeIFSP-alOB_UKwAIg"],
+        "issued_at": "2018-04-19T17:40:19.888328Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6624,7 +6624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aff98df81654f6d90416769b809a20f
+      - b139b63c41c944318ebaba8ecb8055fe
   response:
     status:
       code: 200
@@ -6635,16 +6635,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-77b17cf0-4285-4cbb-ab3d-ce122ce90a07
+      - req-e568c1e3-765e-4df9-8188-ea6a7cb14f25
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6662,15 +6662,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9759bfab5404a5b888b3b3d28663edc
+      - fbe509977aaf4c33abc4350674e005fe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-402db00f-e4c3-4664-b719-09a2d98ae0f4
+      - req-dc25eeb3-4afa-4d3f-b653-354c68eb6682
       Content-Length:
       - '7278'
       Connection:
@@ -6682,7 +6682,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:25.632424Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:20.372054Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6761,10 +6761,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L_bMP_y_T2mn7f3SSWowPA"],
-        "issued_at": "2018-04-09T16:30:25.632473Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nq_yKYb_SMi9gx7LpdGNeA"],
+        "issued_at": "2018-04-19T17:40:20.372127Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6779,7 +6779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9759bfab5404a5b888b3b3d28663edc
+      - fbe509977aaf4c33abc4350674e005fe
   response:
     status:
       code: 200
@@ -6790,16 +6790,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7fd1f5f0-1416-4ef8-bd6b-fae9a783f628
+      - req-2c0b14b2-5287-43e7-a603-fb6f1556a662
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c57aac21-df93-4b35-b4ca-88c175b160f7
+      - req-32d7a9e8-70cd-47ea-9298-c1a94496e43e
       Date:
-      - Mon, 09 Apr 2018 16:30:25 GMT
+      - Thu, 19 Apr 2018 17:40:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a16c44d9-8051-4ebe-baaa-e11d35c818bb
+      - req-f00cb9cf-0221-45e4-a7c0-38714ab1902d
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c4e16b52-318f-4c15-8586-1af77a1ac993
+      - req-25ab97dd-0389-43ea-8421-2072970bb33e
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e3d6786a-13e3-4302-bd03-9d009aad7ec9
+      - req-6441d91b-53b4-4cfa-a7fc-d8e8fb931924
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,50 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b70d3131-2845-4591-aa07-0b045f2f2630
+      - req-c9c7986e-d5dd-4133-b41d-0ddc5e845bf7
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-8dd72ed0-f92c-40d4-8bfc-41f27e1eab40
+      Date:
+      - Thu, 19 Apr 2018 17:40:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
+        "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:40:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6989,7 +7025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,14 +7038,50 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-3ce2d1b0-da44-4a67-b718-4deab68044b5
+      - req-9129c7bb-0d66-48fe-a98d-c324c76ac578
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-6ee3ffec-739b-45bf-bc22-ca54023ea215
+      Date:
+      - Thu, 19 Apr 2018 17:40:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
+        "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:40:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7024,7 +7096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7037,14 +7109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-098efa3f-2a6a-4cfe-a898-bff5aa30766e
+      - req-1616e50f-28cf-4351-8d31-cac58edf274f
       Date:
-      - Mon, 09 Apr 2018 16:30:26 GMT
+      - Thu, 19 Apr 2018 17:40:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7059,7 +7131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7072,14 +7144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-9eafb8ca-1bfc-419c-a351-f3e3a5ae1632
+      - req-5cb7c413-114e-46e9-ad26-86f752c0f012
       Date:
-      - Mon, 09 Apr 2018 16:30:27 GMT
+      - Thu, 19 Apr 2018 17:40:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7094,7 +7166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7107,14 +7179,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-cdf68a06-e102-4506-9d95-66940ae6348f
+      - req-f7594356-0e87-46db-987c-c522b6f9d73d
       Date:
-      - Mon, 09 Apr 2018 16:30:27 GMT
+      - Thu, 19 Apr 2018 17:40:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7132,15 +7204,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:27 GMT
+      - Thu, 19 Apr 2018 17:40:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 62108b5863214ab29d2c37ade486135f
+      - fcddf2ad6f3949c882a0e917f6c4c331
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-314cb111-c54e-43b9-805a-12091867dd94
+      - req-d4c8669a-a300-453a-bf42-87900ecad3be
       Content-Length:
       - '7311'
       Connection:
@@ -7152,7 +7224,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:27.422819Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:23.390995Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7231,16 +7303,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GYR1NhegQ4my_bwApZmtfA"],
-        "issued_at": "2018-04-09T16:30:27.422870Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fmB_MLsrRPuJ_pgqOiERFQ"],
+        "issued_at": "2018-04-19T17:40:23.391067Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"62108b5863214ab29d2c37ade486135f"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"fcddf2ad6f3949c882a0e917f6c4c331"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7252,15 +7324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:27 GMT
+      - Thu, 19 Apr 2018 17:40:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0b56511a6840496aab12b3f5f9276324
+      - b0212b3b136148d6b2ab4efc164cf12d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-37fbc415-eeb2-479d-b71e-282441b8a990
+      - req-9f14ae22-f466-4830-a501-f6ccb3eff079
       Content-Length:
       - '7346'
       Connection:
@@ -7272,7 +7344,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:27.422819Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:23.390995Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7351,10 +7423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["THlu7MDQTiuXJyVnAWq1Bw",
-        "GYR1NhegQ4my_bwApZmtfA"], "issued_at": "2018-04-09T16:30:27.644589Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NicJLZBlT3-9svr1HVUBnQ",
+        "fmB_MLsrRPuJ_pgqOiERFQ"], "issued_at": "2018-04-19T17:40:23.694131Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7372,15 +7444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:27 GMT
+      - Thu, 19 Apr 2018 17:40:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c06ab1d4fa93433dbac46e2951e7be47
+      - 86f6bf435fee4af5885d7430ff86eaa7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8970a6bc-763a-4e1f-ab2c-f47467031cd3
+      - req-c8580bc6-0860-4404-91bd-5037be19679b
       Content-Length:
       - '7311'
       Connection:
@@ -7392,7 +7464,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:27.894051Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:24.013000Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7471,16 +7543,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kpNsDWZPQ0qJ2S1gm0Gv_g"],
-        "issued_at": "2018-04-09T16:30:27.894091Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["s7AttyqDQWikqWK4OWIO9A"],
+        "issued_at": "2018-04-19T17:40:24.013071Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"c06ab1d4fa93433dbac46e2951e7be47"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"86f6bf435fee4af5885d7430ff86eaa7"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7492,15 +7564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:28 GMT
+      - Thu, 19 Apr 2018 17:40:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7cd8125f94f24e63a6aac9743d079da4
+      - 687bd4e7b6ed436aab82e37e3c73aa88
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1bf01e6e-1000-430c-9702-ffc71217b331
+      - req-e860d362-a944-409e-9ea0-679b25e71fb3
       Content-Length:
       - '7346'
       Connection:
@@ -7512,7 +7584,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:27.894051Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:24.013000Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7591,10 +7663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G7Q_1zKpTqGHBkodNC4TSQ",
-        "kpNsDWZPQ0qJ2S1gm0Gv_g"], "issued_at": "2018-04-09T16:30:28.327488Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5Vwkqit3TxKmSIxdbttZPQ",
+        "s7AttyqDQWikqWK4OWIO9A"], "issued_at": "2018-04-19T17:40:24.305238Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -7609,7 +7681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e462dff7ed4d48bd86eb8dbdb497d8
+      - 8dc15c14c78743c1b48d7bed4bcbc4a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7622,14 +7694,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-5cc9babe-ca0b-4242-885f-88a5f429aab6
+      - req-4eb1cf5c-d4ed-47fb-8c79-91b62cfd77b7
       Date:
-      - Mon, 09 Apr 2018 16:30:28 GMT
+      - Thu, 19 Apr 2018 17:40:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -7644,22 +7716,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fae26e9-3be5-4b3f-9f47-ce8387dadc9b
+      - req-b3e0dec0-057f-4469-80fe-b92c7c0a0ba7
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-3fae26e9-3be5-4b3f-9f47-ce8387dadc9b
+      - req-b3e0dec0-057f-4469-80fe-b92c7c0a0ba7
       Date:
-      - Mon, 09 Apr 2018 16:30:28 GMT
+      - Thu, 19 Apr 2018 17:40:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7692,7 +7764,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -7707,22 +7779,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-470a3223-383a-4d12-9e11-6cd5e4c05a55
+      - req-958353fe-bae9-47ec-a945-acde263160ba
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-470a3223-383a-4d12-9e11-6cd5e4c05a55
+      - req-958353fe-bae9-47ec-a945-acde263160ba
       Date:
-      - Mon, 09 Apr 2018 16:30:28 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -7739,7 +7811,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -7754,27 +7826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87086a76da7c4a68b8ab6c3cb8258463
+      - 2cd179e5da0c4d5a8c111ce44d4414c8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d20bdc0-9622-47f7-a047-df935e838917
+      - req-06fe3fb6-e75e-455f-ae29-a4bb242eca7c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8d20bdc0-9622-47f7-a047-df935e838917
+      - req-06fe3fb6-e75e-455f-ae29-a4bb242eca7c
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -7789,27 +7861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87086a76da7c4a68b8ab6c3cb8258463
+      - 2cd179e5da0c4d5a8c111ce44d4414c8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c64010f-ddeb-4959-b2de-f021a00e6a5a
+      - req-f5d9c631-c528-43fc-9495-7010e4276010
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9c64010f-ddeb-4959-b2de-f021a00e6a5a
+      - req-f5d9c631-c528-43fc-9495-7010e4276010
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -7824,27 +7896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f1a6e505cd94550b5f27217af6a5e5d
+      - 0f86200e245241f0940a98a9a38e9bcd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4be01ac3-2387-42f6-8cbd-b3f32cc1e10c
+      - req-8f25d339-7e86-4aea-8a4e-797d3d5f50ce
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4be01ac3-2387-42f6-8cbd-b3f32cc1e10c
+      - req-8f25d339-7e86-4aea-8a4e-797d3d5f50ce
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -7859,27 +7931,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f1a6e505cd94550b5f27217af6a5e5d
+      - 0f86200e245241f0940a98a9a38e9bcd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81c7beab-f5d8-40a9-a386-a55f73abdaae
+      - req-fc35c33b-6485-470c-a14a-993fe31aff0b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-81c7beab-f5d8-40a9-a386-a55f73abdaae
+      - req-fc35c33b-6485-470c-a14a-993fe31aff0b
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -7894,22 +7966,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 507f948ca89a4a0b8a8b8c19bfcc3738
+      - 6bda1dc7f4ea413b98908d8ba3360a23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c2b70dd-5d4b-4015-a3fe-fef0b42ecdec
+      - req-ddcfd408-038e-47fc-aa6e-2b48b50461d7
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-2c2b70dd-5d4b-4015-a3fe-fef0b42ecdec
+      - req-ddcfd408-038e-47fc-aa6e-2b48b50461d7
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -7924,7 +7996,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -7939,22 +8011,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 507f948ca89a4a0b8a8b8c19bfcc3738
+      - 6bda1dc7f4ea413b98908d8ba3360a23
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d19cdbba-3972-4016-ac67-eddadac34a80
+      - req-00a4e1e6-5acc-4a84-8a3d-cdad6a88883c
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-d19cdbba-3972-4016-ac67-eddadac34a80
+      - req-00a4e1e6-5acc-4a84-8a3d-cdad6a88883c
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -7969,7 +8041,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -7984,27 +8056,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3e6ec71525144d5b6f5a3c7c6b87e36
+      - 546ad3ae9e5843ddbee3a41c1972eb4e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-24869a33-2e9d-4c36-8ec7-58084ff6f8f3
+      - req-71bc1dcd-4573-4f70-871a-a695f8aa818c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-24869a33-2e9d-4c36-8ec7-58084ff6f8f3
+      - req-71bc1dcd-4573-4f70-871a-a695f8aa818c
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -8019,27 +8091,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3e6ec71525144d5b6f5a3c7c6b87e36
+      - 546ad3ae9e5843ddbee3a41c1972eb4e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2dc8659a-9e15-4e40-bb38-d7c019f52ce9
+      - req-6fce768b-31fa-4de7-9792-cffd56f9ef5b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2dc8659a-9e15-4e40-bb38-d7c019f52ce9
+      - req-6fce768b-31fa-4de7-9792-cffd56f9ef5b
       Date:
-      - Mon, 09 Apr 2018 16:30:29 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -8054,27 +8126,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8beb82bb-e46f-4193-9283-88dce42ed9db
+      - req-d9d24966-4451-4b60-b6c1-964580269136
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8beb82bb-e46f-4193-9283-88dce42ed9db
+      - req-d9d24966-4451-4b60-b6c1-964580269136
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -8089,27 +8161,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6f384c21b9b46ef9e2436487c5fa540
+      - c3bbaa556e894f6ebb24f953d24becf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2f0078e-76ff-41b9-b93f-1555e454b3a8
+      - req-6186a6ec-fcfd-4d12-bfc6-cec963a536ea
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2f0078e-76ff-41b9-b93f-1555e454b3a8
+      - req-6186a6ec-fcfd-4d12-bfc6-cec963a536ea
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -8124,27 +8196,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4d1145aff4a4c998fedee8d406ea2ea
+      - 283d4a97efb44a1c8492cbefaae8a082
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9389f3a4-7e25-42fc-9bc7-54c3767738c9
+      - req-6db5f649-fde5-442f-a005-c343fe1803db
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9389f3a4-7e25-42fc-9bc7-54c3767738c9
+      - req-6db5f649-fde5-442f-a005-c343fe1803db
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -8159,27 +8231,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4d1145aff4a4c998fedee8d406ea2ea
+      - 283d4a97efb44a1c8492cbefaae8a082
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b6e944b-fa00-491a-b65f-152911c64883
+      - req-46da65aa-8ae3-4fa6-ace0-5937c30f7f4b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2b6e944b-fa00-491a-b65f-152911c64883
+      - req-46da65aa-8ae3-4fa6-ace0-5937c30f7f4b
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -8194,27 +8266,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96e665c968984afdb7796c4f1942aa3f
+      - 41f92fe96de544bba7793a08de0e0b39
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-deed6520-4c9e-48af-ba66-f057f4e598ba
+      - req-759017d8-fbe6-4f84-a9cf-4a544dfc6b14
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-deed6520-4c9e-48af-ba66-f057f4e598ba
+      - req-759017d8-fbe6-4f84-a9cf-4a544dfc6b14
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -8229,27 +8301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96e665c968984afdb7796c4f1942aa3f
+      - 41f92fe96de544bba7793a08de0e0b39
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbfd2c57-7d59-482f-a385-31757ebe5482
+      - req-5b32820f-7409-4542-bb1c-267c401ae8aa
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cbfd2c57-7d59-482f-a385-31757ebe5482
+      - req-5b32820f-7409-4542-bb1c-267c401ae8aa
       Date:
-      - Mon, 09 Apr 2018 16:30:30 GMT
+      - Thu, 19 Apr 2018 17:40:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8267,15 +8339,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:31 GMT
+      - Thu, 19 Apr 2018 17:40:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e24e7e6d0e6944e3abc455aebcc3bc93
+      - b40dcc82dd474ac3b26ce6194c7483ee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f6f725b-c94a-4ed6-8eba-f0742551a9a8
+      - req-496a19cc-03ee-47ad-b080-d0ec888dc3ab
       Content-Length:
       - '7311'
       Connection:
@@ -8287,7 +8359,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:32.131113Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:28.780222Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8366,10 +8438,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fOIXs3cVR16nc_lYEukxBA"],
-        "issued_at": "2018-04-09T16:30:32.131220Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HcCLMWxOS7GDDYrbwiXgQQ"],
+        "issued_at": "2018-04-19T17:40:28.780310Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8387,15 +8459,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:32 GMT
+      - Thu, 19 Apr 2018 17:40:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1e985a07-641f-4cb3-9f03-6356e3388aa6
+      - req-f1b71d43-d3d3-4ab1-a8c9-c04c8210b815
       Content-Length:
       - '7311'
       Connection:
@@ -8407,7 +8479,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:32.461600Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:29.181957Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8486,10 +8558,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oFKqMa66SPe2iOsZtTF_GA"],
-        "issued_at": "2018-04-09T16:30:32.461661Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4SZj0Ne4SZCM2sv4mA9Fjg"],
+        "issued_at": "2018-04-19T17:40:29.182027Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8504,7 +8576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -8515,22 +8587,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-1de5117f-1eb4-4dac-bf8a-20ab32998d4c
+      - req-65ba7f42-0ec4-49d0-be32-9f10c7b9e569
       Date:
-      - Mon, 09 Apr 2018 16:30:32 GMT
+      - Thu, 19 Apr 2018 17:40:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
         "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -8575,19 +8637,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8605,15 +8677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:32 GMT
+      - Thu, 19 Apr 2018 17:40:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 35ba4c63d18d404f82573ee648ab4e83
+      - 306e19c0861a4548bbb02bfcf495ef96
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80772bb6-9ccd-4b9f-9153-e607367503be
+      - req-1693e3e4-d1c2-464a-b3ac-af6bbe26ad9e
       Content-Length:
       - '7311'
       Connection:
@@ -8625,7 +8697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:33.187019Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:29.720835Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8704,10 +8776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ARYNCFy-ScWtxh-CD6W_CA"],
-        "issued_at": "2018-04-09T16:30:33.187088Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KlP4upzxRnOpaMOMj2Y6-Q"],
+        "issued_at": "2018-04-19T17:40:29.720897Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8725,15 +8797,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:33 GMT
+      - Thu, 19 Apr 2018 17:40:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '089e73a351ce484583451888875200f2'
+      - 4299771b1f484e51bb118ccf031c62b8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0ff833a1-8002-43a1-a705-f49e34e8785f
+      - req-6c70ce42-f524-4b21-8814-8798361003f4
       Content-Length:
       - '297'
       Connection:
@@ -8742,12 +8814,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:30:33.455026Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:40:29.927591Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["s-88oc91T4-i6hcnwTIN8A"],
-        "issued_at": "2018-04-09T16:30:33.455131Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8a4PkYXkQCyRyi0ALvcNfw"],
+        "issued_at": "2018-04-19T17:40:29.927647Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -8762,20 +8834,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '089e73a351ce484583451888875200f2'
+      - 4299771b1f484e51bb118ccf031c62b8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:33 GMT
+      - Thu, 19 Apr 2018 17:40:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68492086-60d4-47c2-91e8-19c952e20dd6
+      - req-0a10ad8a-6182-40a8-b6de-e4401ed8cc1b
       Content-Length:
       - '2457'
       Connection:
@@ -8808,13 +8880,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"089e73a351ce484583451888875200f2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"4299771b1f484e51bb118ccf031c62b8"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8826,15 +8898,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:33 GMT
+      - Thu, 19 Apr 2018 17:40:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bdc17508b944a2490b2ac3cd5c65a55
+      - 42351f85c0fe41fabc004f6870d21aa7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5e0cf234-e3c1-4926-8f47-086873947e05
+      - req-b6df9b3c-6dee-4f4e-af47-1bb68bfd638d
       Content-Length:
       - '7313'
       Connection:
@@ -8846,7 +8918,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:33.455026Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:29.927591Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8925,10 +8997,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gMHJmQniT2Cwt23uzu4pNA",
-        "s-88oc91T4-i6hcnwTIN8A"], "issued_at": "2018-04-09T16:30:34.154241Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c-qgkR8IQFagq0rW1kzDcA",
+        "8a4PkYXkQCyRyi0ALvcNfw"], "issued_at": "2018-04-19T17:40:30.341953Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -8943,20 +9015,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bdc17508b944a2490b2ac3cd5c65a55
+      - 42351f85c0fe41fabc004f6870d21aa7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:34 GMT
+      - Thu, 19 Apr 2018 17:40:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-79cdb2fe-41b1-41d1-baad-ee3634260d69
+      - req-7b4f26d9-52e7-49d1-91cf-d8110eb91349
       Content-Length:
       - '2179'
       Connection:
@@ -8989,7 +9061,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9007,15 +9079,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:34 GMT
+      - Thu, 19 Apr 2018 17:40:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 372820d38249424f8cf94f8f8d146b3a
+      - 849547f2836f4f12b7d60b17ff2a53c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b5183c44-ef4b-4076-993e-f72cafb2ad9c
+      - req-37c0d194-d497-422c-b2bc-9ce908ed173e
       Content-Length:
       - '7278'
       Connection:
@@ -9027,7 +9099,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:34.772463Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:30.805266Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9106,10 +9178,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mwbIVDynTkeSrQE3cZGm-g"],
-        "issued_at": "2018-04-09T16:30:34.772579Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YkUmc1dYRK6NhV5p_pQxuQ"],
+        "issued_at": "2018-04-19T17:40:30.805328Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9127,15 +9199,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:34 GMT
+      - Thu, 19 Apr 2018 17:40:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc8e736863a94a23b3b652881917b54c
+      - cc99575ee7634893853e674e9e0b133a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2850be58-62cd-4891-a031-b66f992531fa
+      - req-16b702f8-a903-4517-9ff7-5dd33a28ce1e
       Content-Length:
       - '7278'
       Connection:
@@ -9147,7 +9219,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:35.155452Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:31.104581Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9226,10 +9298,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5VxMou6BTK-2y4rgXL1ePA"],
-        "issued_at": "2018-04-09T16:30:35.155523Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OivipOQoSy6La15Dr-OS9Q"],
+        "issued_at": "2018-04-19T17:40:31.104643Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9247,15 +9319,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:35 GMT
+      - Thu, 19 Apr 2018 17:40:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 26de677a530641938204333d25857e46
+      - 854ab1239c204d1a8242f74fa33bc9ff
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-105cb4bc-0ef3-4130-97dc-6d4b3b50c1f6
+      - req-0a1efb89-dba7-4b8c-9315-eef47b256ae3
       Content-Length:
       - '7264'
       Connection:
@@ -9267,7 +9339,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:35.495672Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:31.449587Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9346,10 +9418,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2BR3jxGfQ9OcuNDNBWIu-A"],
-        "issued_at": "2018-04-09T16:30:35.495741Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ug3FaUIHTHKWO39zVnHHUg"],
+        "issued_at": "2018-04-19T17:40:31.449651Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9367,15 +9439,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:35 GMT
+      - Thu, 19 Apr 2018 17:40:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d81d18c4750841349902081d25734bd4
+      - 1efc69a352b04533abc53e0955b55e53
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3ff146fd-c610-43f3-ac40-57e3654a139b
+      - req-f53c4abd-eede-43e5-acbb-c787f0664fc9
       Content-Length:
       - '7278'
       Connection:
@@ -9387,7 +9459,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:35.899226Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:31.773675Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9466,10 +9538,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g4FTPYhnTK6Odoz4ykN4GQ"],
-        "issued_at": "2018-04-09T16:30:35.899300Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WaddZCg9Tb2SX3h0USzToA"],
+        "issued_at": "2018-04-19T17:40:31.773738Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9487,15 +9559,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:36 GMT
+      - Thu, 19 Apr 2018 17:40:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0564b312e50942cc8899d26d29a71bb7
+      - 20d01ff81c4543ecb59472da73ab227e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6435d30b-cad4-4d38-a64f-63945facb686
+      - req-559cdce3-1e2a-4733-9aad-a661210b9d41
       Content-Length:
       - '7265'
       Connection:
@@ -9507,7 +9579,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:36.366919Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:32.085712Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9586,10 +9658,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Wq267OuOR6C1j5-GWs59eg"],
-        "issued_at": "2018-04-09T16:30:36.366996Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["76RU2LkDQlyKBKpy1-onOw"],
+        "issued_at": "2018-04-19T17:40:32.085813Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9607,15 +9679,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:36 GMT
+      - Thu, 19 Apr 2018 17:40:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 29b3a34b43b44ca78fa8dbdbf7a69910
+      - d56b02b07028494dba15bb5b5fbe325e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-57e75dd9-edc9-4b45-a8e7-822db4cc0d76
+      - req-fe50a550-ad51-47ae-954a-f85bb3be2ddf
       Content-Length:
       - '7278'
       Connection:
@@ -9627,7 +9699,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:36.697642Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:32.484512Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9706,10 +9778,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NP6RDVtVQZq6uETq7pZcoA"],
-        "issued_at": "2018-04-09T16:30:36.697718Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xeefEkR_Rw29YUr2o-e1DA"],
+        "issued_at": "2018-04-19T17:40:32.484584Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9727,15 +9799,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:36 GMT
+      - Thu, 19 Apr 2018 17:40:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8f86b8f28fb94578801f76b523de89ef
+      - d29aa73425374a55ae5636b517a2e03c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f3c10d1e-bea4-4cf2-a375-5db47ac7e70c
+      - req-8359e929-71c3-48e9-9137-26ee948e67e2
       Content-Length:
       - '7278'
       Connection:
@@ -9747,7 +9819,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:36.920938Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:32.795136Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9826,10 +9898,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IjfY2hYiS2Kd1etXEIwBqw"],
-        "issued_at": "2018-04-09T16:30:36.920973Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tULSPLs4TKSh1Jdk2mHA1A"],
+        "issued_at": "2018-04-19T17:40:32.795199Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -9844,7 +9916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8f86b8f28fb94578801f76b523de89ef
+      - d29aa73425374a55ae5636b517a2e03c
   response:
     status:
       code: 200
@@ -9855,14 +9927,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b3e762ca-7359-4a71-8edc-47a5655a90cc
+      - req-7102c580-b20d-4344-a697-13f3aa21fa2f
       Date:
-      - Mon, 09 Apr 2018 16:30:37 GMT
+      - Thu, 19 Apr 2018 17:40:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9880,15 +9952,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:37 GMT
+      - Thu, 19 Apr 2018 17:40:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7d9f4a1ad6d244e1a5d1db9fa0aeea8e
+      - c8fb4cd70f73463c831e7837e0f10a29
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-20b7da13-6921-4c4c-8398-a72dfc7ff8f2
+      - req-809dc6e6-c46b-47a5-a2cd-327677fb5fe1
       Content-Length:
       - '7278'
       Connection:
@@ -9900,7 +9972,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:37.446438Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:33.329641Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9979,10 +10051,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["23vAPIe2Rjq1QMaQEP_Cxw"],
-        "issued_at": "2018-04-09T16:30:37.446545Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["l61ABYfmSxmYpkz3h17rug"],
+        "issued_at": "2018-04-19T17:40:33.329703Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -9997,7 +10069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d9f4a1ad6d244e1a5d1db9fa0aeea8e
+      - c8fb4cd70f73463c831e7837e0f10a29
   response:
     status:
       code: 200
@@ -10008,14 +10080,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2d48483b-9859-476d-878e-37f1185527d5
+      - req-78493101-4506-46a5-ae40-db58eb7cf3dd
       Date:
-      - Mon, 09 Apr 2018 16:30:37 GMT
+      - Thu, 19 Apr 2018 17:40:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10033,15 +10105,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:37 GMT
+      - Thu, 19 Apr 2018 17:40:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-15b9cae1-85d9-41db-9558-1d438fdc1d27
+      - req-5e496b7c-34c0-4cb3-8619-6aeb82178a6d
       Content-Length:
       - '7264'
       Connection:
@@ -10053,7 +10125,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:37.929115Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:33.840719Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10132,10 +10204,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tdykRdhVRKebmVplcWtCUQ"],
-        "issued_at": "2018-04-09T16:30:37.929151Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SL7J7L3xQSqMsa4ZA-hB4w"],
+        "issued_at": "2018-04-19T17:40:33.840820Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -10150,7 +10222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10161,9 +10233,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-349ddee7-e6d6-4d3f-a9f1-0e4a95ac79b0
+      - req-567ba62e-e6a4-410c-81c0-d20e865be5a9
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -10197,7 +10269,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -10212,7 +10284,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10223,14 +10295,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1ef9182b-b047-4daf-a7f2-06dc869479ea
+      - req-494882fe-77c9-4103-ab02-1488d5ea5b0c
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10248,15 +10320,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fd4ebbb2c3df4be0aac2988915a56f8c
+      - a832f828486f4df5a111ffbee8543bfc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0267af2b-8cf2-4516-85f6-bafc5acd51fa
+      - req-5b6362dc-2600-4277-b7b3-9f14c749d3aa
       Content-Length:
       - '7278'
       Connection:
@@ -10268,7 +10340,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:38.476672Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:34.619750Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10347,10 +10419,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w_cMq5RRQD2_av4QIeGpHQ"],
-        "issued_at": "2018-04-09T16:30:38.476709Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hjRHNWiISWmsWFc9nisjgA"],
+        "issued_at": "2018-04-19T17:40:34.619854Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -10365,7 +10437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd4ebbb2c3df4be0aac2988915a56f8c
+      - a832f828486f4df5a111ffbee8543bfc
   response:
     status:
       code: 200
@@ -10376,14 +10448,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0998cb49-8285-43ea-92c3-7b679eea244f
+      - req-39a787af-4fd0-4532-87fb-ff5df2badba6
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -10398,7 +10470,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35ba4c63d18d404f82573ee648ab4e83
+      - 306e19c0861a4548bbb02bfcf495ef96
   response:
     status:
       code: 200
@@ -10409,14 +10481,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4ad23ba2-d279-451d-bc4e-cb3c2c925f63
+      - req-9018131d-92b6-455d-b1e5-20f0949ed605
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10434,15 +10506,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:38 GMT
+      - Thu, 19 Apr 2018 17:40:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fc74591ccf70492cb693287af42e7839
+      - 64534e20e999457893c07ad8b9f3735d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a8dd77bf-ae16-404c-9979-350b202a8332
+      - req-169c0a3a-24c8-405b-9c69-1e4d2768292d
       Content-Length:
       - '7265'
       Connection:
@@ -10454,7 +10526,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:38.979717Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:35.696321Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10533,10 +10605,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ciiELfc7RDK4-LfeFXEBJQ"],
-        "issued_at": "2018-04-09T16:30:38.979782Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DZJDS2qAS7yRw7VsvxVFIA"],
+        "issued_at": "2018-04-19T17:40:35.696416Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -10551,7 +10623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc74591ccf70492cb693287af42e7839
+      - 64534e20e999457893c07ad8b9f3735d
   response:
     status:
       code: 200
@@ -10562,14 +10634,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9fbeaf91-f8f8-4fb7-8f0a-8eb3e5a8c504
+      - req-d581c4b2-71c9-40ed-844e-ca7e525f5028
       Date:
-      - Mon, 09 Apr 2018 16:30:39 GMT
+      - Thu, 19 Apr 2018 17:40:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10587,15 +10659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:39 GMT
+      - Thu, 19 Apr 2018 17:40:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9fc22f8beff0488382197c2cc3f836c4
+      - abbaf59af9e6433a831f248308fa4655
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43ca8578-5a59-487b-98b6-a2d5eef9fb5e
+      - req-a55d0b69-715d-4d46-ba1e-43597a2f7e18
       Content-Length:
       - '7278'
       Connection:
@@ -10607,7 +10679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:39.352719Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:36.215072Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10686,10 +10758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rT13Ar3oTQSclTItccKrWA"],
-        "issued_at": "2018-04-09T16:30:39.352757Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_vFBo--uQvmdHQkFMJEfgw"],
+        "issued_at": "2018-04-19T17:40:36.215133Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -10704,7 +10776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fc22f8beff0488382197c2cc3f836c4
+      - abbaf59af9e6433a831f248308fa4655
   response:
     status:
       code: 200
@@ -10715,14 +10787,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-143c33b8-574c-47ac-96bf-3c329dee610c
+      - req-2e3a9490-e74e-449e-8511-3eee35200ef3
       Date:
-      - Mon, 09 Apr 2018 16:30:39 GMT
+      - Thu, 19 Apr 2018 17:40:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -10737,7 +10809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10748,9 +10820,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d0f11675-0468-40a0-94ca-3cada4d58464
+      - req-2e8c710e-0ad3-4f2c-80d5-503576fe30d4
       Date:
-      - Mon, 09 Apr 2018 16:30:39 GMT
+      - Thu, 19 Apr 2018 17:40:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10777,7 +10849,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -10792,7 +10864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10803,9 +10875,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e400c71b-7b9b-43cc-91b8-f93cfe9825bd
+      - req-8ecd9794-7d7d-4c9c-80e1-f1f224af7365
       Date:
-      - Mon, 09 Apr 2018 16:30:40 GMT
+      - Thu, 19 Apr 2018 17:40:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10832,7 +10904,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -10847,7 +10919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10858,9 +10930,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-4b8f0abf-443c-4ce3-9e61-8a15c9cf6ac3
+      - req-ddfc42f6-ff2a-4234-a424-d5f9093c182d
       Date:
-      - Mon, 09 Apr 2018 16:30:40 GMT
+      - Thu, 19 Apr 2018 17:40:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10887,7 +10959,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -10902,7 +10974,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10913,9 +10985,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9395f00f-18ce-4405-9da7-948259255712
+      - req-95ce96b9-551e-403d-9806-89309e319f37
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10927,7 +10999,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -10942,7 +11014,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10953,9 +11025,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6cb7b0ee-8b27-4f34-b6a9-eb95b76f4d2c
+      - req-f47dc8e3-cc5b-4415-a2ad-434dabccb017
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10967,7 +11039,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -10982,7 +11054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 567712b0c5734b5ab02674d809843dfd
+      - ef1e0ae8d6c043a98ff7ecf1a5bea94e
   response:
     status:
       code: 200
@@ -10993,9 +11065,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f02c8f02-ca8d-432f-abad-1283f98898d3
+      - req-b68f1269-e4de-435f-9f1f-a7a37550d064
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11007,7 +11079,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -11022,7 +11094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -11033,9 +11105,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c3fa019b-cf51-4c4f-944a-5c6deb85d029
+      - req-b6c39944-a245-4ce4-baf1-29378a94a2db
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:40:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 94d4473d2fa842459d65374d9c0c2a3b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-767d09b8-dc37-495c-9857-a1d3556776ec
+      Date:
+      - Thu, 19 Apr 2018 17:40:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -11139,139 +11343,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-618ceb7b-06ce-485a-819a-b15df1203910
-      Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -11286,7 +11358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -11297,9 +11369,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7f0d5eed-2753-485d-bf66-ec33b3dbe1ba
+      - req-82a512a3-3d87-4c91-970c-0d579933d803
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11341,7 +11413,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -11356,7 +11428,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -11367,9 +11439,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b8cdf994-e43d-47f2-9fb5-c3cf8331cbf2
+      - req-7f25f201-a40b-4c81-b795-6f6af9a936cd
       Date:
-      - Mon, 09 Apr 2018 16:30:41 GMT
+      - Thu, 19 Apr 2018 17:40:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11411,7 +11483,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -11426,7 +11498,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -11437,9 +11509,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5cda5373-97a8-4c84-a582-6edec64d784d
+      - req-737a9fd2-1878-4a06-b43d-b843bb6d0480
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11842,7 +11914,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -11857,7 +11929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -11868,9 +11940,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-cbef93b9-eb03-435e-ada8-6dc1852bc7e4
+      - req-fc6cea8b-aa5f-4c7c-8d00-340bf11b5d4f
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12273,7 +12345,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -12288,7 +12360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12299,9 +12371,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-122492ee-a313-4cd4-88f2-fa7ecd9e9996
+      - req-0fc62237-4213-424f-bb0f-6cde3fd7f5d0
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12333,7 +12405,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -12348,7 +12420,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12359,9 +12431,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-504cd044-8ae5-4497-ba12-7ec62ae0d41d
+      - req-2ecc242b-09d3-4a84-a7d3-e92db35f6fe0
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12393,7 +12465,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -12408,7 +12480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12419,9 +12491,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-a477a1e8-9a5b-4c03-bbd4-0fb926aef4d8
+      - req-c6bd6dad-d320-4aae-81b1-13a001fe3fca
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -12456,7 +12528,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -12471,7 +12543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12482,9 +12554,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-3a7cefe4-d56e-4a27-a562-bcec70ad757a
+      - req-f2b024c2-4e3e-43a5-b3ff-136e3117f74a
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -12527,7 +12599,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -12542,7 +12614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12553,9 +12625,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-0b1f0689-e5f2-459e-a591-ecc944fe9230
+      - req-91e30e44-c194-4389-9f95-22f9a52bbb1e
       Date:
-      - Mon, 09 Apr 2018 16:30:42 GMT
+      - Thu, 19 Apr 2018 17:40:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -12598,7 +12670,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -12613,7 +12685,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12624,9 +12696,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-9b9387e0-cd75-40bf-b1ee-65ccd295fa3d
+      - req-a86d595a-3b36-439f-a0a9-9bf0c03c9196
       Date:
-      - Mon, 09 Apr 2018 16:30:43 GMT
+      - Thu, 19 Apr 2018 17:40:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -12733,7 +12805,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -12748,7 +12820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12759,9 +12831,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-ab0b50dc-7327-47be-afba-a8c11a0cb0f6
+      - req-6437047c-9441-4bc6-a088-568166b7a5a4
       Date:
-      - Mon, 09 Apr 2018 16:30:43 GMT
+      - Thu, 19 Apr 2018 17:40:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -12803,7 +12875,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -12818,7 +12890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df6d013118d5423e85c6d4f5031cf0b0
+      - 94d4473d2fa842459d65374d9c0c2a3b
   response:
     status:
       code: 200
@@ -12829,15 +12901,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-062d512f-7aa4-41ab-afe8-e9b4f3ba716b
+      - req-1dd7fe20-47ac-4797-a0ee-af0b5b9923f4
       Date:
-      - Mon, 09 Apr 2018 16:30:43 GMT
+      - Thu, 19 Apr 2018 17:40:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -12855,13 +12927,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:43 GMT
+      - Thu, 19 Apr 2018 17:40:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7975e056-5a52-4004-a784-adffaf8475bf
+      - req-1dad3e87-aac0-4660-af18-0fec6d345591
       Content-Length:
       - '4227'
       Connection:
@@ -12870,10 +12942,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:44.055120", "expires":
-        "2018-04-09T17:30:44Z", "id": "26db97117afe463abdcfcabf19ff087f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:42.102871", "expires":
+        "2018-04-19T18:40:42Z", "id": "9dc2223ca66349969f929e72f09cd962", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["m1mP683QTQ-CMypP2I_-jQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iHDeP6xfSJ2JepBnS9uuMg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -12918,7 +12990,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -12936,13 +13008,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:44 GMT
+      - Thu, 19 Apr 2018 17:40:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00427814-e951-4d26-aaba-5673e7f8c5a5
+      - req-645dab99-ea19-45e0-bb17-fcf9e7d555fb
       Content-Length:
       - '4227'
       Connection:
@@ -12951,10 +13023,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:44.270540", "expires":
-        "2018-04-09T17:30:44Z", "id": "97ed053183f54a3bade8bca7a7d19769", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:42.591935", "expires":
+        "2018-04-19T18:40:42Z", "id": "52b2370e36564935bb80547cab827268", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["R_eFZTciTUSui_UMBb6ujw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["E_iNpAW4QumwxCGC8q8A_Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -12999,7 +13071,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13017,13 +13089,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:44 GMT
+      - Thu, 19 Apr 2018 17:40:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b2e90377-bfd8-42af-aac9-d68720518172
+      - req-fb93cbbf-45c7-400c-bee0-26bd3758de0a
       Content-Length:
       - '370'
       Connection:
@@ -13032,13 +13104,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:44.417273", "expires":
-        "2018-04-09T17:30:44Z", "id": "9ea8fc301d224292a3a7005d0da96d99", "audit_ids":
-        ["Q7qx4iXEQdyuzQWDuF9HxA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:42.778397", "expires":
+        "2018-04-19T18:40:42Z", "id": "31658da6afa148afb8a5793f6921e714", "audit_ids":
+        ["JEY-vfRvRSS9Y-dkh9YIAA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:42 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -13053,20 +13125,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ea8fc301d224292a3a7005d0da96d99
+      - 31658da6afa148afb8a5793f6921e714
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:44 GMT
+      - Thu, 19 Apr 2018 17:40:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0c241563-df31-40fd-8f81-989f02f9e10a
+      - req-adac9bd0-7f29-46d2-8d3e-4124f431aaca
       Content-Length:
       - '884'
       Connection:
@@ -13087,13 +13159,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9ea8fc301d224292a3a7005d0da96d99"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"31658da6afa148afb8a5793f6921e714"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13105,13 +13177,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:44 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ae428ef-25b6-43f0-90a1-9f32731428ea
+      - req-e02bec66-4ff9-42a3-9876-d0f6583da456
       Content-Length:
       - '4214'
       Connection:
@@ -13120,11 +13192,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:44.795226", "expires":
-        "2018-04-09T17:30:44Z", "id": "dace6e35eed44b0fac5756d617d7f317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:43.147416", "expires":
+        "2018-04-19T18:40:42Z", "id": "0b7f21e719424323940b85a4e3e35db2", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["UwQ2_mRCSXGFBRtv3AEoGQ",
-        "Q7qx4iXEQdyuzQWDuF9HxA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["PaeDGNBdSuSniRtaM8Rt8Q",
+        "JEY-vfRvRSS9Y-dkh9YIAA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -13169,7 +13241,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13187,13 +13259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:44 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-63436a31-5462-4f82-88d7-888624c3865f
+      - req-557c01c3-1e9e-46c9-999d-0941cb0c4a14
       Content-Length:
       - '370'
       Connection:
@@ -13202,13 +13274,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:45.008699", "expires":
-        "2018-04-09T17:30:45Z", "id": "02df53254cb44f5faf8182687c8c2a47", "audit_ids":
-        ["z3M2lprXSPSWpur9temyVQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:43.359156", "expires":
+        "2018-04-19T18:40:43Z", "id": "1701ee8c60d847d38e9c59dff051af1b", "audit_ids":
+        ["11Oh0trtTVCFNgS-ESDmNg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -13223,20 +13295,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02df53254cb44f5faf8182687c8c2a47
+      - 1701ee8c60d847d38e9c59dff051af1b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:45 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d175416e-eccc-4542-b234-9b729cc123bc
+      - req-006a3bb1-51ba-47aa-ae8e-14cdfdf29b9a
       Content-Length:
       - '884'
       Connection:
@@ -13257,13 +13329,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"02df53254cb44f5faf8182687c8c2a47"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"1701ee8c60d847d38e9c59dff051af1b"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13275,13 +13347,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:45 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-959b238a-da51-42af-9222-6f767b78b689
+      - req-89899f5d-cd91-456a-a955-2c5771dfb994
       Content-Length:
       - '4214'
       Connection:
@@ -13290,11 +13362,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:45.404841", "expires":
-        "2018-04-09T17:30:45Z", "id": "3fc887ec64fe43fa84d3652a2fb22535", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:43.710307", "expires":
+        "2018-04-19T18:40:43Z", "id": "039378003be744aa97386828c84837fc", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["zffsC6faRB2Mi1lug7apzw",
-        "z3M2lprXSPSWpur9temyVQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["LSZ6stJbRYq3iIxND3lgHg",
+        "11Oh0trtTVCFNgS-ESDmNg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -13339,7 +13411,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -13354,20 +13426,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02df53254cb44f5faf8182687c8c2a47
+      - 1701ee8c60d847d38e9c59dff051af1b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:45 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-adb547ec-0e36-4ff2-8440-87f173b83e64
+      - req-382522e7-bb9c-4ee2-bc9b-0a10f5351bf9
       Content-Length:
       - '884'
       Connection:
@@ -13388,7 +13460,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13406,13 +13478,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:45 GMT
+      - Thu, 19 Apr 2018 17:40:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-adf4920c-ca30-40f5-bc26-f32340d8e04a
+      - req-65f39da6-cafe-44c6-a79a-6ccfb84bdf8b
       Content-Length:
       - '4188'
       Connection:
@@ -13421,10 +13493,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:45.958471", "expires":
-        "2018-04-09T17:30:45Z", "id": "b1adb4d4924e4d849506c6ca8fed8afd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:44.137611", "expires":
+        "2018-04-19T18:40:44Z", "id": "755acd7393c04ebea8eb36a06f7ff1e6", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["gtgq2GE2R-2AnH3GHNQ1cQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["7Sc9wkukSE2w_eCtCoUyAg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -13469,7 +13541,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13487,13 +13559,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:46 GMT
+      - Thu, 19 Apr 2018 17:40:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3f1fbef5-7304-4c20-9edb-a9eaeaf8545b
+      - req-b9c9e6e3-e8e6-46c1-b258-c7e8673050d5
       Content-Length:
       - '4188'
       Connection:
@@ -13502,10 +13574,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:46.237451", "expires":
-        "2018-04-09T17:30:46Z", "id": "7ded5678d5e2439593aa2a8676e2fbe6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:44.444384", "expires":
+        "2018-04-19T18:40:44Z", "id": "2434cbf25fa1447ba5908fb9a3196dea", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hSl9z1ddSP-43cAmKVediw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BHTli3W1T4-2l4OIvg9syQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -13550,7 +13622,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13568,13 +13640,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:46 GMT
+      - Thu, 19 Apr 2018 17:40:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9d98b50f-8d2b-418b-8f29-439b170e2826
+      - req-3f7fa349-3664-467d-a63b-a830c3b1e891
       Content-Length:
       - '4174'
       Connection:
@@ -13583,10 +13655,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:46.501439", "expires":
-        "2018-04-09T17:30:46Z", "id": "86eae7055dbc4903b5374d8e88002801", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:44.730442", "expires":
+        "2018-04-19T18:40:44Z", "id": "e4a15f6661494434931a0a1641f2821c", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["glb3BbodSt-TKK-6TZIOzA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fWcQqjrwQOS0dotgr9WRfQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -13631,7 +13703,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13649,13 +13721,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:46 GMT
+      - Thu, 19 Apr 2018 17:40:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3ab164df-b8e3-443b-b666-03b926556ed2
+      - req-d47a44a2-f518-4a25-8237-36b2868b0ae3
       Content-Length:
       - '4188'
       Connection:
@@ -13664,10 +13736,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:46.765250", "expires":
-        "2018-04-09T17:30:46Z", "id": "cbedcaf34cbe45f0aebaf14d34e4cd15", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:45.015021", "expires":
+        "2018-04-19T18:40:44Z", "id": "0d599eba00c64bff829194e213c4e8f0", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["eQOka9HKSTe_ovjHpmcCwg"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["EHp4_59ITY-CvZeIj2n26w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -13712,7 +13784,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13730,13 +13802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:46 GMT
+      - Thu, 19 Apr 2018 17:40:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1f695ae5-d650-4a29-b3df-fae5268766fc
+      - req-f7d02dfa-6c09-4f95-8156-1738fade336d
       Content-Length:
       - '4175'
       Connection:
@@ -13745,10 +13817,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:47.116943", "expires":
-        "2018-04-09T17:30:47Z", "id": "67ed0ea2c08640e0aec2fa20e20ff800", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:45.273799", "expires":
+        "2018-04-19T18:40:45Z", "id": "efe2fe76de384df19e5ec4b807880940", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hbGjCeGhRRynbQnbiO7pjQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MKeYm1ekRVyP0cc479XFZg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -13793,7 +13865,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13811,13 +13883,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:47 GMT
+      - Thu, 19 Apr 2018 17:40:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d2e908bb-0c14-4c49-b739-e68ea4f27030
+      - req-1036f3b7-96e4-432a-aefd-e426cdb1b3d5
       Content-Length:
       - '4188'
       Connection:
@@ -13826,10 +13898,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:47.444450", "expires":
-        "2018-04-09T17:30:47Z", "id": "0603bcdbf29c40d895a07919f915ce9e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:45.520463", "expires":
+        "2018-04-19T18:40:45Z", "id": "5414e81a868a465eb275f21535253d4c", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["lAEd1K9vQT6-ritNP9_lxA"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["0cKVbGCvRyy9i7MCS0NI2w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -13874,7 +13946,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -13892,13 +13964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:47 GMT
+      - Thu, 19 Apr 2018 17:40:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df3d71ef-5c04-40c7-9cfa-a74a90a8c028
+      - req-fd2b0ea0-9965-4e8a-9a97-5082853930af
       Content-Length:
       - '4188'
       Connection:
@@ -13907,10 +13979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:47.774266", "expires":
-        "2018-04-09T17:30:47Z", "id": "f217f6b0664c4ee3b59fe9275ae1bb2f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:45.770349", "expires":
+        "2018-04-19T18:40:45Z", "id": "383df0baa943463496ec8c9c680723a3", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["ntD1Ghd6TVK7RFhzWwQ7iQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["YPnUX-DAT46epOO9U1pEXA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -13955,7 +14027,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -13970,27 +14042,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f217f6b0664c4ee3b59fe9275ae1bb2f
+      - 383df0baa943463496ec8c9c680723a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-674f3136-871a-4af2-be64-003b126122c1
+      - req-66b58a6b-bce1-4af6-9736-847e5aa9b4ac
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-674f3136-871a-4af2-be64-003b126122c1
+      - req-66b58a6b-bce1-4af6-9736-847e5aa9b4ac
       Date:
-      - Mon, 09 Apr 2018 16:30:48 GMT
+      - Thu, 19 Apr 2018 17:40:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14008,13 +14080,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:48 GMT
+      - Thu, 19 Apr 2018 17:40:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a80ea57-6876-41f7-97d3-12ad17a31676
+      - req-9af8046b-474b-4146-91b4-61a2594632fd
       Content-Length:
       - '4188'
       Connection:
@@ -14023,10 +14095,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:48.509472", "expires":
-        "2018-04-09T17:30:48Z", "id": "8b1a7e64e8874943b7ed6ddfc69404eb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:46.530445", "expires":
+        "2018-04-19T18:40:46Z", "id": "94fa006c0b7545cc84594b367e043fad", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lNj1H6LmT3OZSPSE0LsAQQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["f-2x9j_ATwOy2xM4vD8I1g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -14071,7 +14143,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -14086,27 +14158,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b1a7e64e8874943b7ed6ddfc69404eb
+      - 94fa006c0b7545cc84594b367e043fad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3a3ad15a-c6cf-4c24-abac-12f614bbeb8c
+      - req-7ab90c8f-9137-4071-8e11-0a80fe6fc0ac
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3a3ad15a-c6cf-4c24-abac-12f614bbeb8c
+      - req-7ab90c8f-9137-4071-8e11-0a80fe6fc0ac
       Date:
-      - Mon, 09 Apr 2018 16:30:48 GMT
+      - Thu, 19 Apr 2018 17:40:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14124,13 +14196,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:48 GMT
+      - Thu, 19 Apr 2018 17:40:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fb2abf34-6ea8-4e1b-900b-a000c670601b
+      - req-579ceb83-aa55-40d6-a51b-68aa66f77e26
       Content-Length:
       - '4174'
       Connection:
@@ -14139,10 +14211,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:49.196971", "expires":
-        "2018-04-09T17:30:49Z", "id": "06deb09a3474496eb382f44d9103acc1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:47.087661", "expires":
+        "2018-04-19T18:40:47Z", "id": "fc6745edfb6741cfbf4bb412dd0449e7", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Goj6iohjTyCgxRZTSIEhWg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3yztN0jATIqgyL5zIbFYmw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -14187,7 +14259,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -14202,22 +14274,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-288ff288-8824-4523-942e-f51308d28f9c
+      - req-d5b97ac4-5f98-4fae-9bcc-8f416feab1a5
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-288ff288-8824-4523-942e-f51308d28f9c
+      - req-d5b97ac4-5f98-4fae-9bcc-8f416feab1a5
       Date:
-      - Mon, 09 Apr 2018 16:30:49 GMT
+      - Thu, 19 Apr 2018 17:40:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -14250,7 +14322,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -14265,22 +14337,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1689e0a0-bdcb-4de2-a94f-3ef98c50eed6
+      - req-04d482b8-0c86-4542-98ea-9144b5dec6e5
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-1689e0a0-bdcb-4de2-a94f-3ef98c50eed6
+      - req-04d482b8-0c86-4542-98ea-9144b5dec6e5
       Date:
-      - Mon, 09 Apr 2018 16:30:50 GMT
+      - Thu, 19 Apr 2018 17:40:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -14321,7 +14393,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -14336,22 +14408,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b61662f-e44c-4dfb-a107-55120b92af6e
+      - req-4dd2c2ed-d961-45c0-a28e-d753dd0f1463
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-1b61662f-e44c-4dfb-a107-55120b92af6e
+      - req-4dd2c2ed-d961-45c0-a28e-d753dd0f1463
       Date:
-      - Mon, 09 Apr 2018 16:30:50 GMT
+      - Thu, 19 Apr 2018 17:40:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -14385,7 +14457,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -14400,27 +14472,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1c07b6a8-8cc2-4438-94ab-04bb5b3b36e2
+      - req-594722c4-c9de-45f2-aedd-7113d2028ab8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1c07b6a8-8cc2-4438-94ab-04bb5b3b36e2
+      - req-594722c4-c9de-45f2-aedd-7113d2028ab8
       Date:
-      - Mon, 09 Apr 2018 16:30:51 GMT
+      - Thu, 19 Apr 2018 17:40:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14438,13 +14510,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:51 GMT
+      - Thu, 19 Apr 2018 17:40:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d286d67-3054-42db-b16f-b804e79df96d
+      - req-59c773bf-1119-499c-8414-5c137ddfc6f3
       Content-Length:
       - '4188'
       Connection:
@@ -14453,10 +14525,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:51.271500", "expires":
-        "2018-04-09T17:30:51Z", "id": "1b83f28fd4ab46e3b5969848197e2c91", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:48.842332", "expires":
+        "2018-04-19T18:40:48Z", "id": "89e438a4c8bd46aea67504a5adc88db1", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["TwzmSqDYSi-xxYzritd1HQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["uLJ7by-tTOCgSpaiLk-EFQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -14501,7 +14573,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -14516,27 +14588,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b83f28fd4ab46e3b5969848197e2c91
+      - 89e438a4c8bd46aea67504a5adc88db1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c53fc8a4-70d4-44c8-8f1f-4f0d86dce42b
+      - req-c26861fa-2798-4c52-b872-33c3d5ee2dc5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c53fc8a4-70d4-44c8-8f1f-4f0d86dce42b
+      - req-c26861fa-2798-4c52-b872-33c3d5ee2dc5
       Date:
-      - Mon, 09 Apr 2018 16:30:51 GMT
+      - Thu, 19 Apr 2018 17:40:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -14551,27 +14623,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ed053183f54a3bade8bca7a7d19769
+      - 52b2370e36564935bb80547cab827268
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81408ba8-7b44-4b2d-81c9-a5c5c03436dc
+      - req-cbd35a8b-47ac-4852-b6e9-6ce35028037c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-81408ba8-7b44-4b2d-81c9-a5c5c03436dc
+      - req-cbd35a8b-47ac-4852-b6e9-6ce35028037c
       Date:
-      - Mon, 09 Apr 2018 16:30:52 GMT
+      - Thu, 19 Apr 2018 17:40:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14589,13 +14661,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:52 GMT
+      - Thu, 19 Apr 2018 17:40:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f98a08c-706a-430a-b91a-844eca268a55
+      - req-130fe742-65e5-4fde-9b09-c95938c6ae93
       Content-Length:
       - '4175'
       Connection:
@@ -14604,10 +14676,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:52.451379", "expires":
-        "2018-04-09T17:30:52Z", "id": "1de7475ec2bb4ee09d2ca802cb1a8808", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:49.980301", "expires":
+        "2018-04-19T18:40:49Z", "id": "e7ce235ebbbd4c9ebd4b64506c7fc695", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["StQabpoSSJGx4Mwc9TL69Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["l0BOBvO4So2Wev1CGHe4Og"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -14652,7 +14724,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -14667,27 +14739,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1de7475ec2bb4ee09d2ca802cb1a8808
+      - e7ce235ebbbd4c9ebd4b64506c7fc695
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad945899-bca6-4e05-a0c5-2ba44becd695
+      - req-a72adaa7-e6b1-4e64-9fe1-0f3ea28da105
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ad945899-bca6-4e05-a0c5-2ba44becd695
+      - req-a72adaa7-e6b1-4e64-9fe1-0f3ea28da105
       Date:
-      - Mon, 09 Apr 2018 16:30:52 GMT
+      - Thu, 19 Apr 2018 17:40:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14705,13 +14777,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:52 GMT
+      - Thu, 19 Apr 2018 17:40:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-175e453f-9fd9-45df-b73a-1da148944505
+      - req-d237f6e4-fe71-40d0-a9b6-eb667a13fb62
       Content-Length:
       - '4188'
       Connection:
@@ -14720,10 +14792,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:30:53.123167", "expires":
-        "2018-04-09T17:30:53Z", "id": "23213755bd8b4269bb97f7c8a910c017", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:40:50.667120", "expires":
+        "2018-04-19T18:40:50Z", "id": "bee62159353d40de9be7e689b8d67766", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["fJiQ6zQ3Sy6BIPH565iGOQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["fPlgVXzrRTKlZBDuc7u8cw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -14768,7 +14840,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -14783,27 +14855,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23213755bd8b4269bb97f7c8a910c017
+      - bee62159353d40de9be7e689b8d67766
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2363efee-5e7d-48f8-9c12-1471db70407a
+      - req-213b9ed7-f30a-41c9-b163-7f77b812eb3b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2363efee-5e7d-48f8-9c12-1471db70407a
+      - req-213b9ed7-f30a-41c9-b163-7f77b812eb3b
       Date:
-      - Mon, 09 Apr 2018 16:30:53 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -14818,27 +14890,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f217f6b0664c4ee3b59fe9275ae1bb2f
+      - 383df0baa943463496ec8c9c680723a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ccf48c6-8313-4891-9a2b-669c40bc8e56
+      - req-8035641c-7564-401b-acdf-8aa7d3f66941
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5ccf48c6-8313-4891-9a2b-669c40bc8e56
+      - req-8035641c-7564-401b-acdf-8aa7d3f66941
       Date:
-      - Mon, 09 Apr 2018 16:30:53 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -14853,27 +14925,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f217f6b0664c4ee3b59fe9275ae1bb2f
+      - 383df0baa943463496ec8c9c680723a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c8a836a3-a0e7-4ff4-8aaf-357b3f4ed25f
+      - req-24016850-c113-4d3f-a1cf-0ee8b023811c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c8a836a3-a0e7-4ff4-8aaf-357b3f4ed25f
+      - req-24016850-c113-4d3f-a1cf-0ee8b023811c
       Date:
-      - Mon, 09 Apr 2018 16:30:54 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -14888,27 +14960,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b1a7e64e8874943b7ed6ddfc69404eb
+      - 94fa006c0b7545cc84594b367e043fad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5afafd2d-e4c4-43ba-9af7-436abff9ba56
+      - req-31403b62-124f-433c-9aa5-6b74936fd0f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5afafd2d-e4c4-43ba-9af7-436abff9ba56
+      - req-31403b62-124f-433c-9aa5-6b74936fd0f0
       Date:
-      - Mon, 09 Apr 2018 16:30:54 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -14923,27 +14995,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b1a7e64e8874943b7ed6ddfc69404eb
+      - 94fa006c0b7545cc84594b367e043fad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4aee1593-98ed-43e8-8d90-30e6864b61e6
+      - req-e8e924b2-330d-45de-b2bd-8b94ddbd0677
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4aee1593-98ed-43e8-8d90-30e6864b61e6
+      - req-e8e924b2-330d-45de-b2bd-8b94ddbd0677
       Date:
-      - Mon, 09 Apr 2018 16:30:54 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -14958,22 +15030,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe0bdc60-eee0-4a74-b303-ad05e46020a7
+      - req-889a6931-fd9c-4d0d-b1d7-c134713360ca
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-fe0bdc60-eee0-4a74-b303-ad05e46020a7
+      - req-889a6931-fd9c-4d0d-b1d7-c134713360ca
       Date:
-      - Mon, 09 Apr 2018 16:30:54 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -14988,7 +15060,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -15003,22 +15075,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c39e5ca-464e-4a8c-a9df-e7a2b6f09d58
+      - req-25276265-08c2-44dd-9c3c-fb362ae2e2d5
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-9c39e5ca-464e-4a8c-a9df-e7a2b6f09d58
+      - req-25276265-08c2-44dd-9c3c-fb362ae2e2d5
       Date:
-      - Mon, 09 Apr 2018 16:30:54 GMT
+      - Thu, 19 Apr 2018 17:40:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15033,7 +15105,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -15048,27 +15120,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b83f28fd4ab46e3b5969848197e2c91
+      - 89e438a4c8bd46aea67504a5adc88db1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78b652dc-658e-4ae9-8be9-bcaa946dc0cd
+      - req-0c699bc1-1e3a-4182-a89f-465a407d1318
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-78b652dc-658e-4ae9-8be9-bcaa946dc0cd
+      - req-0c699bc1-1e3a-4182-a89f-465a407d1318
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -15083,27 +15155,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b83f28fd4ab46e3b5969848197e2c91
+      - 89e438a4c8bd46aea67504a5adc88db1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68f24805-3c60-4dec-9b36-cb022140769c
+      - req-07cd63de-3bcd-4bde-92e2-fc5fc5674246
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-68f24805-3c60-4dec-9b36-cb022140769c
+      - req-07cd63de-3bcd-4bde-92e2-fc5fc5674246
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -15118,27 +15190,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ed053183f54a3bade8bca7a7d19769
+      - 52b2370e36564935bb80547cab827268
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ad3abcf-7175-4316-801a-85e6ad7d0fa7
+      - req-147b83ae-c219-4c35-83a3-e0f4ac3a8b77
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0ad3abcf-7175-4316-801a-85e6ad7d0fa7
+      - req-147b83ae-c219-4c35-83a3-e0f4ac3a8b77
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -15153,27 +15225,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ed053183f54a3bade8bca7a7d19769
+      - 52b2370e36564935bb80547cab827268
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-704ef7ea-c466-4e36-8c7c-a069bf598bb6
+      - req-82c8e4ac-b96b-4a64-b68c-d15714f78d40
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-704ef7ea-c466-4e36-8c7c-a069bf598bb6
+      - req-82c8e4ac-b96b-4a64-b68c-d15714f78d40
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -15188,27 +15260,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1de7475ec2bb4ee09d2ca802cb1a8808
+      - e7ce235ebbbd4c9ebd4b64506c7fc695
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61ee8bb3-ac13-4c03-996f-dbc467dc244c
+      - req-3112cb90-7a75-4440-8575-25fd673f5170
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-61ee8bb3-ac13-4c03-996f-dbc467dc244c
+      - req-3112cb90-7a75-4440-8575-25fd673f5170
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -15223,27 +15295,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1de7475ec2bb4ee09d2ca802cb1a8808
+      - e7ce235ebbbd4c9ebd4b64506c7fc695
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8940ec2c-2842-427d-ab08-6c3c7259bc71
+      - req-23f229f1-2223-48e3-8580-4c003609bb7a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8940ec2c-2842-427d-ab08-6c3c7259bc71
+      - req-23f229f1-2223-48e3-8580-4c003609bb7a
       Date:
-      - Mon, 09 Apr 2018 16:30:55 GMT
+      - Thu, 19 Apr 2018 17:40:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -15258,27 +15330,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23213755bd8b4269bb97f7c8a910c017
+      - bee62159353d40de9be7e689b8d67766
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8596fa1-700d-48ce-a54c-d30ab3578605
+      - req-8881f447-3240-4503-a419-f6744b7ecfd0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e8596fa1-700d-48ce-a54c-d30ab3578605
+      - req-8881f447-3240-4503-a419-f6744b7ecfd0
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -15293,27 +15365,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23213755bd8b4269bb97f7c8a910c017
+      - bee62159353d40de9be7e689b8d67766
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5cb155ad-27ec-4a4f-97df-d6b03b56945e
+      - req-b6ee5dc4-7b89-41f4-acde-e2c89be82ad5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5cb155ad-27ec-4a4f-97df-d6b03b56945e
+      - req-b6ee5dc4-7b89-41f4-acde-e2c89be82ad5
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -15328,27 +15400,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f217f6b0664c4ee3b59fe9275ae1bb2f
+      - 383df0baa943463496ec8c9c680723a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fb61f76-2907-42e5-8192-401ccba26585
+      - req-5197ac99-957a-4c41-8bbb-4f1ee130bb87
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3fb61f76-2907-42e5-8192-401ccba26585
+      - req-5197ac99-957a-4c41-8bbb-4f1ee130bb87
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -15363,27 +15435,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f217f6b0664c4ee3b59fe9275ae1bb2f
+      - 383df0baa943463496ec8c9c680723a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-878971d0-3bdc-4e2d-8d4c-3d0c7ae87554
+      - req-8fadb60d-0cf9-438f-8160-5d21775afc89
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-878971d0-3bdc-4e2d-8d4c-3d0c7ae87554
+      - req-8fadb60d-0cf9-438f-8160-5d21775afc89
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -15398,27 +15470,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b1a7e64e8874943b7ed6ddfc69404eb
+      - 94fa006c0b7545cc84594b367e043fad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c37044b-a9f9-4031-ae73-93d50df5211f
+      - req-dea022bf-5f8b-4690-a7ef-95f6bcd612d5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c37044b-a9f9-4031-ae73-93d50df5211f
+      - req-dea022bf-5f8b-4690-a7ef-95f6bcd612d5
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -15433,27 +15505,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b1a7e64e8874943b7ed6ddfc69404eb
+      - 94fa006c0b7545cc84594b367e043fad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a32810a-cea2-4a79-be0c-395d7f6f0845
+      - req-85fc0258-b702-43c7-9f45-2a2d7fc3d52b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6a32810a-cea2-4a79-be0c-395d7f6f0845
+      - req-85fc0258-b702-43c7-9f45-2a2d7fc3d52b
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -15468,27 +15540,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5746d665-a32c-4d35-95c3-a65f3deffe03
+      - req-c5a8306b-2ed3-4e08-909a-910aa4ed158e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5746d665-a32c-4d35-95c3-a65f3deffe03
+      - req-c5a8306b-2ed3-4e08-909a-910aa4ed158e
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -15503,27 +15575,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06deb09a3474496eb382f44d9103acc1
+      - fc6745edfb6741cfbf4bb412dd0449e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6669789e-8a20-4e50-b64a-55cf4383b928
+      - req-908283b3-11ad-4cbc-89e7-7ef1b51a79a1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6669789e-8a20-4e50-b64a-55cf4383b928
+      - req-908283b3-11ad-4cbc-89e7-7ef1b51a79a1
       Date:
-      - Mon, 09 Apr 2018 16:30:56 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -15538,27 +15610,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b83f28fd4ab46e3b5969848197e2c91
+      - 89e438a4c8bd46aea67504a5adc88db1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3498eaf-18ca-4e12-887b-6f685e66a474
+      - req-5562deab-4397-4cd9-82ca-4f0f856d8daa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d3498eaf-18ca-4e12-887b-6f685e66a474
+      - req-5562deab-4397-4cd9-82ca-4f0f856d8daa
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -15573,27 +15645,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b83f28fd4ab46e3b5969848197e2c91
+      - 89e438a4c8bd46aea67504a5adc88db1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fda5b177-4af2-47cf-8dad-c61ccf82a633
+      - req-c222a7cb-6203-4b3a-aab8-2afa7a219767
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fda5b177-4af2-47cf-8dad-c61ccf82a633
+      - req-c222a7cb-6203-4b3a-aab8-2afa7a219767
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -15608,27 +15680,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ed053183f54a3bade8bca7a7d19769
+      - 52b2370e36564935bb80547cab827268
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26276877-8792-47bf-aaf2-c64bed6d7136
+      - req-b297e3eb-443d-45f2-b05f-c864e9066715
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-26276877-8792-47bf-aaf2-c64bed6d7136
+      - req-b297e3eb-443d-45f2-b05f-c864e9066715
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -15643,27 +15715,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ed053183f54a3bade8bca7a7d19769
+      - 52b2370e36564935bb80547cab827268
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9970fe0-5464-46fc-8f4c-be554bcaf0b6
+      - req-e6333ab2-db17-4116-90f9-cb2b771c5407
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d9970fe0-5464-46fc-8f4c-be554bcaf0b6
+      - req-e6333ab2-db17-4116-90f9-cb2b771c5407
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -15678,27 +15750,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1de7475ec2bb4ee09d2ca802cb1a8808
+      - e7ce235ebbbd4c9ebd4b64506c7fc695
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-53ba40c7-e786-43bb-8c30-686818aafad1
+      - req-3f38d525-6ef3-478c-8847-199d7133ccf6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-53ba40c7-e786-43bb-8c30-686818aafad1
+      - req-3f38d525-6ef3-478c-8847-199d7133ccf6
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -15713,27 +15785,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1de7475ec2bb4ee09d2ca802cb1a8808
+      - e7ce235ebbbd4c9ebd4b64506c7fc695
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1b8b0eb-9441-43cf-a2f8-4937911c8d21
+      - req-e3a12f52-fc08-4bb2-9ef6-cc96b5734830
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a1b8b0eb-9441-43cf-a2f8-4937911c8d21
+      - req-e3a12f52-fc08-4bb2-9ef6-cc96b5734830
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -15748,27 +15820,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23213755bd8b4269bb97f7c8a910c017
+      - bee62159353d40de9be7e689b8d67766
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c8f1623e-25c8-4852-9277-f509aace3ab8
+      - req-f1af9c32-ad63-476a-bcb7-68b9451a4627
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c8f1623e-25c8-4852-9277-f509aace3ab8
+      - req-f1af9c32-ad63-476a-bcb7-68b9451a4627
       Date:
-      - Mon, 09 Apr 2018 16:30:57 GMT
+      - Thu, 19 Apr 2018 17:40:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -15783,27 +15855,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23213755bd8b4269bb97f7c8a910c017
+      - bee62159353d40de9be7e689b8d67766
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-36635aed-2969-49eb-beb9-6bdfbb7a9371
+      - req-9ba6f4bc-dc90-41ab-93d3-abe8d0c3f4d6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-36635aed-2969-49eb-beb9-6bdfbb7a9371
+      - req-9ba6f4bc-dc90-41ab-93d3-abe8d0c3f4d6
       Date:
-      - Mon, 09 Apr 2018 16:30:58 GMT
+      - Thu, 19 Apr 2018 17:40:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15821,15 +15893,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:58 GMT
+      - Thu, 19 Apr 2018 17:40:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a6ba2b10c8d54b1b8ee50d19d067e5fc
+      - 9bc327621243410084d92f0533e9d4d2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-efbb1f71-9372-45c7-990c-be3c0b71da45
+      - req-b559ad1e-1373-4c25-a6b5-51922cbf9e43
       Content-Length:
       - '7311'
       Connection:
@@ -15841,7 +15913,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:58.446510Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:55.491569Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15920,10 +15992,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JgCrv6eNRtuVBV4MelF2-A"],
-        "issued_at": "2018-04-09T16:30:58.446586Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hWW-XUCeRq2ReA7pMiXdmQ"],
+        "issued_at": "2018-04-19T17:40:55.491629Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15941,15 +16013,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:58 GMT
+      - Thu, 19 Apr 2018 17:40:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d18960a49b884884897c883cdfca1589
+      - ce5a6fa380bc49178c8e38d79f4e4c93
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8c9c6b86-c66c-4abb-8f7d-3cddecf2aae7
+      - req-7c930bf5-305d-4fc3-a2c4-d6c472a2107f
       Content-Length:
       - '7311'
       Connection:
@@ -15961,7 +16033,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:30:58.682786Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:40:55.817382Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16040,10 +16112,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ghoH-W2iTySGMro_iOYxFA"],
-        "issued_at": "2018-04-09T16:30:58.682827Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a3VfkbqWRQusjvtJ0zplOg"],
+        "issued_at": "2018-04-19T17:40:55.817448Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16061,15 +16133,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:58 GMT
+      - Thu, 19 Apr 2018 17:40:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cc6f0371ff014edfa6e24c8582be34e4
+      - 2de21bd89c6e4aa4ab21ddd1cbb57169
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2c9b4254-d09b-4704-ba98-46434872310d
+      - req-12cd0ae1-629d-42ed-bd9a-b2798da75d61
       Content-Length:
       - '297'
       Connection:
@@ -16078,12 +16150,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:30:58.848776Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:40:56.027018Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LKD5JakjT16Ng4ftACwc_A"],
-        "issued_at": "2018-04-09T16:30:58.848811Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r6IUXuueQl-FgIf0z_wvDQ"],
+        "issued_at": "2018-04-19T17:40:56.027077Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:56 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -16098,20 +16170,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc6f0371ff014edfa6e24c8582be34e4
+      - 2de21bd89c6e4aa4ab21ddd1cbb57169
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:58 GMT
+      - Thu, 19 Apr 2018 17:40:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4538fcfd-666e-4f29-921e-5b87bfbf05a5
+      - req-d9fe9dea-5264-4d60-af69-e28787a56c9d
       Content-Length:
       - '2457'
       Connection:
@@ -16144,13 +16216,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"cc6f0371ff014edfa6e24c8582be34e4"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"2de21bd89c6e4aa4ab21ddd1cbb57169"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16162,15 +16234,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:59 GMT
+      - Thu, 19 Apr 2018 17:40:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dadd298d2da4420ca64ee3475346776d
+      - ebfaefc2183444a8b41f63e923c0ece6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f9eb184-17da-438f-adbb-0792b3380567
+      - req-d3381b7c-bfe6-4c76-84f4-ed0fa8de5be2
       Content-Length:
       - '7313'
       Connection:
@@ -16182,7 +16254,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:58.848776Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:56.027018Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16261,10 +16333,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L-BZZKN_T0aLKQYeC7DKfg",
-        "LKD5JakjT16Ng4ftACwc_A"], "issued_at": "2018-04-09T16:30:59.184641Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KGXJnbyvTH-TsHNMG6IxAw",
+        "r6IUXuueQl-FgIf0z_wvDQ"], "issued_at": "2018-04-19T17:40:56.549608Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -16279,20 +16351,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dadd298d2da4420ca64ee3475346776d
+      - ebfaefc2183444a8b41f63e923c0ece6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:59 GMT
+      - Thu, 19 Apr 2018 17:40:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a6e7379-7252-4220-8910-00534e410294
+      - req-39da2a93-981c-474b-a9fe-0ed46e3f9d2d
       Content-Length:
       - '2179'
       Connection:
@@ -16325,7 +16397,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16343,15 +16415,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:59 GMT
+      - Thu, 19 Apr 2018 17:40:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 91654d0e3d5a41e5ac204de6275cb7b5
+      - 199e6c568be24a5d921d7a066264a936
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35c87a2b-491a-4f5d-9526-6713ae1b9c0e
+      - req-cd79a9f7-b760-4f9a-ac86-78eecc684dfc
       Content-Length:
       - '7278'
       Connection:
@@ -16363,7 +16435,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:59.517067Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:57.011557Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16442,10 +16514,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PDjuP2YtQVi4S8c0YbgG3w"],
-        "issued_at": "2018-04-09T16:30:59.517123Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qQVNUCTbQySYbS-VHZFpVw"],
+        "issued_at": "2018-04-19T17:40:57.011619Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16463,15 +16535,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:59 GMT
+      - Thu, 19 Apr 2018 17:40:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 72d098dbebbc409ea6f0b2520e691f44
+      - 3a957c47b0c9456e857ec62632929f10
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-768ad67c-f2b5-4ea5-ab6b-c1e21e14c96e
+      - req-bcc12b8f-a05d-4d3d-a0c3-c0185e048459
       Content-Length:
       - '7278'
       Connection:
@@ -16483,7 +16555,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:59.732024Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:57.335121Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16562,10 +16634,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zanNjqZHQs2dRG_3bTzHDg"],
-        "issued_at": "2018-04-09T16:30:59.732063Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pDSziiK7TnqDFXzI_H_e1g"],
+        "issued_at": "2018-04-19T17:40:57.335205Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:30:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16583,15 +16655,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:30:59 GMT
+      - Thu, 19 Apr 2018 17:40:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be11b97823fa4292bd941078b2b294ce
+      - a068cd236c254f18954beb7db30a39ac
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d301637-f32c-40fc-9aa3-1c308565cd83
+      - req-ca837665-9e3b-489c-8160-46eb5d1be308
       Content-Length:
       - '7264'
       Connection:
@@ -16603,7 +16675,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:30:59.973933Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:57.676646Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16682,10 +16754,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ahLWSLvvRbauBKsGQyQlWQ"],
-        "issued_at": "2018-04-09T16:30:59.973966Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vJWlc2GpSfCYyu7p6Gkxkw"],
+        "issued_at": "2018-04-19T17:40:57.676745Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16703,15 +16775,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:00 GMT
+      - Thu, 19 Apr 2018 17:40:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 74b94fa0ebd84fd19820953e337c703a
+      - 8af56d25ca0f444f8678f8d83f9c98b2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fab37af3-bed8-4bf8-909b-7d6067b9be9f
+      - req-9c71df8f-093d-45d7-8220-367b27732b67
       Content-Length:
       - '7278'
       Connection:
@@ -16723,7 +16795,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:00.303981Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:57.992639Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16802,10 +16874,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X4YHGr8ZQNag3Af_oYOtwg"],
-        "issued_at": "2018-04-09T16:31:00.304047Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QBxVhW3wRiK_zsUM4qAoOQ"],
+        "issued_at": "2018-04-19T17:40:57.992704Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16823,15 +16895,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:00 GMT
+      - Thu, 19 Apr 2018 17:40:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9fdf4b48dadb440b9a009396ea3a06b9
+      - 61457fe996b642eb950984641120f47b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22845b1a-81d7-4a42-86ee-c01cb38c0934
+      - req-694c1482-024c-49b8-b3a6-920bd883f0a7
       Content-Length:
       - '7265'
       Connection:
@@ -16843,7 +16915,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:00.622421Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:58.357359Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16922,10 +16994,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gjb3Cr6fRJONafz330M8hw"],
-        "issued_at": "2018-04-09T16:31:00.622480Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RBPSEgNNQByaCVERI8N0rg"],
+        "issued_at": "2018-04-19T17:40:58.357429Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16943,15 +17015,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:00 GMT
+      - Thu, 19 Apr 2018 17:40:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b45a99240a97482888474c2d815c48c4
+      - 38913a98aabf43a0a82d0718fedda2fa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f75e946f-8868-412e-8fd9-cd53d31b4862
+      - req-49ec04a8-d7b3-4095-9d9b-547ebca38658
       Content-Length:
       - '7278'
       Connection:
@@ -16963,7 +17035,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:00.942601Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:58.686884Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17042,10 +17114,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aGQ6JqfJTDuG8ZXJcw6Jdw"],
-        "issued_at": "2018-04-09T16:31:00.942662Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yz6sbW8_S5Wi7CoMrfkKCg"],
+        "issued_at": "2018-04-19T17:40:58.686953Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17063,15 +17135,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:01 GMT
+      - Thu, 19 Apr 2018 17:40:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f35a96660a0443c694ecf5aa9941ead3
+      - 24f9e670012d4dc280d329d60d3480d6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b8d8859d-3fa9-4ae9-a446-c1473b6520a5
+      - req-57432f54-76c3-4ed9-af67-78fbba0b52b4
       Content-Length:
       - '7278'
       Connection:
@@ -17083,7 +17155,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:01.337489Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:58.993080Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17162,10 +17234,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zAzhLcP-TAKBZoWWJy9nYA"],
-        "issued_at": "2018-04-09T16:31:01.337550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LraTNl9qQ22SD5p-PpAnMA"],
+        "issued_at": "2018-04-19T17:40:58.993141Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -17180,7 +17252,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f35a96660a0443c694ecf5aa9941ead3
+      - 24f9e670012d4dc280d329d60d3480d6
   response:
     status:
       code: 200
@@ -17193,22 +17265,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291461.53362'
+      - '1524159659.17090'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291461.53362'
+      - '1524159659.17090'
       X-Trans-Id:
-      - tx66dbd320b5524dd980118-005acb9545
+      - txb4976d5f81484194a8aa2-005ad8d4ab
       Date:
-      - Mon, 09 Apr 2018 16:31:01 GMT
+      - Thu, 19 Apr 2018 17:40:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17226,15 +17298,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:01 GMT
+      - Thu, 19 Apr 2018 17:40:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 48f011247efc4c82995b4fe88e09f459
+      - 81ca5c598f61457b90c4649a984f7862
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-82fd74f4-ad32-45a5-943f-b5d7cfaabf57
+      - req-eb27dea7-b459-4b87-b446-cc5d84508139
       Content-Length:
       - '7278'
       Connection:
@@ -17246,7 +17318,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:01.909727Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:59.475749Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17325,10 +17397,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XRZAyI7WQAO7HzZDSeTiAg"],
-        "issued_at": "2018-04-09T16:31:01.909847Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["me6zHEkVQuiG2MFr8iDOoA"],
+        "issued_at": "2018-04-19T17:40:59.475849Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -17343,7 +17415,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f011247efc4c82995b4fe88e09f459
+      - 81ca5c598f61457b90c4649a984f7862
   response:
     status:
       code: 200
@@ -17356,22 +17428,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291462.19198'
+      - '1524159659.66532'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291462.19198'
+      - '1524159659.66532'
       X-Trans-Id:
-      - tx6fd0e7edc0914ff79cd3e-005acb9546
+      - txf32a943d8db24aafb5f1b-005ad8d4ab
       Date:
-      - Mon, 09 Apr 2018 16:31:02 GMT
+      - Thu, 19 Apr 2018 17:40:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:40:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17389,15 +17461,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:02 GMT
+      - Thu, 19 Apr 2018 17:40:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-97409d57-05d8-4191-b83b-af5530b2b29c
+      - req-b79e631f-c4a4-4504-aef4-4a4d989dba4e
       Content-Length:
       - '7264'
       Connection:
@@ -17409,7 +17481,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:02.591578Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:40:59.981379Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17488,10 +17560,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ouAfR4dESaeUyb8f4znoOA"],
-        "issued_at": "2018-04-09T16:31:02.591644Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gtof1VhaSfCLnaO30K-INA"],
+        "issued_at": "2018-04-19T17:40:59.981463Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -17506,7 +17578,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
   response:
     status:
       code: 200
@@ -17535,15 +17607,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx84e04144ed3243538592d-005acb9546
+      - tx20b96251e9824c39b7b14-005ad8d4ac
       Date:
-      - Mon, 09 Apr 2018 16:31:02 GMT
+      - Thu, 19 Apr 2018 17:41:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -17558,7 +17630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
   response:
     status:
       code: 200
@@ -17587,14 +17659,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx6cebe296581f427db1718-005acb9546
+      - tx3a4c5c227ed544e29884b-005ad8d4ac
       Date:
-      - Mon, 09 Apr 2018 16:31:02 GMT
+      - Thu, 19 Apr 2018 17:41:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17612,15 +17684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:03 GMT
+      - Thu, 19 Apr 2018 17:41:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95b7d37424ee4f2c854f4c83317dce44
+      - 29227bb27f044eccb935692bdadb6121
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ffff09b-1394-42b2-b36e-be8676eb2d52
+      - req-6a1cd558-890d-4f1a-9f06-abe2bca63051
       Content-Length:
       - '7278'
       Connection:
@@ -17632,7 +17704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:03.235550Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:41:00.790183Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17711,10 +17783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z7PnpeZcRBWA3Wqz59BLQA"],
-        "issued_at": "2018-04-09T16:31:03.235621Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YxyIpRKwQzmwCrdVo3wOJg"],
+        "issued_at": "2018-04-19T17:41:00.790253Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -17729,7 +17801,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95b7d37424ee4f2c854f4c83317dce44
+      - 29227bb27f044eccb935692bdadb6121
   response:
     status:
       code: 200
@@ -17742,22 +17814,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291463.44334'
+      - '1524159660.97963'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291463.44334'
+      - '1524159660.97963'
       X-Trans-Id:
-      - txb470d7e7fdae44b3b0559-005acb9547
+      - tx7f1f613e6959475db28be-005ad8d4ac
       Date:
-      - Mon, 09 Apr 2018 16:31:03 GMT
+      - Thu, 19 Apr 2018 17:41:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -17772,7 +17844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d18960a49b884884897c883cdfca1589
+      - ce5a6fa380bc49178c8e38d79f4e4c93
   response:
     status:
       code: 200
@@ -17785,22 +17857,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291463.61284'
+      - '1524159661.16499'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291463.61284'
+      - '1524159661.16499'
       X-Trans-Id:
-      - txf684c2f89de7444ebf1a0-005acb9547
+      - tx382fea811da342e5b9d17-005ad8d4ad
       Date:
-      - Mon, 09 Apr 2018 16:31:03 GMT
+      - Thu, 19 Apr 2018 17:41:01 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17818,15 +17890,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:03 GMT
+      - Thu, 19 Apr 2018 17:41:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 54af814224924c0289b5dd291e97b389
+      - 9ce319ed9ea54e8187c71d0b7631a968
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c33817df-9cc0-44c0-b078-618c2493e403
+      - req-c82e3b40-d8a0-45b9-a1e8-22cb67d7b877
       Content-Length:
       - '7265'
       Connection:
@@ -17838,7 +17910,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:03.949485Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:41:01.616210Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17917,10 +17989,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IMQQdkTAQ7WHEd3yy8cR_Q"],
-        "issued_at": "2018-04-09T16:31:03.949554Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wCjZOS66T22uTRPnN40KCQ"],
+        "issued_at": "2018-04-19T17:41:01.616295Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -17935,7 +18007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 54af814224924c0289b5dd291e97b389
+      - 9ce319ed9ea54e8187c71d0b7631a968
   response:
     status:
       code: 200
@@ -17948,22 +18020,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291464.17844'
+      - '1524159661.88465'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291464.17844'
+      - '1524159661.88465'
       X-Trans-Id:
-      - tx5ecf00f1380f42f998b0b-005acb9548
+      - tx79e12940dd284c82aa458-005ad8d4ad
       Date:
-      - Mon, 09 Apr 2018 16:31:04 GMT
+      - Thu, 19 Apr 2018 17:41:01 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17981,15 +18053,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:31:04 GMT
+      - Thu, 19 Apr 2018 17:41:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc462756ce654f89a320ca4aaaf88dff
+      - 06bbb671c5b24511be4598d455255a78
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5583b55d-964b-4c35-b7f8-8c2edd4f7fe2
+      - req-99a31046-f343-4e51-b80f-4200a2d58a15
       Content-Length:
       - '7278'
       Connection:
@@ -18001,7 +18073,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:31:04.511364Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:41:02.235474Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18080,10 +18152,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lswrnkZ8RTeaT0tq7v-lkg"],
-        "issued_at": "2018-04-09T16:31:04.511429Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OwUO0dKjRVaHFWpJxgLCnQ"],
+        "issued_at": "2018-04-19T17:41:02.235543Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -18098,7 +18170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc462756ce654f89a320ca4aaaf88dff
+      - 06bbb671c5b24511be4598d455255a78
   response:
     status:
       code: 200
@@ -18111,22 +18183,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291464.70575'
+      - '1524159662.50235'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291464.70575'
+      - '1524159662.50235'
       X-Trans-Id:
-      - tx4c513c87d81641f087e48-005acb9548
+      - tx8492e0f462c146569502b-005ad8d4ae
       Date:
-      - Mon, 09 Apr 2018 16:31:04 GMT
+      - Thu, 19 Apr 2018 17:41:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -18141,7 +18213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
   response:
     status:
       code: 200
@@ -18162,9 +18234,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx772aa79096dc4baaa4bf8-005acb9548
+      - tx6a9b7b628247419798af1-005ad8d4ae
       Date:
-      - Mon, 09 Apr 2018 16:31:04 GMT
+      - Thu, 19 Apr 2018 17:41:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -18174,7 +18246,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -18189,7 +18261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
   response:
     status:
       code: 200
@@ -18210,14 +18282,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx6b593e6af31d47f9b4c96-005acb9548
+      - tx0570d80f16d64bb99c04e-005ad8d4ae
       Date:
-      - Mon, 09 Apr 2018 16:31:04 GMT
+      - Thu, 19 Apr 2018 17:41:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -18232,7 +18304,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8524ea1d49de4be5b07f7909cf3701ee
+      - 7b857f1b130c43708bf0bb38961e7861
   response:
     status:
       code: 200
@@ -18253,12 +18325,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx4aab134893de46df9eb3b-005acb9549
+      - txc33d39f642e14110b9be5-005ad8d4ae
       Date:
-      - Mon, 09 Apr 2018 16:31:05 GMT
+      - Thu, 19 Apr 2018 17:41:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:31:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:56 GMT
+      - Thu, 19 Apr 2018 17:36:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d5e90e25-89ca-4dcd-b4fa-6b69ecf3a7cd
+      - req-50805282-0634-4b53-8c52-9952baf732cd
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:56.170981Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:39.264433Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-BYrn1L-TwCPsIoyc-E32g"],
-        "issued_at": "2018-04-09T16:26:56.171020Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AEZTR-_sQAG1IOaaa6rXfA"],
+        "issued_at": "2018-04-19T17:36:39.264504Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:26:56 GMT
+      - Thu, 19 Apr 2018 17:36:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:56 GMT
+      - Thu, 19 Apr 2018 17:36:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c95e8db2256d407a861079d1fcb1027e
+      - 597bd0e3bb7a4529ab01a1b7e2fb9ea0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6619a2ed-299f-4caf-ab6a-7f56a00d3f3e
+      - req-1cc3219f-bff9-4f4e-af25-59a10a8a0b38
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:56.694439Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:39.945998Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p5XxHf4vRAaAhBe4s0nQvA"],
-        "issued_at": "2018-04-09T16:26:56.694492Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gVhhkc8oRcCx5ZCg8V-zkQ"],
+        "issued_at": "2018-04-19T17:36:39.946071Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -289,7 +289,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c95e8db2256d407a861079d1fcb1027e
+      - 597bd0e3bb7a4529ab01a1b7e2fb9ea0
   response:
     status:
       code: 200
@@ -300,13 +300,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:26:56 GMT
+      - Thu, 19 Apr 2018 17:36:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -324,15 +324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:56 GMT
+      - Thu, 19 Apr 2018 17:36:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bd4cf5cad4f24065bc06efd19181c0b3
+      - 94452b630ea84de8bc9aedb012092449
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b54c61f3-5527-4921-bda8-ec461ec232e8
+      - req-5d8dd0e0-7804-46b4-86ae-12431ce210e4
       Content-Length:
       - '7311'
       Connection:
@@ -344,7 +344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:57.009472Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:40.385680Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -423,16 +423,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZQQd1nxXSB6UDluDltnBpw"],
-        "issued_at": "2018-04-09T16:26:57.009512Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UTyidMSQQq2t6O9_ByTZVA"],
+        "issued_at": "2018-04-19T17:36:40.385750Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"bd4cf5cad4f24065bc06efd19181c0b3"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"94452b630ea84de8bc9aedb012092449"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -444,15 +444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:57 GMT
+      - Thu, 19 Apr 2018 17:36:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95c07d3aefd5408b975dd8d7182c703e
+      - 12453e25212b41a5968483007468baf6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-daeee43f-41e1-4584-ac64-f62e2d0c65e1
+      - req-977d99f9-ca8d-45c7-9bec-3bb7b141eb17
       Content-Length:
       - '7346'
       Connection:
@@ -464,7 +464,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:57.009472Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:40.385680Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -543,10 +543,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["csy8GHKdRpKf7u-fAFHHhg",
-        "ZQQd1nxXSB6UDluDltnBpw"], "issued_at": "2018-04-09T16:26:57.227978Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RkzKwbFcQaOhNw6eNJ5F2Q",
+        "UTyidMSQQq2t6O9_ByTZVA"], "issued_at": "2018-04-19T17:36:40.695136Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -564,15 +564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:57 GMT
+      - Thu, 19 Apr 2018 17:36:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7cff7d5d-d236-40cc-84fe-9eea8b202dde
+      - req-0918a6a4-fbf1-4390-99d4-6a6b2ef05ba5
       Content-Length:
       - '7311'
       Connection:
@@ -584,7 +584,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:57.525018Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:41.037410Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -663,10 +663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rcnMXX-XRb27nhatRf8H6Q"],
-        "issued_at": "2018-04-09T16:26:57.525066Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H8stgJFASx-Pdtme4v6ZPQ"],
+        "issued_at": "2018-04-19T17:36:41.037472Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -681,7 +681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 300
@@ -692,7 +692,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:26:57 GMT
+      - Thu, 19 Apr 2018 17:36:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -705,7 +705,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -723,15 +723,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:57 GMT
+      - Thu, 19 Apr 2018 17:36:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fe321541871b490c9eba2bece8c4b850
+      - 78125588ef3a4985be10e2edef1e89c2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f26538ed-b29d-43de-a9f0-fdf7505f4638
+      - req-35e20a1f-2928-4c1d-9099-a5a569d27f30
       Content-Length:
       - '7311'
       Connection:
@@ -743,7 +743,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:57.957401Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:41.564858Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -822,10 +822,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["drKkNolvTO-iWJpU4veLBg"],
-        "issued_at": "2018-04-09T16:26:57.957438Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xaP7kbE1SFKWdjy1jSZ6LQ"],
+        "issued_at": "2018-04-19T17:36:41.564935Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -843,15 +843,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:58 GMT
+      - Thu, 19 Apr 2018 17:36:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 249f8c949caf48af9e9c7bca994d065d
+      - 6de24a4df5f24ccbbdc1e3c1dc7ae6ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-edbf8b7e-a915-423f-b120-74e26829a989
+      - req-6d0880b0-b538-4b71-b2f7-34dcf125d3ab
       Content-Length:
       - '7311'
       Connection:
@@ -863,7 +863,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:58.211630Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:41.908850Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -942,10 +942,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q2I-9k5-SpSqpVQegmFJrw"],
-        "issued_at": "2018-04-09T16:26:58.211668Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r7wkuL0AQFqm3o2wOkOO4A"],
+        "issued_at": "2018-04-19T17:36:41.908920Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -963,15 +963,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:58 GMT
+      - Thu, 19 Apr 2018 17:36:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4dba6c6a1f2e4f9d8ac16b374912e719
+      - 471495900eda4d9194600f2de3f2aacb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f710e8d4-8fff-45f6-9d92-314937061633
+      - req-deda957d-1b70-498f-ba81-8541af2ebf8a
       Content-Length:
       - '7311'
       Connection:
@@ -983,7 +983,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:58.587827Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:42.581554Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1062,10 +1062,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2DnOUb6cQByODVY58zf1nw"],
-        "issued_at": "2018-04-09T16:26:58.587865Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EzTF-5JHTdamiGKcMrEABg"],
+        "issued_at": "2018-04-19T17:36:42.581620Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1083,15 +1083,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:58 GMT
+      - Thu, 19 Apr 2018 17:36:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c945e4e67d36411480ecadc3c05d16bd
+      - 8addf2d0ca544b2ea2df4ef191c28234
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c6e6a8d6-b783-4d17-94a5-eb4c8030d750
+      - req-f6265056-741e-42ab-a24f-b96cb1cd7865
       Content-Length:
       - '7311'
       Connection:
@@ -1103,7 +1103,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:26:58.867808Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:36:43.101736Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1182,10 +1182,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OBgth_0ETZyTAPP4MQr9Sg"],
-        "issued_at": "2018-04-09T16:26:58.867846Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oLbL6mkPRf-XdmdRzOQCkg"],
+        "issued_at": "2018-04-19T17:36:43.101827Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1203,15 +1203,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:58 GMT
+      - Thu, 19 Apr 2018 17:36:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '0396f66d884240d6b33df1a67f96095a'
+      - bd75ff87f8ab4bde83a5ab909598a53e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e58ef997-0a54-4562-a20f-856888f704bd
+      - req-684baab7-d567-4ea3-a9fd-caf7553996e4
       Content-Length:
       - '297'
       Connection:
@@ -1220,12 +1220,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:26:59.049233Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:36:43.313162Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3PDcVtXSQyCCQ2paFBDObw"],
-        "issued_at": "2018-04-09T16:26:59.049263Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FP1TuaGjQxCf30zzzEtNtQ"],
+        "issued_at": "2018-04-19T17:36:43.313221Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1240,20 +1240,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0396f66d884240d6b33df1a67f96095a'
+      - bd75ff87f8ab4bde83a5ab909598a53e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b9fc2a9-583e-4ddd-997a-b2d0b1a91ecf
+      - req-646f75a2-8976-4463-a667-6d53f913426e
       Content-Length:
       - '2457'
       Connection:
@@ -1286,13 +1286,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"0396f66d884240d6b33df1a67f96095a"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"bd75ff87f8ab4bde83a5ab909598a53e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1304,15 +1304,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4a2cc68f2d2944098c32169d1c0a5da9
+      - 5801e4521c814d81a07117384bc9111b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-32f0de29-bd5b-44c9-af34-2151d7a0943a
+      - req-257cd8ab-7d9f-4538-ba8f-3dd4572280c1
       Content-Length:
       - '7313'
       Connection:
@@ -1324,7 +1324,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:26:59.049233Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:43.313162Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1403,10 +1403,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zgYE1UmdT-O-ksmnR6j1jw",
-        "3PDcVtXSQyCCQ2paFBDObw"], "issued_at": "2018-04-09T16:26:59.387438Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qu9101RYTh6wWJHUzV1lnw",
+        "FP1TuaGjQxCf30zzzEtNtQ"], "issued_at": "2018-04-19T17:36:43.734069Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1421,20 +1421,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a2cc68f2d2944098c32169d1c0a5da9
+      - 5801e4521c814d81a07117384bc9111b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-21bd2916-db3c-4bcf-84f5-0d75b8f73759
+      - req-e9c44f5a-f24c-4775-8dc4-c235f2de38e4
       Content-Length:
       - '2179'
       Connection:
@@ -1467,7 +1467,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1485,15 +1485,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98d2498d37bb46c499c2672e1d3df668
+      - c90411c25d4643908edcd610d31c89a9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-de074e30-be67-428a-8642-0e98d356f284
+      - req-df268e45-98b2-4445-b566-5893e8343671
       Content-Length:
       - '7278'
       Connection:
@@ -1505,7 +1505,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:26:59.744283Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:44.196935Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1584,10 +1584,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VGTjXkyHTo6nxkRIxwHRyQ"],
-        "issued_at": "2018-04-09T16:26:59.744323Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u8ZtSV7gRFK28XFRF7aImg"],
+        "issued_at": "2018-04-19T17:36:44.197007Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1602,7 +1602,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d2498d37bb46c499c2672e1d3df668
+      - c90411c25d4643908edcd610d31c89a9
   response:
     status:
       code: 200
@@ -1613,7 +1613,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1622,7 +1622,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:26:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1640,15 +1640,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:26:59 GMT
+      - Thu, 19 Apr 2018 17:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4be7f06ebc5b4ee48e2a8ca6b7fe78b1
+      - 3227fb93ef0b49d29461cb23a6eef39d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-15872b23-a6be-4f12-9989-0e7371a29786
+      - req-418d5639-ca82-43d4-bac3-fce3f8e63403
       Content-Length:
       - '7278'
       Connection:
@@ -1660,7 +1660,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:00.036061Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:44.589047Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1739,10 +1739,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rNquF5vkTbGOJ9yLpcUNXw"],
-        "issued_at": "2018-04-09T16:27:00.036098Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5tYuuOsiR3q2hCMAUvpcaQ"],
+        "issued_at": "2018-04-19T17:36:44.589115Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1757,7 +1757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4be7f06ebc5b4ee48e2a8ca6b7fe78b1
+      - 3227fb93ef0b49d29461cb23a6eef39d
   response:
     status:
       code: 200
@@ -1768,7 +1768,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1777,7 +1777,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1795,15 +1795,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e8733e1a3374c7a9a6502162923227c
+      - 54fd8180eb9a4f6395fb493d391ce62b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6481d978-658c-490d-abfb-451bd21bd885
+      - req-791d9f6c-51b8-4b9a-879c-ba727ead251a
       Content-Length:
       - '7264'
       Connection:
@@ -1815,7 +1815,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:00.356023Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:45.000039Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1894,10 +1894,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1rqs0YLERlWYRucvakEk9w"],
-        "issued_at": "2018-04-09T16:27:00.356089Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FIC0e7HZTbu2hH2Rqu6m5g"],
+        "issued_at": "2018-04-19T17:36:45.000108Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1912,7 +1912,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e8733e1a3374c7a9a6502162923227c
+      - 54fd8180eb9a4f6395fb493d391ce62b
   response:
     status:
       code: 200
@@ -1923,7 +1923,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1932,7 +1932,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1950,15 +1950,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d6371bec9d1d46ba827cc39b62e0e1ac
+      - 86552a28b7494396999ef7aeb1796df8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9d729431-65db-4468-b08a-238a872ece34
+      - req-d42dfd7d-217e-4934-962d-457c2849269e
       Content-Length:
       - '7278'
       Connection:
@@ -1970,7 +1970,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:00.661946Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:45.361413Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2049,10 +2049,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jxnxQnr1RyyzxHz_HeMa5w"],
-        "issued_at": "2018-04-09T16:27:00.662017Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["29yQPlZMSWyzZi61U4VJlQ"],
+        "issued_at": "2018-04-19T17:36:45.361511Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2067,7 +2067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6371bec9d1d46ba827cc39b62e0e1ac
+      - 86552a28b7494396999ef7aeb1796df8
   response:
     status:
       code: 200
@@ -2078,7 +2078,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2087,7 +2087,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2105,15 +2105,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:00 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 574d8a351aef43cf96c34c75ad2f0441
+      - 4a385a44b80b40069b1edba5c6c5bee3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dcc2197d-4482-47cf-8cc0-06bb7beccaca
+      - req-91528da3-89ff-4a85-8063-f6b2be75a2ad
       Content-Length:
       - '7265'
       Connection:
@@ -2125,7 +2125,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:00.984012Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:45.757408Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2204,10 +2204,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6DoiztjhRFmlazWULhAh2w"],
-        "issued_at": "2018-04-09T16:27:00.984053Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FlUyigL2R3y5Ee-1ClZyHA"],
+        "issued_at": "2018-04-19T17:36:45.757482Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2222,7 +2222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 574d8a351aef43cf96c34c75ad2f0441
+      - 4a385a44b80b40069b1edba5c6c5bee3
   response:
     status:
       code: 200
@@ -2233,7 +2233,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2242,7 +2242,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2260,15 +2260,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d268ef867be94018a0425abdbe340f67
+      - 45be0bf29dcd4ac7ba4d13c3266318ac
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7416a27f-9d43-49b7-bde4-45953b874d7c
+      - req-6e2108c8-a01d-401c-ba99-db12e1192e86
       Content-Length:
       - '7278'
       Connection:
@@ -2280,7 +2280,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:01.311736Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:46.145124Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2359,10 +2359,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PMTiYSMBRdml2BaiFgjfng"],
-        "issued_at": "2018-04-09T16:27:01.311787Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YVP5JqOvTx2tD4plpdhRVQ"],
+        "issued_at": "2018-04-19T17:36:46.145193Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2377,7 +2377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d268ef867be94018a0425abdbe340f67
+      - 45be0bf29dcd4ac7ba4d13c3266318ac
   response:
     status:
       code: 200
@@ -2388,7 +2388,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2397,7 +2397,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2412,7 +2412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2425,9 +2425,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-2b196e78-2bf1-4d97-ae1f-b91dd4fd830e
+      - req-31a846c6-fd35-43d4-bde7-22fad4586686
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2441,7 +2441,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2456,7 +2456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2469,9 +2469,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-991941fb-4a88-4a8b-a440-3294e3a9b443
+      - req-524a4b39-99d7-4e3e-b785-b6aa77e39555
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2485,7 +2485,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2500,7 +2500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2513,9 +2513,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-7296de95-e00e-4f44-9331-8a74b67c0fe2
+      - req-1a8e5f91-3d00-4d90-9c5f-a031904b11ce
       Date:
-      - Mon, 09 Apr 2018 16:27:01 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2530,7 +2530,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2545,7 +2545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2558,9 +2558,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-b2285f13-0a50-42ed-a2bb-18e7328e1248
+      - req-6a1489c2-d3a8-4fe4-9d8c-a5ff9d38da49
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2570,7 +2570,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2585,7 +2585,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2598,15 +2598,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-2929aca4-c700-4067-88fa-a55bd49b832e
+      - req-a504bf02-2a23-48be-a95c-f3c439296d1a
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2634,15 +2634,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-7a49d655-479e-4f2e-b48e-446dfbd241db
+      - req-927bf5c2-a577-4e01-899b-115067eb9430
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -2657,28 +2657,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe321541871b490c9eba2bece8c4b850
+      - 78125588ef3a4985be10e2edef1e89c2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52cf5151-b9b0-42f4-a2ad-4bdeb9f608b8
+      - req-cbf04878-1053-4205-bd8f-d3d244e9e439
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-52cf5151-b9b0-42f4-a2ad-4bdeb9f608b8
+      - req-cbf04878-1053-4205-bd8f-d3d244e9e439
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -2693,7 +2693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2706,14 +2706,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-f8358016-5ddb-4ea7-81cc-3e33c0932b31
+      - req-e59c4ba0-75b5-4939-9aaa-7ed4ddc45d11
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2728,7 +2728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d2498d37bb46c499c2672e1d3df668
+      - c90411c25d4643908edcd610d31c89a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2741,9 +2741,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8920e1ed-abae-43fa-88e1-b30ac4497fcb
+      - req-b1a808b8-41a9-4de2-bd62-31e9215969b8
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2752,7 +2752,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2767,7 +2767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4be7f06ebc5b4ee48e2a8ca6b7fe78b1
+      - 3227fb93ef0b49d29461cb23a6eef39d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2780,9 +2780,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c9eda8ef-e480-4349-9ffd-eff1270c11e5
+      - req-fc6075a8-3d94-4da9-8d33-7a6e39b01410
       Date:
-      - Mon, 09 Apr 2018 16:27:02 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2791,7 +2791,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2806,7 +2806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e8733e1a3374c7a9a6502162923227c
+      - 54fd8180eb9a4f6395fb493d391ce62b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2819,9 +2819,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d9cd3aa0-a086-446e-918a-ff278cbf4785
+      - req-c811bb24-d1a2-4134-bd86-829efcb5e2db
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2830,7 +2830,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2845,7 +2845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6371bec9d1d46ba827cc39b62e0e1ac
+      - 86552a28b7494396999ef7aeb1796df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2858,9 +2858,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7248bbe3-4d79-47ea-be18-cbd9ab67a514
+      - req-5393ab5f-dabe-4435-b543-7e40898e3e8c
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2869,7 +2869,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2897,9 +2897,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-192370cb-1546-4c88-875b-da551a23ff19
+      - req-6f386e5c-c03f-4e0e-954b-ec3b319508e3
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2908,7 +2908,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2923,7 +2923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 574d8a351aef43cf96c34c75ad2f0441
+      - 4a385a44b80b40069b1edba5c6c5bee3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2936,9 +2936,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f6b106f0-8860-490a-93b2-f107ca02c74e
+      - req-4d39cf19-e48d-4340-8244-974357952fbf
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2947,7 +2947,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2962,7 +2962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d268ef867be94018a0425abdbe340f67
+      - 45be0bf29dcd4ac7ba4d13c3266318ac
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2975,9 +2975,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-47e57c6b-3254-477b-a382-894a007672e1
+      - req-8f44fb98-d851-4034-b1d6-3e3415e2637e
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2986,7 +2986,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3004,15 +3004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:03 GMT
+      - Thu, 19 Apr 2018 17:36:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dd0ffb392030463aab6058f0c660b4f0
+      - 9ae01e3074f746079e687cfed577978b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-77172d72-58b4-4647-a33c-3e50a1b94de5
+      - req-2dac404d-9eeb-46ba-9dfc-954214b335bf
       Content-Length:
       - '7278'
       Connection:
@@ -3024,7 +3024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:04.196662Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:49.443502Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3103,10 +3103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZyUlDeXdTvypCZFg6GBcWg"],
-        "issued_at": "2018-04-09T16:27:04.196731Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F9ua1UNzThOU8EVnKfDfcQ"],
+        "issued_at": "2018-04-19T17:36:49.443567Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3121,22 +3121,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd0ffb392030463aab6058f0c660b4f0
+      - 9ae01e3074f746079e687cfed577978b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe8b0baf-846c-43bc-9b2b-986610895e56
+      - req-6491cb27-9abd-4ccb-a269-29cdc6ab6773
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-fe8b0baf-846c-43bc-9b2b-986610895e56
+      - req-6491cb27-9abd-4ccb-a269-29cdc6ab6773
       Date:
-      - Mon, 09 Apr 2018 16:27:04 GMT
+      - Thu, 19 Apr 2018 17:36:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3146,7 +3146,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3164,15 +3164,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:05 GMT
+      - Thu, 19 Apr 2018 17:36:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be30d5d4f08d4ab1b601e87c7acde742
+      - 95a2d5127e494a7cacf2110dfbbf57a3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-65c9e794-2ad5-49fe-a78a-746086c2df09
+      - req-a1ced14a-77da-4fa2-9f9a-8f7fc74d4a0d
       Content-Length:
       - '7278'
       Connection:
@@ -3184,7 +3184,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:05.273945Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:50.605743Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3263,10 +3263,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cCOIm6rBQb6Oweal-7CsJg"],
-        "issued_at": "2018-04-09T16:27:05.274014Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MNC0VN_2RUiDg03RaeQZ5w"],
+        "issued_at": "2018-04-19T17:36:50.605837Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3281,22 +3281,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be30d5d4f08d4ab1b601e87c7acde742
+      - 95a2d5127e494a7cacf2110dfbbf57a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b689ad2e-5dd2-4fe3-b463-4b565a999ad4
+      - req-ffe0be41-165f-4a55-86ad-d845f44329c0
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b689ad2e-5dd2-4fe3-b463-4b565a999ad4
+      - req-ffe0be41-165f-4a55-86ad-d845f44329c0
       Date:
-      - Mon, 09 Apr 2018 16:27:06 GMT
+      - Thu, 19 Apr 2018 17:36:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3306,7 +3306,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3324,15 +3324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:06 GMT
+      - Thu, 19 Apr 2018 17:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 29866eac7af7470c99215e9f6700e4f2
+      - 263384e8c49e489e9a4b46b6b759bf12
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-48bbe1d8-686c-4817-ac00-5c60d8573d13
+      - req-81c9f982-7f00-4b3e-8328-954e1f0b9744
       Content-Length:
       - '7264'
       Connection:
@@ -3344,7 +3344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:06.436477Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:51.468675Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3423,10 +3423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DL_PsP1GTsqKTOsMdjQooQ"],
-        "issued_at": "2018-04-09T16:27:06.436548Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kUomg-ljSTGHpKIz_1wN2A"],
+        "issued_at": "2018-04-19T17:36:51.468729Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3441,22 +3441,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 29866eac7af7470c99215e9f6700e4f2
+      - 263384e8c49e489e9a4b46b6b759bf12
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87ff211a-f435-424f-9227-3e70251abdeb
+      - req-cee890ea-63d2-483b-858c-e4f9e226a9f6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-87ff211a-f435-424f-9227-3e70251abdeb
+      - req-cee890ea-63d2-483b-858c-e4f9e226a9f6
       Date:
-      - Mon, 09 Apr 2018 16:27:07 GMT
+      - Thu, 19 Apr 2018 17:36:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3466,7 +3466,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3484,15 +3484,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:07 GMT
+      - Thu, 19 Apr 2018 17:36:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d676f60b637947e8bbbb1d4ba21b16f1
+      - 2e94da7b61e847b4a9ec4cda6da0aaf2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e673b83f-971c-4ff9-b5ff-86f24e7e2073
+      - req-5a5e6291-aceb-4593-9019-18d64665ab68
       Content-Length:
       - '7278'
       Connection:
@@ -3504,7 +3504,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:07.663355Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:52.366256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3583,10 +3583,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O2PxcTa6SRGKKbrXgEst8g"],
-        "issued_at": "2018-04-09T16:27:07.663424Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G993HdmrQMCL0g2w7287vQ"],
+        "issued_at": "2018-04-19T17:36:52.366342Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3601,22 +3601,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d676f60b637947e8bbbb1d4ba21b16f1
+      - 2e94da7b61e847b4a9ec4cda6da0aaf2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c41046d7-88f3-4162-9b0b-f5e62b918fd1
+      - req-010f5264-103c-4c0f-8f98-17178b0dff2f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c41046d7-88f3-4162-9b0b-f5e62b918fd1
+      - req-010f5264-103c-4c0f-8f98-17178b0dff2f
       Date:
-      - Mon, 09 Apr 2018 16:27:08 GMT
+      - Thu, 19 Apr 2018 17:36:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3626,7 +3626,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3641,22 +3641,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe321541871b490c9eba2bece8c4b850
+      - 78125588ef3a4985be10e2edef1e89c2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2a4e961e-c3d9-4a27-91e0-096e8db0cd6a
+      - req-d547d2b8-7f1d-44cc-b29f-e2d4075114c6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-2a4e961e-c3d9-4a27-91e0-096e8db0cd6a
+      - req-d547d2b8-7f1d-44cc-b29f-e2d4075114c6
       Date:
-      - Mon, 09 Apr 2018 16:27:09 GMT
+      - Thu, 19 Apr 2018 17:36:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3666,7 +3666,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3684,15 +3684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:09 GMT
+      - Thu, 19 Apr 2018 17:36:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 555fe882856b4f539fafb5f6b371aa9f
+      - cbe554c47cfb464aa1d7838b1e8a650d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-34ebf026-07dd-4271-89f5-6a34c892fad1
+      - req-f6624972-d821-44ca-9be5-07df5cb18680
       Content-Length:
       - '7265'
       Connection:
@@ -3704,7 +3704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:09.363050Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:53.893311Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3783,10 +3783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PqHtnx8pSAiBRTHRUbtOBw"],
-        "issued_at": "2018-04-09T16:27:09.363133Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pTikw8m8Tkah8k93a1tbkg"],
+        "issued_at": "2018-04-19T17:36:53.893402Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3801,22 +3801,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 555fe882856b4f539fafb5f6b371aa9f
+      - cbe554c47cfb464aa1d7838b1e8a650d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce02e38b-4683-4767-b03d-a4b27a56653f
+      - req-37b3eb04-2852-45f2-9712-0c9abba09120
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ce02e38b-4683-4767-b03d-a4b27a56653f
+      - req-37b3eb04-2852-45f2-9712-0c9abba09120
       Date:
-      - Mon, 09 Apr 2018 16:27:10 GMT
+      - Thu, 19 Apr 2018 17:36:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3826,7 +3826,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3844,15 +3844,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:10 GMT
+      - Thu, 19 Apr 2018 17:36:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7bbd88200d2844bc87f18a345e49bba0
+      - cbc12116c8f14eaebdbba410e0f4e931
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-74c1e392-b803-4f46-8943-bca1d5448ca2
+      - req-5a63219e-4858-4988-9ab2-d7af782df61f
       Content-Length:
       - '7278'
       Connection:
@@ -3864,7 +3864,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:10.559507Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:55.018330Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3943,10 +3943,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GSqr42ozS5CH4KxzjXv8sg"],
-        "issued_at": "2018-04-09T16:27:10.559566Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7T_Aq7FxRDO2MzYIZLBBeQ"],
+        "issued_at": "2018-04-19T17:36:55.018422Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3961,22 +3961,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bbd88200d2844bc87f18a345e49bba0
+      - cbc12116c8f14eaebdbba410e0f4e931
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19a4e8af-00fe-4868-8622-d437a63c3110
+      - req-3f60d4bf-f7d7-49e0-a2d6-0a02bb8f59b2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-19a4e8af-00fe-4868-8622-d437a63c3110
+      - req-3f60d4bf-f7d7-49e0-a2d6-0a02bb8f59b2
       Date:
-      - Mon, 09 Apr 2018 16:27:11 GMT
+      - Thu, 19 Apr 2018 17:36:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3986,7 +3986,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4004,15 +4004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:11 GMT
+      - Thu, 19 Apr 2018 17:36:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43da06a34bec478cad3fb953088115d3
+      - e773b6c8c84748c0a13407b452676590
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc535933-98c6-4559-b700-f88a6bdefedc
+      - req-09ef2196-7ca1-4a2e-b6b9-a3c8c0fc0fd2
       Content-Length:
       - '7278'
       Connection:
@@ -4024,7 +4024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:11.551645Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:55.879401Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4103,10 +4103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ry5mcr8BRImo9kwSIGb3cg"],
-        "issued_at": "2018-04-09T16:27:11.551716Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YK8jHBkFTauWEF1XBvjVxA"],
+        "issued_at": "2018-04-19T17:36:55.879463Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4121,7 +4121,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43da06a34bec478cad3fb953088115d3
+      - e773b6c8c84748c0a13407b452676590
   response:
     status:
       code: 200
@@ -4132,16 +4132,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9eab2764-05c5-4a6a-a9a0-99d56f299db9
+      - req-c39920b0-3b3c-49f4-b602-b55404feb2f3
       Date:
-      - Mon, 09 Apr 2018 16:27:11 GMT
+      - Thu, 19 Apr 2018 17:36:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4159,15 +4159,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:11 GMT
+      - Thu, 19 Apr 2018 17:36:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2901b489bfe04f208b79ee47a1f25b7f
+      - 99c5f2e8420a42ebbc9dc3685dd21831
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc10ec54-1687-4e95-8c5d-a254f90c0305
+      - req-c3fff88f-38a4-41e0-83ef-4bc1e0c80c7b
       Content-Length:
       - '7278'
       Connection:
@@ -4179,7 +4179,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:12.071780Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:56.368874Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4258,10 +4258,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1htRacnrSvaGs6-mevj0rQ"],
-        "issued_at": "2018-04-09T16:27:12.071837Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sfAZn5F8QHu_ksNpz4ef4A"],
+        "issued_at": "2018-04-19T17:36:56.368947Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4276,7 +4276,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2901b489bfe04f208b79ee47a1f25b7f
+      - 99c5f2e8420a42ebbc9dc3685dd21831
   response:
     status:
       code: 200
@@ -4287,16 +4287,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-48c93ac8-a75d-4007-8c1c-e8e0e1bbdaa4
+      - req-377b42e6-79a6-42a2-96a4-f3a325991af5
       Date:
-      - Mon, 09 Apr 2018 16:27:12 GMT
+      - Thu, 19 Apr 2018 17:36:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4314,15 +4314,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:12 GMT
+      - Thu, 19 Apr 2018 17:36:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b85437a625654ec39d1d04495ec77745
+      - 27edc5b0ce2542009d41eeadb75ed16b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4db9b641-5bab-4898-a7c4-6997dd0f39d1
+      - req-7c66e63f-29c2-44f8-a645-fd100811c5b3
       Content-Length:
       - '7264'
       Connection:
@@ -4334,7 +4334,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:12.402508Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:56.882212Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4413,10 +4413,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kXI3vQysRfWP6elhiZmGvA"],
-        "issued_at": "2018-04-09T16:27:12.402549Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["236LhB9aTxeaGU4KZ51Bzg"],
+        "issued_at": "2018-04-19T17:36:56.882283Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4431,7 +4431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85437a625654ec39d1d04495ec77745
+      - 27edc5b0ce2542009d41eeadb75ed16b
   response:
     status:
       code: 200
@@ -4442,16 +4442,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4b3df6ac-9663-4b88-ba0d-1a920efd1f9a
+      - req-0d034c7c-44dd-4055-935c-3b5f0ed0bb86
       Date:
-      - Mon, 09 Apr 2018 16:27:12 GMT
+      - Thu, 19 Apr 2018 17:36:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4469,15 +4469,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:12 GMT
+      - Thu, 19 Apr 2018 17:36:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e7c0054850145338a1b9f94edc40409
+      - d525a4ea77cd477f86dba9157a20ed73
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-93960219-a212-4531-88e9-182842170cfc
+      - req-18467291-3654-4c52-861b-cdbdbe053f3e
       Content-Length:
       - '7278'
       Connection:
@@ -4489,7 +4489,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:13.016380Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:57.397017Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4568,10 +4568,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fu7XWrFoSrmX2XPtqWPFRA"],
-        "issued_at": "2018-04-09T16:27:13.016455Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ry78quahQQOa1W0m8T9PHA"],
+        "issued_at": "2018-04-19T17:36:57.397115Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4586,7 +4586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e7c0054850145338a1b9f94edc40409
+      - d525a4ea77cd477f86dba9157a20ed73
   response:
     status:
       code: 200
@@ -4597,16 +4597,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fbe8e5d4-167f-47ac-acba-65dfe370cc7a
+      - req-d198e14a-7dc1-41e4-a302-f5fa16ef49c2
       Date:
-      - Mon, 09 Apr 2018 16:27:13 GMT
+      - Thu, 19 Apr 2018 17:36:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4621,7 +4621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c95e8db2256d407a861079d1fcb1027e
+      - 597bd0e3bb7a4529ab01a1b7e2fb9ea0
   response:
     status:
       code: 200
@@ -4632,16 +4632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3958af2d-0445-48a7-ac89-52b1ed3ccbe5
+      - req-9345458f-3a6d-4133-972a-88b934b2c69e
       Date:
-      - Mon, 09 Apr 2018 16:27:13 GMT
+      - Thu, 19 Apr 2018 17:36:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4659,15 +4659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:13 GMT
+      - Thu, 19 Apr 2018 17:36:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 22c166189a7f4e929bbd174d0eb28bcb
+      - ec7e45e5887347e5b5d47ce05aa2d7bb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa874264-97e8-457a-bfa7-bf09242144b6
+      - req-76dd8dc1-1cab-44d9-bf82-06db50c709d8
       Content-Length:
       - '7265'
       Connection:
@@ -4679,7 +4679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:13.691512Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:58.058044Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4758,10 +4758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gp7qLnOEScmZaYHTCZKiBw"],
-        "issued_at": "2018-04-09T16:27:13.691580Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0_Sj5SheRFOabc1Amy-Ygg"],
+        "issued_at": "2018-04-19T17:36:58.058109Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22c166189a7f4e929bbd174d0eb28bcb
+      - ec7e45e5887347e5b5d47ce05aa2d7bb
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c8defcab-e860-4768-a115-eb187df548ea
+      - req-b679b133-8f30-4df6-a2c0-c6c38f81a028
       Date:
-      - Mon, 09 Apr 2018 16:27:13 GMT
+      - Thu, 19 Apr 2018 17:36:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4814,15 +4814,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eaaadd94ed6d4547b3af2c9e25ebf24e
+      - 69aee2746c634922aafea84c6b7e44ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6b3f26e3-4e1c-4cdb-991e-9dcb051c782d
+      - req-a54f6946-f92e-4543-b1c3-8d030886a3ff
       Content-Length:
       - '7278'
       Connection:
@@ -4834,7 +4834,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:14.225922Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:58.600592Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4913,10 +4913,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["308pcImMS1C7qCYrCDY2pg"],
-        "issued_at": "2018-04-09T16:27:14.225988Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ur4C4v3tSOGSpWa3zVboFA"],
+        "issued_at": "2018-04-19T17:36:58.600649Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4931,7 +4931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eaaadd94ed6d4547b3af2c9e25ebf24e
+      - 69aee2746c634922aafea84c6b7e44ce
   response:
     status:
       code: 200
@@ -4942,16 +4942,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-47b82f27-5a42-4559-ae50-8417e97c9688
+      - req-d3357fcf-9b5a-424c-bb10-1018fb24eada
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4966,7 +4966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4979,9 +4979,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-265e0f4a-5458-4cb7-b59c-9cda3fe35c5f
+      - req-66555a37-d621-44cf-8bfa-d29880a1e3e7
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4991,7 +4991,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5006,7 +5006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5019,9 +5019,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-99288811-c834-473a-b42c-8349785f2e3b
+      - req-37569864-d6b6-49db-a681-f5d3d7db93c3
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5031,7 +5031,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5049,15 +5049,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f971ef0ccc934e6a98e7ee8bc21a2323
+      - 9171da22cc224539a6f8efbe7f088ec6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5268907e-a848-4354-9fee-f5ea4f991a03
+      - req-31fabd77-f3ff-4fa3-b182-9f5873e435bb
       Content-Length:
       - '7278'
       Connection:
@@ -5069,7 +5069,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:14.821719Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:59.202873Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5148,10 +5148,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jvviaoRJQ7ORrVL0TPYz5Q"],
-        "issued_at": "2018-04-09T16:27:14.821780Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4P-VH7dtQFqlJvzTVyjGoA"],
+        "issued_at": "2018-04-19T17:36:59.202922Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5166,7 +5166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f971ef0ccc934e6a98e7ee8bc21a2323
+      - 9171da22cc224539a6f8efbe7f088ec6
   response:
     status:
       code: 200
@@ -5177,14 +5177,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5e392998-49fd-4e31-a8d7-e037a12ad60b
+      - req-94aa9b2d-101a-4422-98cf-533962c7c48c
       Date:
-      - Mon, 09 Apr 2018 16:27:14 GMT
+      - Thu, 19 Apr 2018 17:36:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:36:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5202,15 +5202,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:15 GMT
+      - Thu, 19 Apr 2018 17:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '090254f063d24775b2d2e0b1f755e121'
+      - 4bfd4a8f047140d5b2f9053b6a0fe6ec
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f7a5238b-3e42-4573-b3cf-903ce31e082a
+      - req-106a2bfb-02dc-4ca2-bfe8-8673da739af2
       Content-Length:
       - '7278'
       Connection:
@@ -5222,7 +5222,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:15.308578Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:36:59.980174Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5301,10 +5301,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oMEwUU3dQWKcbFPjFmO8YA"],
-        "issued_at": "2018-04-09T16:27:15.308658Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b-WrSFruR_qH-ezI546RAA"],
+        "issued_at": "2018-04-19T17:36:59.980239Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5319,7 +5319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '090254f063d24775b2d2e0b1f755e121'
+      - 4bfd4a8f047140d5b2f9053b6a0fe6ec
   response:
     status:
       code: 200
@@ -5330,14 +5330,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3c8ae672-4e42-4c5e-adb1-d56051c52894
+      - req-8026621c-e1e4-4641-8f24-ccb927eb11c0
       Date:
-      - Mon, 09 Apr 2018 16:27:15 GMT
+      - Thu, 19 Apr 2018 17:37:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5355,15 +5355,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:15 GMT
+      - Thu, 19 Apr 2018 17:37:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-91bf2752-5e3b-4d85-a328-79f71145f8ea
+      - req-a98d89ba-0f8b-4a21-a9c7-feaee0d7f69b
       Content-Length:
       - '7264'
       Connection:
@@ -5375,7 +5375,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:15.784893Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:00.566496Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5454,10 +5454,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6fz4G_zmSf2AqhQNPZEjfQ"],
-        "issued_at": "2018-04-09T16:27:15.784942Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XoyoxlA8Rjuf5dHiHraYwQ"],
+        "issued_at": "2018-04-19T17:37:00.566571Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5472,7 +5472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -5483,9 +5483,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d15bee76-4cd5-4f8b-b8ee-42d58efae5d4
+      - req-58ecb892-2699-4776-97ca-564d780c6915
       Date:
-      - Mon, 09 Apr 2018 16:27:15 GMT
+      - Thu, 19 Apr 2018 17:37:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5519,7 +5519,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5534,7 +5534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -5545,14 +5545,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5b318307-48f0-468e-b453-2a29ad22fbb4
+      - req-03512ff1-b3a1-4fce-a455-180fa5713e65
       Date:
-      - Mon, 09 Apr 2018 16:27:16 GMT
+      - Thu, 19 Apr 2018 17:37:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5570,15 +5570,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:16 GMT
+      - Thu, 19 Apr 2018 17:37:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5fbc76637dec419297b6fd239f75a04c
+      - 2292b0f142244ae58aadc06542f8fd5a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ab074d72-c2a5-4391-9dec-8b88cd5ab988
+      - req-cdd64797-7600-42a2-8443-575051996690
       Content-Length:
       - '7278'
       Connection:
@@ -5590,7 +5590,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:16.309854Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:01.323996Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5669,10 +5669,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eMQL7G4_QBaYwbJ1GzbT-Q"],
-        "issued_at": "2018-04-09T16:27:16.309897Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qcQlca7qREiAkeEvAIFlfw"],
+        "issued_at": "2018-04-19T17:37:01.324089Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5fbc76637dec419297b6fd239f75a04c
+      - 2292b0f142244ae58aadc06542f8fd5a
   response:
     status:
       code: 200
@@ -5698,14 +5698,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9b7dff00-bc57-4197-9c95-f6d340dbf701
+      - req-8fe84694-6e16-4b56-95e7-0c9a9c58213c
       Date:
-      - Mon, 09 Apr 2018 16:27:16 GMT
+      - Thu, 19 Apr 2018 17:37:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5720,7 +5720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c945e4e67d36411480ecadc3c05d16bd
+      - 8addf2d0ca544b2ea2df4ef191c28234
   response:
     status:
       code: 200
@@ -5731,14 +5731,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2d984321-fb95-40fb-8a53-cfa0c885a1f6
+      - req-166870b6-b0cf-4b99-8dc9-e0f7d6d10745
       Date:
-      - Mon, 09 Apr 2018 16:27:17 GMT
+      - Thu, 19 Apr 2018 17:37:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5756,15 +5756,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:17 GMT
+      - Thu, 19 Apr 2018 17:37:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a737cb06e6744befa2c4b08bb1b7289a
+      - e8c4f5947fbc4ab884eaee80aa3cf716
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4849e4b5-6700-477b-8467-173e9709772d
+      - req-1beca8a8-efe1-4a04-bcb5-8a905366c3c6
       Content-Length:
       - '7265'
       Connection:
@@ -5776,7 +5776,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:17.957596Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:02.061934Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5855,10 +5855,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h14z83uOSZWRr9WuPtoxWQ"],
-        "issued_at": "2018-04-09T16:27:17.957635Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sjHdytqORrWIzjXIMKz7wA"],
+        "issued_at": "2018-04-19T17:37:02.062000Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5873,7 +5873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a737cb06e6744befa2c4b08bb1b7289a
+      - e8c4f5947fbc4ab884eaee80aa3cf716
   response:
     status:
       code: 200
@@ -5884,14 +5884,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-82cc8eae-182d-4805-8836-8a2f38b14a89
+      - req-5070898e-b344-4658-bb66-bbbc4a570b0e
       Date:
-      - Mon, 09 Apr 2018 16:27:18 GMT
+      - Thu, 19 Apr 2018 17:37:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5909,15 +5909,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:18 GMT
+      - Thu, 19 Apr 2018 17:37:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 61daa61e27b9411eb0794fa7ef4e0514
+      - b405b4194adb4b36b0efa3a2b3c05957
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-63b53a13-aefc-4a01-b3ce-6584f415764f
+      - req-6b1a037f-c16c-4872-a954-02ec38efd4cf
       Content-Length:
       - '7278'
       Connection:
@@ -5929,7 +5929,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:18.328993Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:02.794671Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6008,10 +6008,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XLKh0y2nQW6KShNH4-u0dg"],
-        "issued_at": "2018-04-09T16:27:18.329032Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uBXGsA1xRRSXtZ1Fv-yWOg"],
+        "issued_at": "2018-04-19T17:37:02.794751Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -6026,7 +6026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61daa61e27b9411eb0794fa7ef4e0514
+      - b405b4194adb4b36b0efa3a2b3c05957
   response:
     status:
       code: 200
@@ -6037,14 +6037,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2fc9a213-c192-4a2e-ab9f-7d64a633aecc
+      - req-7859f679-33bb-415b-ae13-86961f2953ce
       Date:
-      - Mon, 09 Apr 2018 16:27:18 GMT
+      - Thu, 19 Apr 2018 17:37:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -6059,7 +6059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6070,9 +6070,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-5de97c19-c095-4250-89af-3dd65f402014
+      - req-8dbb7819-6a57-4177-a37c-408b3e878c12
       Date:
-      - Mon, 09 Apr 2018 16:27:19 GMT
+      - Thu, 19 Apr 2018 17:37:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6099,7 +6099,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -6114,7 +6114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6125,9 +6125,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-6581d51b-e214-412c-aad6-9f52421e6aa6
+      - req-c1811879-aaf9-474f-a9c5-c9c1e4d4582e
       Date:
-      - Mon, 09 Apr 2018 16:27:20 GMT
+      - Thu, 19 Apr 2018 17:37:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6154,7 +6154,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -6169,7 +6169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6180,9 +6180,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8a74c708-f097-4b9a-a14c-d1bc0fb69656
+      - req-4515a751-c028-49d3-94dd-f835d85d2181
       Date:
-      - Mon, 09 Apr 2018 16:27:20 GMT
+      - Thu, 19 Apr 2018 17:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6209,7 +6209,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6235,9 +6235,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0050c74b-6140-4616-a822-2cc24ad22c2d
+      - req-a21499a3-1c44-4ab0-b94f-f3d4724db17b
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6249,7 +6249,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -6264,7 +6264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6275,9 +6275,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-e1998432-96c7-4fdc-b5ba-ac1d046f28bd
+      - req-4ed5d7c8-2e63-4d60-8b2a-981069d95269
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6333,7 +6333,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6348,7 +6348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6359,9 +6359,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e383a486-31ae-456e-aa18-4da2260e844a
+      - req-4b868f64-900c-4825-915d-603e73031193
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6373,7 +6373,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6388,7 +6388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6399,9 +6399,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-99b9c379-b565-46c1-ac2c-487fef7fbc65
+      - req-8aabfb2a-d093-4eee-aa99-e73528e96cac
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6457,7 +6457,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6472,7 +6472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6483,9 +6483,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-cd76cdb6-e6bb-4553-8189-80e2cb7c2205
+      - req-23808ae7-bed4-459e-a110-11abec42a9aa
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6497,7 +6497,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6512,7 +6512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a169ef750bc4aa3844fafddc94daa0d
+      - 1dd9e73e02d3453e8cdd3619a7b77566
   response:
     status:
       code: 200
@@ -6523,9 +6523,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9853330f-70a1-4612-ba9f-2969a7613c34
+      - req-b5762743-1e30-4ad8-9542-fa002bcc3cc9
       Date:
-      - Mon, 09 Apr 2018 16:27:21 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6581,7 +6581,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6596,7 +6596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6607,14 +6607,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b2f5cb0f-8e66-4bb1-af78-75ee846fe990
+      - req-7f46599d-fc03-4c26-b62f-25136187e964
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6629,7 +6629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6640,9 +6640,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-18b305d8-a1fb-4c6b-80c4-bfa4ecd7c52d
+      - req-f327a19a-8c6e-4ab4-ba5a-8526bf066c6f
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6684,7 +6684,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6699,7 +6699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6710,14 +6710,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-faa0b9a9-94f3-40b7-b0a1-99046572283b
+      - req-fd9a59c5-a59a-4ec9-9e8e-8b28720361d6
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6732,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6743,14 +6743,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-564deb11-723b-4c2a-bdaf-a84e6f5caedb
+      - req-b2e7d8f2-75cb-456a-9654-84219ef8f56d
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6765,7 +6765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6776,14 +6776,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9f17637d-f750-4311-9cec-73355c0c7d7b
+      - req-a5737f97-6f52-4ffd-8f06-b8018f7025c2
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6798,7 +6798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcbee4fe4842460f82b052ed68b27595
+      - 1a9840d419d3495f8e0ec8445efe56e0
   response:
     status:
       code: 200
@@ -6809,14 +6809,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7de86c3a-2a5d-47d9-8f2f-37ddee334677
+      - req-4c7b58f1-f401-4f18-a567-d91801ad1c8e
       Date:
-      - Mon, 09 Apr 2018 16:27:22 GMT
+      - Thu, 19 Apr 2018 17:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6831,7 +6831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6844,9 +6844,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-c98ee4bd-2355-4b99-8b43-e10c50f0432f
+      - req-407951fc-2e6a-4e9a-8ad1-39a9a89c1306
       Date:
-      - Mon, 09 Apr 2018 16:27:23 GMT
+      - Thu, 19 Apr 2018 17:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6892,7 +6892,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6907,7 +6907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6920,9 +6920,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-f90d7208-b764-4f01-ab9a-6326cc5c2ddd
+      - req-95687ab5-f29b-4085-a7bf-73a442b39b94
       Date:
-      - Mon, 09 Apr 2018 16:27:23 GMT
+      - Thu, 19 Apr 2018 17:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6968,7 +6968,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6983,7 +6983,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6996,9 +6996,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-fe4f9cd8-8684-4f52-9586-6284faca13af
+      - req-3b7244d2-5d41-4afb-a37c-b489c010ed89
       Date:
-      - Mon, 09 Apr 2018 16:27:24 GMT
+      - Thu, 19 Apr 2018 17:37:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -7046,7 +7046,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -7061,7 +7061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7074,9 +7074,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-975005a0-c081-440c-95f9-828582b131de
+      - req-dd3eb4ed-cb28-438c-94c1-6aefcf19331f
       Date:
-      - Mon, 09 Apr 2018 16:27:24 GMT
+      - Thu, 19 Apr 2018 17:37:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -7118,7 +7118,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -7133,7 +7133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7146,9 +7146,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-e40d46f5-bb81-4b25-a129-6e9933e05fdf
+      - req-615776a8-c69c-414f-ae3b-e99e0a2b62be
       Date:
-      - Mon, 09 Apr 2018 16:27:24 GMT
+      - Thu, 19 Apr 2018 17:37:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -7171,7 +7171,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7186,7 +7186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7199,14 +7199,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0c941cd7-552f-439f-9057-d92a65e67f90
+      - req-08071fcd-a03d-46f6-88ea-a490f0f2d909
       Date:
-      - Mon, 09 Apr 2018 16:27:25 GMT
+      - Thu, 19 Apr 2018 17:37:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7221,7 +7221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7234,14 +7234,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-9c95a3d1-8180-4ff2-93f6-5383965eac02
+      - req-f39d4802-3d0a-4951-8c7a-e7840fa810d2
       Date:
-      - Mon, 09 Apr 2018 16:27:25 GMT
+      - Thu, 19 Apr 2018 17:37:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7256,7 +7256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7269,14 +7269,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f19ce610-3239-4444-9c11-4682563a5077
+      - req-d73ba38b-5826-4ddd-a0cc-2ab439fa3420
       Date:
-      - Mon, 09 Apr 2018 16:27:25 GMT
+      - Thu, 19 Apr 2018 17:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7291,7 +7291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7304,14 +7304,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d9d21813-b2d2-42bd-b907-8913f8d75169
+      - req-4e72dc8a-e367-485d-9e1b-1cd545548e3e
       Date:
-      - Mon, 09 Apr 2018 16:27:25 GMT
+      - Thu, 19 Apr 2018 17:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7326,7 +7326,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7339,14 +7339,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d408c4cf-28d6-4ccc-99e7-fded9f991ad1
+      - req-8e8bd45a-7ef2-4e7a-8518-3bfd800e45e3
       Date:
-      - Mon, 09 Apr 2018 16:27:26 GMT
+      - Thu, 19 Apr 2018 17:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7361,7 +7361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7374,14 +7374,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-950b7bb1-3edf-4eba-995b-88b8cd67531e
+      - req-59cffd4a-797c-42e5-9178-338f83515ec9
       Date:
-      - Mon, 09 Apr 2018 16:27:26 GMT
+      - Thu, 19 Apr 2018 17:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7396,7 +7396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7409,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d55c2d59-436d-4afb-8bfd-6ec8c18ae45c
+      - req-1821a879-7a93-4f39-b1e6-a7c6dd3d797e
       Date:
-      - Mon, 09 Apr 2018 16:27:26 GMT
+      - Thu, 19 Apr 2018 17:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7431,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7444,14 +7444,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8787c987-c351-4cc8-b245-3b064cd805b8
+      - req-ac214192-583e-4745-855d-5b6724c6a44d
       Date:
-      - Mon, 09 Apr 2018 16:27:26 GMT
+      - Thu, 19 Apr 2018 17:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7466,7 +7466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7479,14 +7479,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-06915cf3-da55-4ee9-b993-f5a11f2f046e
+      - req-8aa37493-594a-4197-a18b-4e25c24e7246
       Date:
-      - Mon, 09 Apr 2018 16:27:27 GMT
+      - Thu, 19 Apr 2018 17:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7501,7 +7501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7514,26 +7514,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c532621e-e5df-41a7-a039-59e9d7b538be
+      - req-5e8fdc52-ffd4-4184-ba83-2e7db8c8f8bf
       Date:
-      - Mon, 09 Apr 2018 16:27:27 GMT
+      - Thu, 19 Apr 2018 17:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:27:19.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:12.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:27:20.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:27:24.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:14.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:27:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:12.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:27:19.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:14.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7548,7 +7548,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9ac2ab6e8a34559856fab66c4de28d5
+      - 20edfdab01504319bde6399efabda5d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7561,26 +7561,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ecde056e-4629-4af7-a3c5-9ec76dab12ab
+      - req-efda6e0f-7c25-4c52-b74e-623adf5b8024
       Date:
-      - Mon, 09 Apr 2018 16:27:27 GMT
+      - Thu, 19 Apr 2018 17:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:27:19.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:37:12.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:27:20.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:37:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:27:24.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:37:14.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-04-09T16:27:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:37:12.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-09T16:27:19.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-04-19T17:37:14.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7598,15 +7598,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:31 GMT
+      - Thu, 19 Apr 2018 17:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 962599665d024d7fa6524c484a1c7474
+      - aefe40cdb69b432292671436cb783dde
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aef7ae66-e48c-4fec-bd88-5371ed389a93
+      - req-20bbcd8e-5f1a-4dc7-b22f-cf3d8ab7284e
       Content-Length:
       - '7311'
       Connection:
@@ -7618,7 +7618,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:27:31.916037Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:24.556360Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7697,10 +7697,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2arkiTU0RLCB5SoyZ8VaGg"],
-        "issued_at": "2018-04-09T16:27:31.916109Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QF7iOqdmQ0qqUtOD2Mo8vA"],
+        "issued_at": "2018-04-19T17:37:24.556446Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7718,15 +7718,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:32 GMT
+      - Thu, 19 Apr 2018 17:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03ed9ff4-b253-42af-a6b4-566b5d9c9528
+      - req-5cac442b-0f63-42f3-b840-7b196b5cfa51
       Content-Length:
       - '7311'
       Connection:
@@ -7738,7 +7738,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:27:32.315305Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:24.893795Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7817,10 +7817,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Fo7itimNQ-ue7lVSS0kKfw"],
-        "issued_at": "2018-04-09T16:27:32.315374Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gbO8ejd0TF2pPYgjpOyFOA"],
+        "issued_at": "2018-04-19T17:37:24.893884Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7835,7 +7835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -7846,9 +7846,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-3abcb8ac-f9a0-45e7-8405-e53621c206de
+      - req-ff9d68cc-d68c-4d21-886d-afbac5222d95
       Date:
-      - Mon, 09 Apr 2018 16:27:32 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7883,7 +7883,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7898,7 +7898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -7909,9 +7909,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-40732cd2-40f9-45db-9862-6797214d5f32
+      - req-24a8a3e5-38bd-4192-aef1-da6786781f02
       Date:
-      - Mon, 09 Apr 2018 16:27:32 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7954,7 +7954,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7969,7 +7969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -7980,9 +7980,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-0f356a4e-acce-4a4d-a63f-e48bf4f2378a
+      - req-0a271ada-e53b-491b-b966-5f1018331749
       Date:
-      - Mon, 09 Apr 2018 16:27:32 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -8025,7 +8025,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -8040,7 +8040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8051,9 +8051,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-cf86faa7-794b-4d8a-8293-41aee5640b2f
+      - req-9482cd1a-73de-4823-84f4-a81f18586b8c
       Date:
-      - Mon, 09 Apr 2018 16:27:32 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -8160,7 +8160,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -8175,7 +8175,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8186,9 +8186,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-bf2236b5-79b4-4162-9d91-7e4dd727884f
+      - req-faffaf46-97e7-4f81-b2ef-c8a12630a773
       Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -8230,7 +8230,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -8245,7 +8245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8256,15 +8256,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-42451efa-eeb9-4abb-a3c0-4e59d1ea9976
+      - req-f42d519f-081e-4571-82cf-d02da0b34a33
       Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
+      - Thu, 19 Apr 2018 17:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8279,7 +8279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8290,22 +8290,52 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-3394c14a-804a-43a3-828f-3563ed2f8cd3
+      - req-74001acf-ee91-446a-9a24-4e0a77a0e65e
       Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
+      - Thu, 19 Apr 2018 17:37:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
+        13}, {"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -8325,36 +8355,6 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -8362,7 +8362,7 @@ http_interactions:
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8377,7 +8377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8388,141 +8388,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5f142e7b-25ec-4f3d-9c4c-d953023376fe
+      - req-104174dd-c80e-4ab6-8151-710bfbce91f8
       Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c1b3c622-ff72-40a6-8883-117643f87e47
-      Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
+      - Thu, 19 Apr 2018 17:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -8626,7 +8494,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -8641,7 +8509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8652,9 +8520,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dd572f06-8fc5-4686-869d-1fce603f07b3
+      - req-bf618922-4072-46cf-bf0b-3c1788a53d46
       Date:
-      - Mon, 09 Apr 2018 16:27:33 GMT
+      - Thu, 19 Apr 2018 17:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
@@ -8759,7 +8627,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8774,7 +8642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8785,9 +8653,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-18da3d97-1686-4514-828f-09c08d3f0257
+      - req-cca81c5a-9d2f-4dfa-9b16-43fabc45c410
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8819,7 +8687,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8834,7 +8702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8845,9 +8713,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-61bc0e47-e824-4b34-a363-4f76aa53d5d9
+      - req-ce7108e3-0227-46bb-8c2e-fde254e3cfd5
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8879,7 +8747,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8894,7 +8762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -8905,9 +8773,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-08dddc2d-dce0-4244-adcd-bc00e066cb98
+      - req-2d0abecf-1adc-49d8-aeaf-6d0c9b6cd100
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9310,7 +9178,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9325,7 +9193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -9336,9 +9204,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c6aee251-3391-43a3-b69f-6b2640727f39
+      - req-ff0a7aa5-5d68-401a-8be0-1aad9d49e1a2
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9741,7 +9609,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9756,7 +9624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -9767,9 +9635,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5012fd1b-d289-4a3a-9e22-3a57d7683205
+      - req-319fa5a1-a9c4-4963-8d93-c01cc423081f
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9811,7 +9679,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9826,7 +9694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18d215ac1c0a4171941146e6e52b25a9
+      - 0cd931f309124e0891f48b0a09554ea9
   response:
     status:
       code: 200
@@ -9837,9 +9705,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b77149a6-75e5-42fa-a3a7-b0516e7c4349
+      - req-bcc7cc46-abaa-43ba-8483-9be70e63ffd6
       Date:
-      - Mon, 09 Apr 2018 16:27:34 GMT
+      - Thu, 19 Apr 2018 17:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9881,7 +9749,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9899,13 +9767,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:36 GMT
+      - Thu, 19 Apr 2018 17:37:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75df12ae-7270-4dad-93ec-34f4f3899483
+      - req-bc3d9e4a-4b04-40e8-ac4a-263fcabc4f79
       Content-Length:
       - '4227'
       Connection:
@@ -9914,10 +9782,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:36.260437", "expires":
-        "2018-04-09T17:27:36Z", "id": "f4c93149c96b4696a32aa75d396e2532", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:28.945130", "expires":
+        "2018-04-19T18:37:28Z", "id": "8f1b481477d64735a8c4670832f6f0f5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["MPbYa8HOQEm9QDzC27o6WQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["C5z4xV0pQVK3H0Pppv_zXw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -9962,7 +9830,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9980,13 +9848,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:36 GMT
+      - Thu, 19 Apr 2018 17:37:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-70bb9c3d-0334-4cdf-bc59-6d67ab6ae8a2
+      - req-525ea4da-2bcd-42b0-8342-f42748d8f662
       Content-Length:
       - '4227'
       Connection:
@@ -9995,10 +9863,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:36.563833", "expires":
-        "2018-04-09T17:27:36Z", "id": "4eaade29f6814a9ab80ace517409b39a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:29.226308", "expires":
+        "2018-04-19T18:37:29Z", "id": "e082a447f7f14d35b093ee142c076c47", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "audit_ids": ["XhTvibfbTGK30FN-fdiMmg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ww5VRJz8R6mMIPWtgpm5Dw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52"}],
@@ -10043,7 +9911,7 @@ http_interactions:
         "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
         "e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872", "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10061,13 +9929,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:36 GMT
+      - Thu, 19 Apr 2018 17:37:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-08a348a9-1bdb-4436-9bd4-78ba4a32fc19
+      - req-25b760ad-494b-4eb7-b8b8-1e9b5c7c332b
       Content-Length:
       - '370'
       Connection:
@@ -10076,13 +9944,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:36.810863", "expires":
-        "2018-04-09T17:27:36Z", "id": "66cc20d306e2457e959f9ea37d8045fb", "audit_ids":
-        ["f_3W0Z3aTD6UEpL1AMt5pQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:29.462795", "expires":
+        "2018-04-19T18:37:29Z", "id": "ba4b29eaed1749ca81b9c30f9e48b571", "audit_ids":
+        ["n2orzCj2RQWmFzHd_iNftg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10097,20 +9965,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66cc20d306e2457e959f9ea37d8045fb
+      - ba4b29eaed1749ca81b9c30f9e48b571
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:36 GMT
+      - Thu, 19 Apr 2018 17:37:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5b398414-5848-4c50-bbec-341fd80c9fe2
+      - req-600debc9-40e4-44e8-b668-75b50d2f3953
       Content-Length:
       - '884'
       Connection:
@@ -10131,13 +9999,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"66cc20d306e2457e959f9ea37d8045fb"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"ba4b29eaed1749ca81b9c30f9e48b571"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10149,13 +10017,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:37 GMT
+      - Thu, 19 Apr 2018 17:37:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c499949c-8cb5-4918-91a9-9f623da30a98
+      - req-0e26aa85-45e7-4ba9-b845-196dca1105cc
       Content-Length:
       - '4214'
       Connection:
@@ -10164,11 +10032,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:37.247355", "expires":
-        "2018-04-09T17:27:36Z", "id": "ebf8044ef7f3444292ee3366d1992b38", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:29.878285", "expires":
+        "2018-04-19T18:37:29Z", "id": "5fc5b5d9a8f14fe88ac29fa31755947a", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["z-N0Mir0QSyZnIz63ZL10A",
-        "f_3W0Z3aTD6UEpL1AMt5pQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["kViHOw3VTdezoC1Zu65VBQ",
+        "n2orzCj2RQWmFzHd_iNftg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -10213,7 +10081,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10231,13 +10099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:37 GMT
+      - Thu, 19 Apr 2018 17:37:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2699cf93-fdcd-4039-8862-25ea54ab29f2
+      - req-35c3bbab-a286-4134-b017-f67e76c2d68a
       Content-Length:
       - '370'
       Connection:
@@ -10246,13 +10114,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:37.456324", "expires":
-        "2018-04-09T17:27:37Z", "id": "98f6acce17de4049919d72c9d71e72fe", "audit_ids":
-        ["pwRuuhEtSFm77Ph-7P4T-g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:30.055628", "expires":
+        "2018-04-19T18:37:30Z", "id": "3c290805032a4146b86046138ba1f474", "audit_ids":
+        ["BJCCWwwKQJeKK7ynEbC8WQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "0e379b058aea4a7ba72d13cddf21c240", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:30 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10267,20 +10135,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98f6acce17de4049919d72c9d71e72fe
+      - 3c290805032a4146b86046138ba1f474
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:38 GMT
+      - Thu, 19 Apr 2018 17:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9693d4d5-a240-4894-b41c-2e05cd119be6
+      - req-ff6c1759-dce1-470d-907d-c59437787ecd
       Content-Length:
       - '884'
       Connection:
@@ -10301,13 +10169,13 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"98f6acce17de4049919d72c9d71e72fe"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
+      string: '{"auth":{"token":{"id":"3c290805032a4146b86046138ba1f474"},"tenantName":"EmsRefreshSpec-Project-parent-test-3"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10319,13 +10187,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:38 GMT
+      - Thu, 19 Apr 2018 17:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a729a328-be44-47a0-945f-752e341cea24
+      - req-d22cb9f6-ea34-48dc-a13a-42e11752a829
       Content-Length:
       - '4214'
       Connection:
@@ -10334,11 +10202,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:38.941523", "expires":
-        "2018-04-09T17:27:37Z", "id": "a4f71005bf7544f4a94b32fd19f31c39", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:30.510419", "expires":
+        "2018-04-19T18:37:30Z", "id": "8574cfb49564464083280e06a7b6f604", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["CryCf1-TT_GPcNCS9Xoi4g",
-        "pwRuuhEtSFm77Ph-7P4T-g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["ZKbPahZQQaWeWWVjg9ydTg",
+        "BJCCWwwKQJeKK7ynEbC8WQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3", "region": "RegionOne",
         "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -10383,7 +10251,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:30 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10398,20 +10266,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98f6acce17de4049919d72c9d71e72fe
+      - 3c290805032a4146b86046138ba1f474
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:39 GMT
+      - Thu, 19 Apr 2018 17:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d24812ff-3e67-473c-943d-a574b3f47c6e
+      - req-2464da6b-31b9-477e-97e1-41a84d9fc97e
       Content-Length:
       - '884'
       Connection:
@@ -10432,7 +10300,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Project2"}, {"description": "", "enabled": true, "id":
         "ef2a3405d1ef4dfd9a3616993ef46a4d", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10450,13 +10318,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:39 GMT
+      - Thu, 19 Apr 2018 17:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9a6adc8-cf9d-4f97-904e-3c4387f05f1d
+      - req-328d9e13-a9d4-4567-ad55-c78919cb889a
       Content-Length:
       - '4188'
       Connection:
@@ -10465,10 +10333,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:39.370535", "expires":
-        "2018-04-09T17:27:39Z", "id": "79983549ab684983ba1cc1f3bab44037", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:30.918248", "expires":
+        "2018-04-19T18:37:30Z", "id": "ba36232de43c4cb09ecd685a057b962e", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["7Yzaqp1nToaHTW4gG4V5Tw"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["G8u45BGfSmeqX2JWkEyjlw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -10513,7 +10381,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10531,13 +10399,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:39 GMT
+      - Thu, 19 Apr 2018 17:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0252c10f-cb7f-417e-82a8-a8d8327401a7
+      - req-17ab6529-41f5-43f3-a785-4ee3e03337fa
       Content-Length:
       - '4188'
       Connection:
@@ -10546,10 +10414,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:39.658538", "expires":
-        "2018-04-09T17:27:39Z", "id": "63caf534c46f46b0970d577740c8ee5b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:31.397900", "expires":
+        "2018-04-19T18:37:31Z", "id": "4d795dab773d4f8e9b9ce732f725601e", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eeJkWydlTrWqkekStau6HQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["q4WjZBAeTuqd8epl5f3Yww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -10594,7 +10462,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10612,13 +10480,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:39 GMT
+      - Thu, 19 Apr 2018 17:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b1318b24-c7e7-406a-8a2a-c9d00aff490e
+      - req-245491a2-f163-48eb-83a3-dadd152d727c
       Content-Length:
       - '4174'
       Connection:
@@ -10627,10 +10495,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:40.052993", "expires":
-        "2018-04-09T17:27:39Z", "id": "43815fbc5b82410696d3bb697a9074af", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:31.672142", "expires":
+        "2018-04-19T18:37:31Z", "id": "cb9df18b903844669cf9d18158c52a86", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1kV-HkjzQp2bo_72ZxgnGA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["odKG3QCrQ_aTt3j4Y6U9bw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -10675,7 +10543,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10693,13 +10561,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:40 GMT
+      - Thu, 19 Apr 2018 17:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4588a8d6-0a75-4b92-a4f8-3548a801af60
+      - req-7cd60f50-0b8a-4b20-9b4a-7ed1e2515f21
       Content-Length:
       - '4188'
       Connection:
@@ -10708,10 +10576,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:40.324686", "expires":
-        "2018-04-09T17:27:40Z", "id": "fa75347f28444c1fb7dfc6a8a9ea717f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:31.922807", "expires":
+        "2018-04-19T18:37:31Z", "id": "a8c725b793c1451a9dcc8e655d0c0033", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["31t8Hkz0RxaWQvDnthU_ug"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["cRMjhs95TxGWXcj1Cf_fCA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -10756,7 +10624,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10774,13 +10642,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:40 GMT
+      - Thu, 19 Apr 2018 17:37:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86a6422b-5275-47e5-a3b9-69f02542d2b4
+      - req-4e732912-02a1-4083-a2d0-c4802d835fcf
       Content-Length:
       - '4175'
       Connection:
@@ -10789,10 +10657,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:40.592171", "expires":
-        "2018-04-09T17:27:40Z", "id": "1fec8e3d29d14731ad36941a4fdfa5fb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:32.228934", "expires":
+        "2018-04-19T18:37:32Z", "id": "f0ea21cb887c4099affe7b2e420c98b7", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UaFtVh9NQAiGnFxXvl0ZGQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ypeabH4FSRS2qDXx9aVcmA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -10837,7 +10705,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10855,13 +10723,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:40 GMT
+      - Thu, 19 Apr 2018 17:37:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fd8ed517-b1f3-4590-80bf-2b72c2af01c4
+      - req-66b1912d-1a26-49cf-a490-fe2b0728bca6
       Content-Length:
       - '4188'
       Connection:
@@ -10870,10 +10738,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:40.868431", "expires":
-        "2018-04-09T17:27:40Z", "id": "8677716953ac4f65a289ac45326e3e8c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:32.552337", "expires":
+        "2018-04-19T18:37:32Z", "id": "0a0047a21d974988bff1bf7aacb267ca", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["zQRqN0zVQ6m0B_xvQKIadQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["zRpR_vR6SzqLi3r6aE_Arg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -10918,7 +10786,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10936,13 +10804,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:40 GMT
+      - Thu, 19 Apr 2018 17:37:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbf65958-7373-4943-8b65-00186404fb12
+      - req-284fbfba-37b8-426b-8c13-e07f225c1455
       Content-Length:
       - '4188'
       Connection:
@@ -10951,10 +10819,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:41.138153", "expires":
-        "2018-04-09T17:27:41Z", "id": "c8919f57563144beace43e1b1856df6a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:32.806579", "expires":
+        "2018-04-19T18:37:32Z", "id": "897df36b58f9483589a2592fc0771dc0", "tenant":
         {"description": "", "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3",
-        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["OL2sTVRKQgmqb2iULN0LIg"]},
+        "name": "EmsRefreshSpec-Project-parent-test-3"}, "audit_ids": ["X4hQ0HAdSg-c0698zdHZIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3"}],
@@ -10999,7 +10867,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11014,27 +10882,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8919f57563144beace43e1b1856df6a
+      - 897df36b58f9483589a2592fc0771dc0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-363be8f5-6325-44b6-ab05-dde9b8c1cfb1
+      - req-957d942c-ba7c-4e19-9443-21adc235b2fb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-363be8f5-6325-44b6-ab05-dde9b8c1cfb1
+      - req-957d942c-ba7c-4e19-9443-21adc235b2fb
       Date:
-      - Mon, 09 Apr 2018 16:27:41 GMT
+      - Thu, 19 Apr 2018 17:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11052,13 +10920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:41 GMT
+      - Thu, 19 Apr 2018 17:37:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-26a4ba8e-7ef3-42ab-9cbb-5dbe36849b56
+      - req-50460549-6dd9-4d4a-980e-63734eb9841f
       Content-Length:
       - '4188'
       Connection:
@@ -11067,10 +10935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:41.844744", "expires":
-        "2018-04-09T17:27:41Z", "id": "6c4faf39086b4508884331ee168babce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:33.480444", "expires":
+        "2018-04-19T18:37:33Z", "id": "54c7bce6ea8b49388092b5307808b39e", "tenant":
         {"description": "", "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XhSTQ7t3QNeQ2A0NcD2kRw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["bCu3zUr7Q-aTQL8i1S21Ig"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74"}],
@@ -11115,7 +10983,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11130,27 +10998,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c4faf39086b4508884331ee168babce
+      - 54c7bce6ea8b49388092b5307808b39e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86ae8d62-3823-49d8-a9ac-41c2860eb365
+      - req-d1236631-b363-4939-96ea-d338cde90983
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-86ae8d62-3823-49d8-a9ac-41c2860eb365
+      - req-d1236631-b363-4939-96ea-d338cde90983
       Date:
-      - Mon, 09 Apr 2018 16:27:42 GMT
+      - Thu, 19 Apr 2018 17:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11168,13 +11036,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:42 GMT
+      - Thu, 19 Apr 2018 17:37:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9816c436-2d2a-4d7d-abf1-316994405ee3
+      - req-c8491ed9-f09f-4918-95ba-bf89b094c4a3
       Content-Length:
       - '4174'
       Connection:
@@ -11183,10 +11051,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:42.557313", "expires":
-        "2018-04-09T17:27:42Z", "id": "fcb63abbbcd5413ea1a1164b070c3aa3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:34.240437", "expires":
+        "2018-04-19T18:37:34Z", "id": "30a36332330f455d97fbe06c07ac317b", "tenant":
         {"description": "", "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ccRrY199Tzuh4qgwwAbzIQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ehE1ADkrRG2Ge0eoyKMFjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91"}],
@@ -11231,7 +11099,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11246,22 +11114,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2d2826b-f0ec-4e02-a988-1c109c0c17c8
+      - req-fbb96aa8-2702-44d5-b8f3-50d1a9f7a84a
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-d2d2826b-f0ec-4e02-a988-1c109c0c17c8
+      - req-fbb96aa8-2702-44d5-b8f3-50d1a9f7a84a
       Date:
-      - Mon, 09 Apr 2018 16:27:43 GMT
+      - Thu, 19 Apr 2018 17:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11294,7 +11162,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11309,22 +11177,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-281ba7a7-8044-480d-ab04-581033698e52
+      - req-b5e0abb6-d62f-4cfa-a17c-a58d4a88c516
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-281ba7a7-8044-480d-ab04-581033698e52
+      - req-b5e0abb6-d62f-4cfa-a17c-a58d4a88c516
       Date:
-      - Mon, 09 Apr 2018 16:27:43 GMT
+      - Thu, 19 Apr 2018 17:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11365,7 +11233,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11380,22 +11248,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02bc4491-8453-4081-9600-7376c1480253
+      - req-128f6d28-9a00-4259-8bd8-39680fb24932
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-02bc4491-8453-4081-9600-7376c1480253
+      - req-128f6d28-9a00-4259-8bd8-39680fb24932
       Date:
-      - Mon, 09 Apr 2018 16:27:43 GMT
+      - Thu, 19 Apr 2018 17:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11429,7 +11297,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11444,27 +11312,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f385b978-1a3d-4c7b-b19a-6f353e291f0c
+      - req-ddc73269-dacf-4c89-ba80-0eef48536e04
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f385b978-1a3d-4c7b-b19a-6f353e291f0c
+      - req-ddc73269-dacf-4c89-ba80-0eef48536e04
       Date:
-      - Mon, 09 Apr 2018 16:27:44 GMT
+      - Thu, 19 Apr 2018 17:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11482,13 +11350,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:44 GMT
+      - Thu, 19 Apr 2018 17:37:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bec3b84a-c124-4646-ac78-db1c9f001db2
+      - req-c1d569d7-49c9-4f6a-ac5f-1a8c62210b66
       Content-Length:
       - '4188'
       Connection:
@@ -11497,10 +11365,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:44.488963", "expires":
-        "2018-04-09T17:27:44Z", "id": "f6041d70a2cb495fa3a395ccbe23499c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:35.931139", "expires":
+        "2018-04-19T18:37:35Z", "id": "e8611988d76642f1bc75ee553c1886b7", "tenant":
         {"description": "", "enabled": true, "id": "52c452d7763a4295950527948232a3e5",
-        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["hURinEs2Sj26QBJRBwpniQ"]},
+        "name": "EmsRefreshSpec-Project-parent-test-1"}, "audit_ids": ["C72fbvwuTOiESVcpCVXYQQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5"}],
@@ -11545,7 +11413,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11560,27 +11428,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6041d70a2cb495fa3a395ccbe23499c
+      - e8611988d76642f1bc75ee553c1886b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de027dcd-3f5c-4798-abe6-793682e3dd37
+      - req-62bf51e5-27b6-44cb-ab5a-b9a85fd4694c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-de027dcd-3f5c-4798-abe6-793682e3dd37
+      - req-62bf51e5-27b6-44cb-ab5a-b9a85fd4694c
       Date:
-      - Mon, 09 Apr 2018 16:27:44 GMT
+      - Thu, 19 Apr 2018 17:37:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11595,27 +11463,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4eaade29f6814a9ab80ace517409b39a
+      - e082a447f7f14d35b093ee142c076c47
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f9909b18-e4cc-4aa0-8151-f38e69141e78
+      - req-e1b85574-5dc0-4fbc-9d76-d16a3a034749
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f9909b18-e4cc-4aa0-8151-f38e69141e78
+      - req-e1b85574-5dc0-4fbc-9d76-d16a3a034749
       Date:
-      - Mon, 09 Apr 2018 16:27:45 GMT
+      - Thu, 19 Apr 2018 17:37:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11633,13 +11501,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:45 GMT
+      - Thu, 19 Apr 2018 17:37:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f38ebfb-8523-49cb-a211-b79725027a04
+      - req-ea3afc82-f971-4eb1-846e-a9f343714003
       Content-Length:
       - '4175'
       Connection:
@@ -11648,10 +11516,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:45.560314", "expires":
-        "2018-04-09T17:27:45Z", "id": "0e7646313a8f43d9ad386b84d4904479", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:36.884842", "expires":
+        "2018-04-19T18:37:36Z", "id": "a725346699da4116bc4e548743aa8649", "tenant":
         {"description": "", "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wUUCnps_Rqy7gStmLbR-Gw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LANcG5MLQzaFnuu-_0jmnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23"}],
@@ -11696,7 +11564,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11711,27 +11579,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e7646313a8f43d9ad386b84d4904479
+      - a725346699da4116bc4e548743aa8649
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d2f491e-f852-4250-971d-0ea5c8bdf423
+      - req-59d0483e-308c-4102-a8a5-068e2072d939
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5d2f491e-f852-4250-971d-0ea5c8bdf423
+      - req-59d0483e-308c-4102-a8a5-068e2072d939
       Date:
-      - Mon, 09 Apr 2018 16:27:45 GMT
+      - Thu, 19 Apr 2018 17:37:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11749,13 +11617,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:46 GMT
+      - Thu, 19 Apr 2018 17:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0afeaaa5-217c-49ce-8591-88c098be530f
+      - req-12a63b6e-48b2-4e18-a57c-ce5f9b5da932
       Content-Length:
       - '4188'
       Connection:
@@ -11764,10 +11632,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:27:46.245322", "expires":
-        "2018-04-09T17:27:46Z", "id": "75c608122e1f4fc98c78191d32b92265", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:37:37.586512", "expires":
+        "2018-04-19T18:37:37Z", "id": "81813c2e8b0d48b88cd72c993f3d4b86", "tenant":
         {"description": "", "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["BnjqeMXzTiqbrH84SQacaA"]},
+        "name": "EmsRefreshSpec-Project-parent-test-2"}, "audit_ids": ["l-u1NSExT2eXxeB0GS9DjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "region": "RegionOne", "internalURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
         "id": "2743bb5edbff4fe3a99465295e7686f4", "publicURL": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d"}],
@@ -11812,7 +11680,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["e6ea2d27f090432bb811e47290dce55b", "e6055e3c27bb4e8ba987a6cd2da07872",
         "79d1f8734bd847a1a6cda6e90acb9f81"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11827,27 +11695,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75c608122e1f4fc98c78191d32b92265
+      - 81813c2e8b0d48b88cd72c993f3d4b86
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-767a71a5-056a-4d72-8a36-ec5cf2862484
+      - req-f8eeb9a9-a259-4786-8ea2-f65015360cdd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-767a71a5-056a-4d72-8a36-ec5cf2862484
+      - req-f8eeb9a9-a259-4786-8ea2-f65015360cdd
       Date:
-      - Mon, 09 Apr 2018 16:27:46 GMT
+      - Thu, 19 Apr 2018 17:37:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -11862,27 +11730,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8919f57563144beace43e1b1856df6a
+      - 897df36b58f9483589a2592fc0771dc0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f1c4b117-b3c3-4f05-b710-a7ae0d2bc388
+      - req-596acbc1-6998-412b-8900-f66f641baca1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f1c4b117-b3c3-4f05-b710-a7ae0d2bc388
+      - req-596acbc1-6998-412b-8900-f66f641baca1
       Date:
-      - Mon, 09 Apr 2018 16:27:46 GMT
+      - Thu, 19 Apr 2018 17:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -11897,27 +11765,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8919f57563144beace43e1b1856df6a
+      - 897df36b58f9483589a2592fc0771dc0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2d2a722a-3e9e-451e-a630-b6170dfe298a
+      - req-2d90dea9-adc6-4599-b0e5-2f89b48ea224
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2d2a722a-3e9e-451e-a630-b6170dfe298a
+      - req-2d90dea9-adc6-4599-b0e5-2f89b48ea224
       Date:
-      - Mon, 09 Apr 2018 16:27:46 GMT
+      - Thu, 19 Apr 2018 17:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -11932,27 +11800,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c4faf39086b4508884331ee168babce
+      - 54c7bce6ea8b49388092b5307808b39e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c931e648-f559-4b62-b86f-845e22e50fa2
+      - req-f095ab61-61ee-4101-885a-26c60d9d00ef
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c931e648-f559-4b62-b86f-845e22e50fa2
+      - req-f095ab61-61ee-4101-885a-26c60d9d00ef
       Date:
-      - Mon, 09 Apr 2018 16:27:47 GMT
+      - Thu, 19 Apr 2018 17:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -11967,27 +11835,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c4faf39086b4508884331ee168babce
+      - 54c7bce6ea8b49388092b5307808b39e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e22ce37c-a3fd-4362-a864-789fcbfdc2ca
+      - req-de11e8ec-a833-4888-89d5-52920579e652
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e22ce37c-a3fd-4362-a864-789fcbfdc2ca
+      - req-de11e8ec-a833-4888-89d5-52920579e652
       Date:
-      - Mon, 09 Apr 2018 16:27:47 GMT
+      - Thu, 19 Apr 2018 17:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12002,22 +11870,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9129fb9d-3da9-48a5-9ece-10a2506813da
+      - req-1fd569a2-9843-4464-8843-ec2c7d31adc1
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-9129fb9d-3da9-48a5-9ece-10a2506813da
+      - req-1fd569a2-9843-4464-8843-ec2c7d31adc1
       Date:
-      - Mon, 09 Apr 2018 16:27:47 GMT
+      - Thu, 19 Apr 2018 17:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12032,7 +11900,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12047,22 +11915,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c78841af-5098-4563-9b54-3735f49b6c0b
+      - req-0cc97d43-1fef-4a57-8753-bcdabe3c484b
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-c78841af-5098-4563-9b54-3735f49b6c0b
+      - req-0cc97d43-1fef-4a57-8753-bcdabe3c484b
       Date:
-      - Mon, 09 Apr 2018 16:27:47 GMT
+      - Thu, 19 Apr 2018 17:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12077,7 +11945,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12092,27 +11960,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6041d70a2cb495fa3a395ccbe23499c
+      - e8611988d76642f1bc75ee553c1886b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de816e7f-13cf-477c-9b73-0c3f5bf8211c
+      - req-e7ca4f9c-fb22-4170-8f7a-81a1d1cc2ebf
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-de816e7f-13cf-477c-9b73-0c3f5bf8211c
+      - req-e7ca4f9c-fb22-4170-8f7a-81a1d1cc2ebf
       Date:
-      - Mon, 09 Apr 2018 16:27:47 GMT
+      - Thu, 19 Apr 2018 17:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12127,27 +11995,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6041d70a2cb495fa3a395ccbe23499c
+      - e8611988d76642f1bc75ee553c1886b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bace390d-b864-447f-9448-55b26fde7f8f
+      - req-df19440e-f61f-4949-92d7-4cabfa36bf21
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bace390d-b864-447f-9448-55b26fde7f8f
+      - req-df19440e-f61f-4949-92d7-4cabfa36bf21
       Date:
-      - Mon, 09 Apr 2018 16:27:48 GMT
+      - Thu, 19 Apr 2018 17:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12162,27 +12030,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4eaade29f6814a9ab80ace517409b39a
+      - e082a447f7f14d35b093ee142c076c47
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ea0269c3-3b61-4ae3-b2eb-a05e5c0e78bd
+      - req-1719b6d5-f29c-4493-8d5b-28755545d5c6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ea0269c3-3b61-4ae3-b2eb-a05e5c0e78bd
+      - req-1719b6d5-f29c-4493-8d5b-28755545d5c6
       Date:
-      - Mon, 09 Apr 2018 16:27:48 GMT
+      - Thu, 19 Apr 2018 17:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12197,27 +12065,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4eaade29f6814a9ab80ace517409b39a
+      - e082a447f7f14d35b093ee142c076c47
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6923d8c-0282-427a-86af-642b710bf681
+      - req-b5693d8f-166a-4b73-a168-784172ad0f9e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b6923d8c-0282-427a-86af-642b710bf681
+      - req-b5693d8f-166a-4b73-a168-784172ad0f9e
       Date:
-      - Mon, 09 Apr 2018 16:27:48 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12232,27 +12100,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e7646313a8f43d9ad386b84d4904479
+      - a725346699da4116bc4e548743aa8649
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-773b2274-6d46-45e5-a637-9c7b1dda6f9f
+      - req-b59d6266-b785-44cf-adf9-c01f21cdc8a7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-773b2274-6d46-45e5-a637-9c7b1dda6f9f
+      - req-b59d6266-b785-44cf-adf9-c01f21cdc8a7
       Date:
-      - Mon, 09 Apr 2018 16:27:48 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12267,27 +12135,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e7646313a8f43d9ad386b84d4904479
+      - a725346699da4116bc4e548743aa8649
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-078c24e7-c83c-4e5a-9297-9020d22ab458
+      - req-67b47f9b-8b2d-4d45-98e1-6db54c7d8868
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-078c24e7-c83c-4e5a-9297-9020d22ab458
+      - req-67b47f9b-8b2d-4d45-98e1-6db54c7d8868
       Date:
-      - Mon, 09 Apr 2018 16:27:48 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12302,27 +12170,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75c608122e1f4fc98c78191d32b92265
+      - 81813c2e8b0d48b88cd72c993f3d4b86
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0870c61d-0f65-4c98-a1a5-96ac973eb489
+      - req-4b7f8552-5e3b-439e-8afb-baa8137d047e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0870c61d-0f65-4c98-a1a5-96ac973eb489
+      - req-4b7f8552-5e3b-439e-8afb-baa8137d047e
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12337,27 +12205,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75c608122e1f4fc98c78191d32b92265
+      - 81813c2e8b0d48b88cd72c993f3d4b86
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76b1a2f4-6a05-4b15-8947-2331c34de120
+      - req-7d8466fa-7e43-4d82-8a23-1c4e6d8124fb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-76b1a2f4-6a05-4b15-8947-2331c34de120
+      - req-7d8466fa-7e43-4d82-8a23-1c4e6d8124fb
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12372,27 +12240,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8919f57563144beace43e1b1856df6a
+      - 897df36b58f9483589a2592fc0771dc0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-488e9e98-fac7-4782-ae39-07cbe394f06c
+      - req-13594a1b-204c-47c6-ac26-e19de65f9bf6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-488e9e98-fac7-4782-ae39-07cbe394f06c
+      - req-13594a1b-204c-47c6-ac26-e19de65f9bf6
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12407,27 +12275,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8919f57563144beace43e1b1856df6a
+      - 897df36b58f9483589a2592fc0771dc0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46f155eb-5985-4062-aaab-825ce8aab29c
+      - req-78cd65b3-33cd-4f47-9149-bea8caf3f1af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-46f155eb-5985-4062-aaab-825ce8aab29c
+      - req-78cd65b3-33cd-4f47-9149-bea8caf3f1af
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -12442,27 +12310,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c4faf39086b4508884331ee168babce
+      - 54c7bce6ea8b49388092b5307808b39e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac466a5c-3965-4ffb-a743-16318de07bcb
+      - req-10d4141d-50bb-4f39-9872-74aa5eafd179
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ac466a5c-3965-4ffb-a743-16318de07bcb
+      - req-10d4141d-50bb-4f39-9872-74aa5eafd179
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -12477,27 +12345,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c4faf39086b4508884331ee168babce
+      - 54c7bce6ea8b49388092b5307808b39e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ff3d948c-227e-4e55-bf95-e47c8f2d75f6
+      - req-ae975b53-b1dc-424d-b802-445585b84ee0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ff3d948c-227e-4e55-bf95-e47c8f2d75f6
+      - req-ae975b53-b1dc-424d-b802-445585b84ee0
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -12512,27 +12380,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d541dee-285c-4f2d-afb0-cf3220ef0185
+      - req-b821341f-7683-47e6-b335-c407bc5da9f0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1d541dee-285c-4f2d-afb0-cf3220ef0185
+      - req-b821341f-7683-47e6-b335-c407bc5da9f0
       Date:
-      - Mon, 09 Apr 2018 16:27:49 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -12547,27 +12415,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fcb63abbbcd5413ea1a1164b070c3aa3
+      - 30a36332330f455d97fbe06c07ac317b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c984243a-3554-4a64-b0ba-08a98c66ab13
+      - req-02f0ac3f-eec1-47a3-948a-3c68bab70fd6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c984243a-3554-4a64-b0ba-08a98c66ab13
+      - req-02f0ac3f-eec1-47a3-948a-3c68bab70fd6
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -12582,27 +12450,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6041d70a2cb495fa3a395ccbe23499c
+      - e8611988d76642f1bc75ee553c1886b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48c4491c-3254-4597-9a27-2edb420b6285
+      - req-becc08ca-0f90-4acf-a023-47ae45fa1124
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-48c4491c-3254-4597-9a27-2edb420b6285
+      - req-becc08ca-0f90-4acf-a023-47ae45fa1124
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -12617,27 +12485,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6041d70a2cb495fa3a395ccbe23499c
+      - e8611988d76642f1bc75ee553c1886b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08bce47c-c207-4f82-b6e0-c16748e46082
+      - req-b77cd620-c54a-4352-9232-3427a93549da
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-08bce47c-c207-4f82-b6e0-c16748e46082
+      - req-b77cd620-c54a-4352-9232-3427a93549da
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -12652,27 +12520,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4eaade29f6814a9ab80ace517409b39a
+      - e082a447f7f14d35b093ee142c076c47
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be9d2be2-f338-4add-8f7c-821322ec05ce
+      - req-f2b8f012-09a6-45b6-b347-95d8bdfe153a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-be9d2be2-f338-4add-8f7c-821322ec05ce
+      - req-f2b8f012-09a6-45b6-b347-95d8bdfe153a
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -12687,27 +12555,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4eaade29f6814a9ab80ace517409b39a
+      - e082a447f7f14d35b093ee142c076c47
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c57c8dc6-f170-48dc-8482-e390eac0ac4b
+      - req-6a23f264-13c7-4a86-9487-144a4de9672f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c57c8dc6-f170-48dc-8482-e390eac0ac4b
+      - req-6a23f264-13c7-4a86-9487-144a4de9672f
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -12722,27 +12590,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e7646313a8f43d9ad386b84d4904479
+      - a725346699da4116bc4e548743aa8649
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f724f6d-7302-42bb-ab61-c8a9aec7b9ed
+      - req-803d9a49-6983-4f19-a89c-e2d12841679f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8f724f6d-7302-42bb-ab61-c8a9aec7b9ed
+      - req-803d9a49-6983-4f19-a89c-e2d12841679f
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -12757,27 +12625,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e7646313a8f43d9ad386b84d4904479
+      - a725346699da4116bc4e548743aa8649
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c267758-a5c3-4da4-996d-3b615105a9ce
+      - req-b858283a-0d82-4421-bf93-17d2a40b898b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6c267758-a5c3-4da4-996d-3b615105a9ce
+      - req-b858283a-0d82-4421-bf93-17d2a40b898b
       Date:
-      - Mon, 09 Apr 2018 16:27:50 GMT
+      - Thu, 19 Apr 2018 17:37:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -12792,27 +12660,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75c608122e1f4fc98c78191d32b92265
+      - 81813c2e8b0d48b88cd72c993f3d4b86
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-106014b9-8617-4a19-9328-9ea9913510e0
+      - req-13382eb1-174f-4a8a-b61b-fc5b9ce14f5c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-106014b9-8617-4a19-9328-9ea9913510e0
+      - req-13382eb1-174f-4a8a-b61b-fc5b9ce14f5c
       Date:
-      - Mon, 09 Apr 2018 16:27:51 GMT
+      - Thu, 19 Apr 2018 17:37:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -12827,27 +12695,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75c608122e1f4fc98c78191d32b92265
+      - 81813c2e8b0d48b88cd72c993f3d4b86
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18540150-65f0-4dba-bc37-aa1422bf558e
+      - req-0a4527f1-f3a1-44f9-923e-0b746e1abf29
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-18540150-65f0-4dba-bc37-aa1422bf558e
+      - req-0a4527f1-f3a1-44f9-923e-0b746e1abf29
       Date:
-      - Mon, 09 Apr 2018 16:27:51 GMT
+      - Thu, 19 Apr 2018 17:37:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12865,15 +12733,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:51 GMT
+      - Thu, 19 Apr 2018 17:37:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 107d6ce6eb3a452cb509d83d580b7204
+      - 3b9303e9380741eabf775db6d772f8be
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f678a15-2f8e-4df2-8c2d-7b6c898081e1
+      - req-97e3c0d5-04e4-46c8-a487-64485503e50a
       Content-Length:
       - '7311'
       Connection:
@@ -12885,7 +12753,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:27:51.660700Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:43.026199Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12964,10 +12832,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6Dvq1znHTvalqFpI1z1hyw"],
-        "issued_at": "2018-04-09T16:27:51.660805Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HsOZyRFNRGCJ4Z6kQWhT9A"],
+        "issued_at": "2018-04-19T17:37:43.026297Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12985,15 +12853,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:51 GMT
+      - Thu, 19 Apr 2018 17:37:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 51d4fd5bdd5e433c8ccbb98ac1cbe818
+      - fd5d099d4f274b0e95df52910caefdbc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f622c26d-8cef-4872-b6b8-117fe78ebd4f
+      - req-f0360d81-4ad5-4986-9256-a5151d291c3a
       Content-Length:
       - '7311'
       Connection:
@@ -13005,7 +12873,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-04-09T17:27:52.151750Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-04-19T18:37:43.445025Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13084,10 +12952,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H0auVe5PRpKZpk92gs-kdw"],
-        "issued_at": "2018-04-09T16:27:52.151856Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wBfFFt6MR7uWokNzLQNHDw"],
+        "issued_at": "2018-04-19T17:37:43.445095Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13105,15 +12973,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:52 GMT
+      - Thu, 19 Apr 2018 17:37:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7aea9605fc424fd982d3f32848f66a16
+      - 7e10ba39d9a246b7a0d27058caf9c2b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78670ee6-e309-4d9e-be7c-d538ce042b85
+      - req-55fd8876-4cfa-4b7d-9c35-2dc1c2e7f99c
       Content-Length:
       - '297'
       Connection:
@@ -13122,12 +12990,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-09T17:27:52.425544Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-04-19T18:37:43.727442Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7uVUGQodSlW4HYphzIaj5Q"],
-        "issued_at": "2018-04-09T16:27:52.425603Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bKBmLULDTj2Abq27u1oVIw"],
+        "issued_at": "2018-04-19T17:37:43.727500Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -13142,20 +13010,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7aea9605fc424fd982d3f32848f66a16
+      - 7e10ba39d9a246b7a0d27058caf9c2b7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:52 GMT
+      - Thu, 19 Apr 2018 17:37:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-686e727a-67aa-42fe-baa5-0a30a7cd4712
+      - req-00d34603-de07-48b4-9181-2e25369a4ca5
       Content-Length:
       - '2457'
       Connection:
@@ -13188,13 +13056,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7aea9605fc424fd982d3f32848f66a16"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7e10ba39d9a246b7a0d27058caf9c2b7"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13206,15 +13074,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:52 GMT
+      - Thu, 19 Apr 2018 17:37:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 212cfd1676984212a2b8b763be948b42
+      - 847b8f3e584a449f94c9cc32bb5302a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f8ee446f-496c-4730-9204-24f59025a45b
+      - req-a9e546f6-50c4-41c0-98ac-e906c5f92482
       Content-Length:
       - '7313'
       Connection:
@@ -13226,7 +13094,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:52.425544Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:43.727442Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13305,10 +13173,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UQynVeBBS8u6JKwMzu9M4A",
-        "7uVUGQodSlW4HYphzIaj5Q"], "issued_at": "2018-04-09T16:27:52.997529Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["enJDdrVWTiW4_N3u_gujmg",
+        "bKBmLULDTj2Abq27u1oVIw"], "issued_at": "2018-04-19T17:37:44.113613Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -13323,20 +13191,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 212cfd1676984212a2b8b763be948b42
+      - 847b8f3e584a449f94c9cc32bb5302a6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:53 GMT
+      - Thu, 19 Apr 2018 17:37:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-320cfb58-f91e-45e4-8df3-f6acc1b67e0e
+      - req-4acac55a-fd93-4b54-acf9-6515b00bf16e
       Content-Length:
       - '2179'
       Connection:
@@ -13369,7 +13237,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13387,15 +13255,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:53 GMT
+      - Thu, 19 Apr 2018 17:37:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 49590c867e604c51a5ff38fe053265c6
+      - f302d587f713491f81ca1073444e96f7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-953de0ce-a492-4136-a1be-51fb32b722b4
+      - req-5b4e0cfb-8376-46fe-b16a-78d5a3a030c5
       Content-Length:
       - '7278'
       Connection:
@@ -13407,7 +13275,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:53.493303Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:44.628301Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13486,10 +13354,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CGDKySeiSau2GTPEJHEdaA"],
-        "issued_at": "2018-04-09T16:27:53.493372Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IhZ0lOOOR6C3gzmkxxHBxA"],
+        "issued_at": "2018-04-19T17:37:44.628370Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13507,15 +13375,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:53 GMT
+      - Thu, 19 Apr 2018 17:37:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ce18a60995c447eb4faced865bbd69e
+      - 67dfbc6d4ac24fc087b233bdcec009c0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0c9f1a02-4003-4ac4-9206-5f82df4946cd
+      - req-62cfc14a-da50-47f5-aecd-8a2388c3d34a
       Content-Length:
       - '7278'
       Connection:
@@ -13527,7 +13395,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:53.909012Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:44.963649Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13606,10 +13474,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ag46AFKzQM2-rnO8_lgrZw"],
-        "issued_at": "2018-04-09T16:27:53.909081Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZO9yFnKHRgi2aPaRCiVD_w"],
+        "issued_at": "2018-04-19T17:37:44.963717Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13627,15 +13495,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:54 GMT
+      - Thu, 19 Apr 2018 17:37:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4690e1d238fc4206856cafa422400d10
+      - 9f52b7c4ccc04d8c8a49eb8d77399924
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1059fa2c-7c9a-4eeb-8fb4-1611bae9fed6
+      - req-38d14049-fece-4514-a737-31bb871c8f7c
       Content-Length:
       - '7264'
       Connection:
@@ -13647,7 +13515,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:54.264977Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:45.279683Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13726,10 +13594,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DSCcivd7RHmT6a6Z5Y3tWQ"],
-        "issued_at": "2018-04-09T16:27:54.265050Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wTDTRxjbR_aqehdN62tJrQ"],
+        "issued_at": "2018-04-19T17:37:45.279754Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13747,15 +13615,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:54 GMT
+      - Thu, 19 Apr 2018 17:37:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43bb7e24867d4ead8cf0f8f20db1b974
+      - a4f0101b0626455796434c20a1f80213
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-94304c17-0d54-4f5f-b2a8-8fd9bbe1ba46
+      - req-99f3fbd8-0a33-492d-8d53-6dbdd2b222b8
       Content-Length:
       - '7278'
       Connection:
@@ -13767,7 +13635,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:54.576442Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:45.586734Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13846,10 +13714,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["45uePhKQSp6Ly66Vxg3ZVA"],
-        "issued_at": "2018-04-09T16:27:54.576497Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MfEos0y3S4e8VGLLLXD2CQ"],
+        "issued_at": "2018-04-19T17:37:45.586840Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13867,15 +13735,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:54 GMT
+      - Thu, 19 Apr 2018 17:37:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 28cacfdbf8de468b8a561b49bbd06e06
+      - 63527e10da254faa9f446932b111c6c9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-932e2a25-cfb0-4cc5-ba68-366958141d21
+      - req-2746e417-de61-4cd2-adc8-912bd43d4b3a
       Content-Length:
       - '7265'
       Connection:
@@ -13887,7 +13755,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:54.919583Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:45.882178Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13966,10 +13834,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IYAjRX_7RVWihG1ISfwFtg"],
-        "issued_at": "2018-04-09T16:27:54.919644Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NBv81HAYS8iOFuc7HRkPeg"],
+        "issued_at": "2018-04-19T17:37:45.882247Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13987,15 +13855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:55 GMT
+      - Thu, 19 Apr 2018 17:37:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 11d00a58977744f0a12bf0016b16e4a1
+      - f6b6f79075ba42ed9014f3cf38624b71
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad8fe327-3075-43dc-bf32-37b53e8bf621
+      - req-d5bdf0a1-af03-4501-bf9a-9076989d5c11
       Content-Length:
       - '7278'
       Connection:
@@ -14007,7 +13875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:55.238025Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:46.202652Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14086,10 +13954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_N87Hi0_SKaXp9OToGjQoQ"],
-        "issued_at": "2018-04-09T16:27:55.238093Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uDAulf_ITyqULkwevNw8vA"],
+        "issued_at": "2018-04-19T17:37:46.202730Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14107,15 +13975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:55 GMT
+      - Thu, 19 Apr 2018 17:37:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b123daaec57f4af7996a5696a580d2a3
+      - b6f7cac839ea4a3a8cb1e3002edef57a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cd9dfbca-52ff-42b0-a2c1-39f1d34f685c
+      - req-25b5b10b-1cd9-4e7d-97ef-5548cc41229b
       Content-Length:
       - '7278'
       Connection:
@@ -14127,7 +13995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:55.583257Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:46.554612Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14206,10 +14074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mt3mvPEqQd6gRdR0ZEEMuQ"],
-        "issued_at": "2018-04-09T16:27:55.583322Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BzVTIz6fRLOoxMhLRe9V_g"],
+        "issued_at": "2018-04-19T17:37:46.554679Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -14224,7 +14092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b123daaec57f4af7996a5696a580d2a3
+      - b6f7cac839ea4a3a8cb1e3002edef57a
   response:
     status:
       code: 200
@@ -14237,22 +14105,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291275.81790'
+      - '1524159466.95058'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291275.81790'
+      - '1524159466.95058'
       X-Trans-Id:
-      - tx3a71807b941e49849e733-005acb948b
+      - tx9ec13b6d777b40bb89985-005ad8d3ea
       Date:
-      - Mon, 09 Apr 2018 16:27:55 GMT
+      - Thu, 19 Apr 2018 17:37:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14270,15 +14138,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:55 GMT
+      - Thu, 19 Apr 2018 17:37:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 97dd1ceba0604f86b407792e412f4a25
+      - ff2258ccf159419da5a99a9d2908e93b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-281c42dd-a571-445c-b237-2c3c5cd46ba8
+      - req-234eb6c3-5add-48d8-bd3e-db3ff626fc25
       Content-Length:
       - '7278'
       Connection:
@@ -14290,7 +14158,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:56.176367Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:47.310879Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14369,10 +14237,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_8moLn9kQWqswbvtKIQ70w"],
-        "issued_at": "2018-04-09T16:27:56.176510Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TVkOrTubRuO7ivWdiCYwgw"],
+        "issued_at": "2018-04-19T17:37:47.310960Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -14387,7 +14255,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97dd1ceba0604f86b407792e412f4a25
+      - ff2258ccf159419da5a99a9d2908e93b
   response:
     status:
       code: 200
@@ -14400,22 +14268,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291276.38370'
+      - '1524159467.55502'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291276.38370'
+      - '1524159467.55502'
       X-Trans-Id:
-      - tx1b00fcacc80d438db3bfb-005acb948c
+      - txba27f6ae3ec348b989a2b-005ad8d3eb
       Date:
-      - Mon, 09 Apr 2018 16:27:56 GMT
+      - Thu, 19 Apr 2018 17:37:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14433,15 +14301,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:56 GMT
+      - Thu, 19 Apr 2018 17:37:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-34b15994-733c-4869-8331-e99d3b4eb5c3
+      - req-e5375d63-ed1a-4244-b260-b95253cf9a5b
       Content-Length:
       - '7264'
       Connection:
@@ -14453,7 +14321,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:56.703905Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:47.848303Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14532,10 +14400,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fwCKezBMQTORGbcYo2wySw"],
-        "issued_at": "2018-04-09T16:27:56.703970Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lzTtnG31TxuZjdypdRiRAQ"],
+        "issued_at": "2018-04-19T17:37:47.848375Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -14550,7 +14418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
   response:
     status:
       code: 200
@@ -14579,15 +14447,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txbfb0cc7286d6400d9df72-005acb948c
+      - tx7ba4fcc56d2c41ae8b050-005ad8d3eb
       Date:
-      - Mon, 09 Apr 2018 16:27:56 GMT
+      - Thu, 19 Apr 2018 17:37:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -14602,7 +14470,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
   response:
     status:
       code: 200
@@ -14631,14 +14499,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx834dc50b068a46c59a2d8-005acb948c
+      - txaddee339858b473b89117-005ad8d3ec
       Date:
-      - Mon, 09 Apr 2018 16:27:57 GMT
+      - Thu, 19 Apr 2018 17:37:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14656,15 +14524,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:57 GMT
+      - Thu, 19 Apr 2018 17:37:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 45b84d9a53e54da98b34b692d6ddbbfb
+      - ec66f3268e4745a081d2317da1e85747
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e53e6b86-63f8-46b5-bf1a-6e1e80f46cc5
+      - req-1c91fb94-3003-486e-a743-3997c6ca6002
       Content-Length:
       - '7278'
       Connection:
@@ -14676,7 +14544,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:57.335971Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:48.705439Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14755,10 +14623,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OSbQQtvGRTGwQM1GFk00iQ"],
-        "issued_at": "2018-04-09T16:27:57.336036Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yiJDY3EAQLuNGB5q4QZcCw"],
+        "issued_at": "2018-04-19T17:37:48.705504Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -14773,7 +14641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 45b84d9a53e54da98b34b692d6ddbbfb
+      - ec66f3268e4745a081d2317da1e85747
   response:
     status:
       code: 200
@@ -14786,22 +14654,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291277.53267'
+      - '1524159468.90398'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291277.53267'
+      - '1524159468.90398'
       X-Trans-Id:
-      - txaf0d2d5e2ea14547a2d7e-005acb948d
+      - tx52be1e291acb423daefef-005ad8d3ec
       Date:
-      - Mon, 09 Apr 2018 16:27:57 GMT
+      - Thu, 19 Apr 2018 17:37:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -14816,7 +14684,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51d4fd5bdd5e433c8ccbb98ac1cbe818
+      - fd5d099d4f274b0e95df52910caefdbc
   response:
     status:
       code: 200
@@ -14829,22 +14697,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291277.69765'
+      - '1524159469.06527'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291277.69765'
+      - '1524159469.06527'
       X-Trans-Id:
-      - txcd9c2ba317ff44cd8784a-005acb948d
+      - txca0971b5a5d54504a1cd7-005ad8d3ec
       Date:
-      - Mon, 09 Apr 2018 16:27:57 GMT
+      - Thu, 19 Apr 2018 17:37:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14862,15 +14730,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:57 GMT
+      - Thu, 19 Apr 2018 17:37:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2fe59fb52bfc4517b4d4e368ed6fe518
+      - 7e031fcf13614eac8c8f9213f005fd7a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03b3a06f-f56f-475d-b9bb-df5cd63cbedc
+      - req-05e7a3b7-7750-48f8-a2dd-dbbef7de5055
       Content-Length:
       - '7265'
       Connection:
@@ -14882,7 +14750,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:58.099387Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:49.340581Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14961,10 +14829,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-Wj7mUixTaKfWGfJjMVdHw"],
-        "issued_at": "2018-04-09T16:27:58.099454Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zLt-7AdgTreQKZT4SexaXg"],
+        "issued_at": "2018-04-19T17:37:49.340651Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -14979,7 +14847,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fe59fb52bfc4517b4d4e368ed6fe518
+      - 7e031fcf13614eac8c8f9213f005fd7a
   response:
     status:
       code: 200
@@ -14992,22 +14860,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291278.30313'
+      - '1524159469.54111'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291278.30313'
+      - '1524159469.54111'
       X-Trans-Id:
-      - tx5871e9edb9294cd3aaf52-005acb948e
+      - tx0240329afda24ba0af568-005ad8d3ed
       Date:
-      - Mon, 09 Apr 2018 16:27:58 GMT
+      - Thu, 19 Apr 2018 17:37:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15025,15 +14893,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:27:58 GMT
+      - Thu, 19 Apr 2018 17:37:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d44efe90110148c694dc583d365b81ba
+      - 1ad6482a3ed84c0e94267693452f3040
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d625b06e-bca4-466b-9467-239ce69b2e09
+      - req-d744b146-e0b6-4430-811e-52acba7b6a0a
       Content-Length:
       - '7278'
       Connection:
@@ -15045,7 +14913,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-04-09T17:27:58.609221Z", "project": {"domain": {"id":
+        "expires_at": "2018-04-19T18:37:49.858810Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15124,10 +14992,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DzSaZuAkREa2wQHXXneykg"],
-        "issued_at": "2018-04-09T16:27:58.609284Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jlwpg_R5SAm-LSgttLOuGg"],
+        "issued_at": "2018-04-19T17:37:49.858883Z"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -15142,7 +15010,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d44efe90110148c694dc583d365b81ba
+      - 1ad6482a3ed84c0e94267693452f3040
   response:
     status:
       code: 200
@@ -15155,22 +15023,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291278.79861'
+      - '1524159470.05636'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291278.79861'
+      - '1524159470.05636'
       X-Trans-Id:
-      - tx0540242b150b40469bcad-005acb948e
+      - txb3e843fc9d8c46969fbdf-005ad8d3ed
       Date:
-      - Mon, 09 Apr 2018 16:27:58 GMT
+      - Thu, 19 Apr 2018 17:37:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -15185,7 +15053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
   response:
     status:
       code: 200
@@ -15206,9 +15074,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd45af36c82844bceb4737-005acb948e
+      - txd69c74c03c624f8e8ead7-005ad8d3ee
       Date:
-      - Mon, 09 Apr 2018 16:27:58 GMT
+      - Thu, 19 Apr 2018 17:37:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -15218,7 +15086,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -15233,7 +15101,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
   response:
     status:
       code: 200
@@ -15254,14 +15122,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx742e40358df94b7c8629d-005acb948e
+      - txb3951c16772e46ebaab47-005ad8d3ee
       Date:
-      - Mon, 09 Apr 2018 16:27:59 GMT
+      - Thu, 19 Apr 2018 17:37:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -15276,7 +15144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34d54d4d0f7849a39df699f800eb13f3
+      - ed1eb723a40d4aeba1dde67738d9fb6c
   response:
     status:
       code: 200
@@ -15297,12 +15165,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txeac459383a324e7d85395-005acb948f
+      - tx41078b60609f41d8bf7ca-005ad8d3ee
       Date:
-      - Mon, 09 Apr 2018 16:27:59 GMT
+      - Thu, 19 Apr 2018 17:37:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:27:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:37:50 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:26 GMT
+      - Thu, 19 Apr 2018 17:41:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc3d8b20-7088-4479-8dcb-c5577bc0aee2
+      - req-9565bf4c-87cd-4a5d-927c-2eab46425102
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:26.340266", "expires":
-        "2018-04-09T17:32:26Z", "id": "c8f76b2be1cb421cacc9e69577ecf63b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:07.815174", "expires":
+        "2018-04-19T18:41:07Z", "id": "6bb818ab4fc24084a5bf0d2adc342273", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["56gq3PAERZG2zHAwK2BFgQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4zir6eVvSHSmCbDG464Gzw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:32:26 GMT
+      - Thu, 19 Apr 2018 17:41:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:26 GMT
+      - Thu, 19 Apr 2018 17:41:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fded24ec-25e0-4d54-8db7-8078385454d2
+      - req-35ca2214-ced9-405a-9a96-41ab85407932
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:26.739625", "expires":
-        "2018-04-09T17:32:26Z", "id": "174d3147fc324963a13bf19453bd8362", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:08.164840", "expires":
+        "2018-04-19T18:41:08Z", "id": "6507cd4d2f474589b2bd5dbfe9b825bc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["oGCKYAYxR4eLq9KdeJPPVg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["n65_RsVdRSiCVFfuXaKSOg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174d3147fc324963a13bf19453bd8362
+      - 6507cd4d2f474589b2bd5dbfe9b825bc
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:32:26 GMT
+      - Thu, 19 Apr 2018 17:41:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:26 GMT
+      - Thu, 19 Apr 2018 17:41:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75d5f601-18d6-409c-864e-d9565762aa00
+      - req-789c9cc7-afa5-468f-ae8b-40864bd2c846
       Content-Length:
       - '4170'
       Connection:
@@ -261,10 +261,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:27.077431", "expires":
-        "2018-04-09T17:32:27Z", "id": "fc7d2e48a877479696a9077d4ebf705b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:08.479310", "expires":
+        "2018-04-19T18:41:08Z", "id": "720086014c054d1d81e7ceab25143428", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Fo-f_rByS5eJYCl2XbVuQQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SuIPFOgtSCGfzog5ccVSAw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -309,13 +309,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"fc7d2e48a877479696a9077d4ebf705b"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"720086014c054d1d81e7ceab25143428"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -327,13 +327,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:27 GMT
+      - Thu, 19 Apr 2018 17:41:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37c2749f-d4d7-49e5-9224-40104235a0a1
+      - req-e6fe59bc-d25e-442f-903a-34087c0be5e9
       Content-Length:
       - '4196'
       Connection:
@@ -342,10 +342,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:27.340065", "expires":
-        "2018-04-09T17:32:27Z", "id": "1969df809190443283beedde87fc8dcd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:08.707093", "expires":
+        "2018-04-19T18:41:08Z", "id": "ca64b807884e48d08769610339b0ff51", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["M4cMF8bAS3yZzC6U9YuvDw", "Fo-f_rByS5eJYCl2XbVuQQ"]},
+        "name": "admin"}, "audit_ids": ["LA6L4d4uQIuYSyis0uOtyw", "SuIPFOgtSCGfzog5ccVSAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -390,7 +390,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -408,13 +408,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:27 GMT
+      - Thu, 19 Apr 2018 17:41:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-18379e54-a16f-408b-84d1-cf93ac9879bc
+      - req-e3bea4d6-8aef-40fe-9031-18d97730a2f4
       Content-Length:
       - '4170'
       Connection:
@@ -423,10 +423,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:27.608430", "expires":
-        "2018-04-09T17:32:27Z", "id": "8044216de6654b7dac82c7a5e0bdf1d7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:08.952194", "expires":
+        "2018-04-19T18:41:08Z", "id": "a2c3413caab543c99a245aaa557c51b8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Q2G5DGtiQqOAggTNi24gyw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["cqm8rZfeS_aY6nrcjf6cJg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -471,7 +471,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -486,7 +486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 300
@@ -497,7 +497,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:32:27 GMT
+      - Thu, 19 Apr 2018 17:41:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -510,7 +510,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:27 GMT
+      - Thu, 19 Apr 2018 17:41:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dd6c3dce-58af-4847-9676-54159887a100
+      - req-6a9d0ba9-ca15-440a-ba6b-0e4837c544f4
       Content-Length:
       - '4170'
       Connection:
@@ -543,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:27.952002", "expires":
-        "2018-04-09T17:32:27Z", "id": "2761d1877af042eeafcc974f541b0109", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:09.284136", "expires":
+        "2018-04-19T18:41:09Z", "id": "b40427a9cd0241678eac4c0bf911a9a1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["527Woie2TQ-dV93WF3XGLg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ml0E1R1rRA2XOF3M8qiR0g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -591,7 +591,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -609,13 +609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:28 GMT
+      - Thu, 19 Apr 2018 17:41:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9a8caa2-f61a-413f-9387-e54aedcb622f
+      - req-a20a1177-3d9a-4990-9ec6-f5c4e42972ca
       Content-Length:
       - '4170'
       Connection:
@@ -624,10 +624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:28.278373", "expires":
-        "2018-04-09T17:32:28Z", "id": "562c8e0cfdfd49f38fa5b8c7ac962505", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:09.545113", "expires":
+        "2018-04-19T18:41:09Z", "id": "d850358850034033b0288762a27573f9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["l2tjm9WRSzmpnAEag9LCyQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ylTvbPeOQkm_C-VpLaNIVA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -672,7 +672,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:28 GMT
+      - Thu, 19 Apr 2018 17:41:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dff22358-fc01-41ee-88ad-410210286258
+      - req-66c51be5-e1d6-4128-8342-d377cc28bd0a
       Content-Length:
       - '4170'
       Connection:
@@ -705,10 +705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:28.582376", "expires":
-        "2018-04-09T17:32:28Z", "id": "da8268b8f38546a3bef4cfa007a56800", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:09.795888", "expires":
+        "2018-04-19T18:41:09Z", "id": "95a6956b43c9425887b520106fc8eacb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["PnlLjC3TQwehgW5CVRrWWw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SDp9s9CjRre8g15JYIU8Nw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -753,7 +753,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -771,13 +771,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:28 GMT
+      - Thu, 19 Apr 2018 17:41:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50cef944-b734-4780-a609-abff7e656d6e
+      - req-70d6bc8e-f0b9-41ca-9645-6328c37e4215
       Content-Length:
       - '4170'
       Connection:
@@ -786,10 +786,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:28.884478", "expires":
-        "2018-04-09T17:32:28Z", "id": "72b58872a8034333811fa38cc764a821", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:10.091179", "expires":
+        "2018-04-19T18:41:10Z", "id": "e92b23ff513e4ac9a4cc287e1288bbaf", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["lsKEUM-qTyagQozzgPrizQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GnWEYSTGQh2Nfxpl0msY5A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -834,7 +834,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -852,13 +852,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dc7842b5-e325-4e54-b6e4-71129998f49f
+      - req-7c016d85-bfeb-4bc4-a7c9-6a1825018abb
       Content-Length:
       - '370'
       Connection:
@@ -867,13 +867,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:29.071941", "expires":
-        "2018-04-09T17:32:29Z", "id": "d59b0d4ec3994d34aabf20c4f96ae246", "audit_ids":
-        ["XcNNPiEUQMe7iAHTuQ-AcA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:10.285758", "expires":
+        "2018-04-19T18:41:10Z", "id": "386222964b31469183d8ebfb3cdb55a8", "audit_ids":
+        ["m-QCkjo4QD6idETy9AsMlg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -888,20 +888,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d59b0d4ec3994d34aabf20c4f96ae246
+      - 386222964b31469183d8ebfb3cdb55a8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4e6b552d-1bac-4229-b98b-0ca1c7bf4ca8
+      - req-2e13ba51-f6e0-4ee9-b355-e122237286ac
       Content-Length:
       - '500'
       Connection:
@@ -918,13 +918,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"d59b0d4ec3994d34aabf20c4f96ae246"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"386222964b31469183d8ebfb3cdb55a8"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -936,13 +936,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75bcd13e-c8f8-478b-85c5-f39c89bc6176
+      - req-218cce52-c95b-487b-9f10-737c8c6be925
       Content-Length:
       - '4143'
       Connection:
@@ -951,11 +951,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:29.449049", "expires":
-        "2018-04-09T17:32:29Z", "id": "5a67d1c57f6b43f7a5a911a4fd0c2ca0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:10.662607", "expires":
+        "2018-04-19T18:41:10Z", "id": "0147eacba2a342089af0827f12230885", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HT5VHwfnTjGUgCrPyv06mA",
-        "XcNNPiEUQMe7iAHTuQ-AcA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8Ja_2i9fQ8aCfJX0XmATPw",
+        "m-QCkjo4QD6idETy9AsMlg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -999,7 +999,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1014,20 +1014,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d59b0d4ec3994d34aabf20c4f96ae246
+      - 386222964b31469183d8ebfb3cdb55a8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9343de6d-9192-4878-9a4e-e620a79d9930
+      - req-23d3b737-e0a3-418a-bb71-6ddaae857b63
       Content-Length:
       - '500'
       Connection:
@@ -1044,7 +1044,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1062,13 +1062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1ac95efb-e0c9-4afc-8afd-8512f31534d4
+      - req-535d5c8d-96ef-43cd-94c1-e5823102db90
       Content-Length:
       - '4117'
       Connection:
@@ -1077,10 +1077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:29.898368", "expires":
-        "2018-04-09T17:32:29Z", "id": "ccad399595b14d379273375164c0a7ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:11.035610", "expires":
+        "2018-04-19T18:41:10Z", "id": "a153b28baef44f74b047b93a82f5a6a3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sUlooC0MQ1-xU45yMiVF5g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tsMSUpRnQfi68DyBY3xSUw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1124,7 +1124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1139,7 +1139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccad399595b14d379273375164c0a7ef
+      - a153b28baef44f74b047b93a82f5a6a3
   response:
     status:
       code: 200
@@ -1150,7 +1150,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:32:29 GMT
+      - Thu, 19 Apr 2018 17:41:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1159,7 +1159,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1177,13 +1177,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:30 GMT
+      - Thu, 19 Apr 2018 17:41:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-873427f7-c66a-4485-ba3d-e27d152fa7d9
+      - req-25cfad5c-e5f8-4f2d-ba18-8f33f20bad55
       Content-Length:
       - '4131'
       Connection:
@@ -1192,10 +1192,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:30.242198", "expires":
-        "2018-04-09T17:32:30Z", "id": "00e75e56553c4bcfb73a183f01a64794", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:11.354473", "expires":
+        "2018-04-19T18:41:11Z", "id": "ef201f00017748ac9cf85394a0f964a2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KGeEBrgmT-aL2NmhvyqxKw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CVDZFB7RQU-ChUd7ZUMgFg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1239,7 +1239,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1254,7 +1254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00e75e56553c4bcfb73a183f01a64794
+      - ef201f00017748ac9cf85394a0f964a2
   response:
     status:
       code: 200
@@ -1265,7 +1265,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:32:30 GMT
+      - Thu, 19 Apr 2018 17:41:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1274,7 +1274,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1292,13 +1292,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:30 GMT
+      - Thu, 19 Apr 2018 17:41:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d1494d39-219c-4872-9bda-226b8452917b
+      - req-33f9d16a-7dd0-434b-a465-41d53f48fa62
       Content-Length:
       - '4118'
       Connection:
@@ -1307,10 +1307,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:30.673362", "expires":
-        "2018-04-09T17:32:30Z", "id": "0760809acb504e66b9313f9c7f8d203c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:11.681624", "expires":
+        "2018-04-19T18:41:11Z", "id": "5f89cb22199f43a497f13d13a9e8d57b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5JWJ44FeQGyNdtxcUh6pSQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JgU71cs9Qky13wAdp6beug"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1354,7 +1354,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1369,7 +1369,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0760809acb504e66b9313f9c7f8d203c'
+      - 5f89cb22199f43a497f13d13a9e8d57b
   response:
     status:
       code: 200
@@ -1380,7 +1380,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:32:30 GMT
+      - Thu, 19 Apr 2018 17:41:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1389,7 +1389,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1404,7 +1404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1417,9 +1417,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-cfae36fa-92f8-4935-88a9-78a6af750dbc
+      - req-04a0bd5d-a28a-41b2-b6cb-16596f94e14b
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1433,7 +1433,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1448,7 +1448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1461,9 +1461,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-e0f527d2-1c4b-4627-96f0-a5e627c0448b
+      - req-42f8c672-d823-4dfc-a96c-8086d89eca6d
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1477,7 +1477,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1492,7 +1492,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1505,9 +1505,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-e6b50511-171c-4307-bba4-f960b46ad207
+      - req-ed1de54e-4294-48c1-bf89-452cea456d2b
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1522,7 +1522,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1537,7 +1537,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1550,9 +1550,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-8c1ffc97-264b-44ce-9855-297326209197
+      - req-2d2051c2-267f-4be9-98f9-7ea73bdac5d5
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1562,7 +1562,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1577,7 +1577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1590,15 +1590,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-57646561-82f7-406f-9113-9965da32bfb9
+      - req-941f9c97-25a8-41d4-892d-a5c3bc80a815
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -1613,7 +1613,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1626,15 +1626,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-341759c2-153c-4ce5-ad25-0be716c34a17
+      - req-24cffbf0-b233-49dd-89f6-cbe7c0468cd0
       Date:
-      - Mon, 09 Apr 2018 16:32:31 GMT
+      - Thu, 19 Apr 2018 17:41:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1649,28 +1649,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2761d1877af042eeafcc974f541b0109
+      - b40427a9cd0241678eac4c0bf911a9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b91cc218-c8d9-4b46-97f9-86ce78218d39
+      - req-76738d4a-78ee-4bb1-945a-fbc320f2dd81
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-b91cc218-c8d9-4b46-97f9-86ce78218d39
+      - req-76738d4a-78ee-4bb1-945a-fbc320f2dd81
       Date:
-      - Mon, 09 Apr 2018 16:32:32 GMT
+      - Thu, 19 Apr 2018 17:41:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1685,7 +1685,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1698,14 +1698,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-35533a9a-61cf-467d-b67c-a100b3c3c33a
+      - req-57681931-f92f-436e-a424-77c219535bf6
       Date:
-      - Mon, 09 Apr 2018 16:32:32 GMT
+      - Thu, 19 Apr 2018 17:41:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1720,7 +1720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccad399595b14d379273375164c0a7ef
+      - a153b28baef44f74b047b93a82f5a6a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1733,9 +1733,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f25557e3-0469-42b4-889d-fa255825601f
+      - req-98f41f36-6dd5-48bf-894e-6f95dcdab344
       Date:
-      - Mon, 09 Apr 2018 16:32:32 GMT
+      - Thu, 19 Apr 2018 17:41:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1744,7 +1744,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1759,7 +1759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00e75e56553c4bcfb73a183f01a64794
+      - ef201f00017748ac9cf85394a0f964a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1772,9 +1772,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-807a0c91-869d-49f9-9849-d7ee8e057354
+      - req-d1c6752f-7635-4192-947e-60802d780817
       Date:
-      - Mon, 09 Apr 2018 16:32:32 GMT
+      - Thu, 19 Apr 2018 17:41:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1783,7 +1783,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1798,7 +1798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1811,9 +1811,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-4d1df353-7558-40c3-8e1f-f56b351caab1
+      - req-e718b822-c353-4164-ac59-bc9b5ed54c92
       Date:
-      - Mon, 09 Apr 2018 16:32:33 GMT
+      - Thu, 19 Apr 2018 17:41:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1822,7 +1822,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1837,7 +1837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0760809acb504e66b9313f9c7f8d203c'
+      - 5f89cb22199f43a497f13d13a9e8d57b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1850,9 +1850,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-902c04b9-dd25-48e4-aaf4-fc4fc05d588f
+      - req-4c83010e-734a-4e72-b3ee-da0b0fe4791b
       Date:
-      - Mon, 09 Apr 2018 16:32:33 GMT
+      - Thu, 19 Apr 2018 17:41:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1861,7 +1861,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1879,13 +1879,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:33 GMT
+      - Thu, 19 Apr 2018 17:41:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-584dccf1-1df1-4360-9f84-e1fe84f9256f
+      - req-87be26e8-c137-4d1b-9834-9d572da0da57
       Content-Length:
       - '4117'
       Connection:
@@ -1894,10 +1894,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:33.591846", "expires":
-        "2018-04-09T17:32:33Z", "id": "5c692ab5b2854b0a82e003e34bf35218", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:14.895808", "expires":
+        "2018-04-19T18:41:14Z", "id": "f251783bd7824a95a3f9911816e2abe3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["civoUPggQE-X_grhBpAD-w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WDlg-p4oRRmW1rbFgfJdYw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1941,7 +1941,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1956,22 +1956,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c692ab5b2854b0a82e003e34bf35218
+      - f251783bd7824a95a3f9911816e2abe3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bdd89829-1d8d-4a1f-ab58-04b9f8436ad0
+      - req-e9c10671-bfd1-4649-96e7-14d0f591e74b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bdd89829-1d8d-4a1f-ab58-04b9f8436ad0
+      - req-e9c10671-bfd1-4649-96e7-14d0f591e74b
       Date:
-      - Mon, 09 Apr 2018 16:32:34 GMT
+      - Thu, 19 Apr 2018 17:41:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1981,7 +1981,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1999,13 +1999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:34 GMT
+      - Thu, 19 Apr 2018 17:41:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0fb1fd83-0d92-4b27-a6c2-41fd79183d2b
+      - req-3d15cc5c-f572-495a-8893-399f3f6c776c
       Content-Length:
       - '4131'
       Connection:
@@ -2014,10 +2014,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:34.599083", "expires":
-        "2018-04-09T17:32:34Z", "id": "782d7138c277419f8b11992903d3a4a6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:16.118685", "expires":
+        "2018-04-19T18:41:16Z", "id": "646684a4d74940a48861a4a0b541e6e3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mwgXcuczR_-6X9amh5DHoQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["M0tiNJXMRiiFZ9THkllO4Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2061,7 +2061,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2076,22 +2076,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 782d7138c277419f8b11992903d3a4a6
+      - 646684a4d74940a48861a4a0b541e6e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-56949df4-b22a-483f-b9e8-651b6346098b
+      - req-3ffa68f0-612d-42c8-91bd-05155366504c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-56949df4-b22a-483f-b9e8-651b6346098b
+      - req-3ffa68f0-612d-42c8-91bd-05155366504c
       Date:
-      - Mon, 09 Apr 2018 16:32:35 GMT
+      - Thu, 19 Apr 2018 17:41:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2101,7 +2101,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2116,22 +2116,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2761d1877af042eeafcc974f541b0109
+      - b40427a9cd0241678eac4c0bf911a9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a79c2a6d-645c-4ae9-b699-9e8161c84315
+      - req-e8c97614-220a-4f0d-b4a2-2ce970097bd1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a79c2a6d-645c-4ae9-b699-9e8161c84315
+      - req-e8c97614-220a-4f0d-b4a2-2ce970097bd1
       Date:
-      - Mon, 09 Apr 2018 16:32:35 GMT
+      - Thu, 19 Apr 2018 17:41:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2141,7 +2141,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2159,13 +2159,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:35 GMT
+      - Thu, 19 Apr 2018 17:41:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5fefb62d-5dfd-4304-ae75-0f47780e8340
+      - req-f157e111-d728-4b15-b985-f89553396c27
       Content-Length:
       - '4118'
       Connection:
@@ -2174,10 +2174,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:36.132271", "expires":
-        "2018-04-09T17:32:36Z", "id": "dba6750b69514dfeb6d3eaba05391a4e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:17.952378", "expires":
+        "2018-04-19T18:41:17Z", "id": "21bc067fed3044ea92253abfd9c5ebbc", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QuDwYTyqQ-etmUytagJOfg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rDxX-dqEQyqrk2DocIkQzg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2221,7 +2221,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2236,22 +2236,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dba6750b69514dfeb6d3eaba05391a4e
+      - 21bc067fed3044ea92253abfd9c5ebbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-20adf78f-ec3e-4cca-bbe1-db3c673c137e
+      - req-ae2e0fcf-f884-479d-8f83-d0c56c2d602a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-20adf78f-ec3e-4cca-bbe1-db3c673c137e
+      - req-ae2e0fcf-f884-479d-8f83-d0c56c2d602a
       Date:
-      - Mon, 09 Apr 2018 16:32:36 GMT
+      - Thu, 19 Apr 2018 17:41:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2261,7 +2261,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2279,13 +2279,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:37 GMT
+      - Thu, 19 Apr 2018 17:41:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-870fd083-03bd-44bd-8c86-a0419fad3873
+      - req-2687554c-23d2-452e-93db-c84b7f6abb5a
       Content-Length:
       - '4117'
       Connection:
@@ -2294,10 +2294,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:37.182837", "expires":
-        "2018-04-09T17:32:37Z", "id": "0186aaf142e543259ae04f07a67fcd30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:18.941571", "expires":
+        "2018-04-19T18:41:18Z", "id": "a8d293bc3260469ebcd45eeac0a166a2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zOwlqIKgQH6bhHD_L7pjKg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WvpcM7MPRZ-CxE-V36s3nw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2341,7 +2341,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0186aaf142e543259ae04f07a67fcd30'
+      - a8d293bc3260469ebcd45eeac0a166a2
   response:
     status:
       code: 200
@@ -2367,16 +2367,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c53ccaea-7372-4916-ae1a-079dd10809de
+      - req-eb533027-a270-43cb-9de1-28d2552eec12
       Date:
-      - Mon, 09 Apr 2018 16:32:37 GMT
+      - Thu, 19 Apr 2018 17:41:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2394,13 +2394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:37 GMT
+      - Thu, 19 Apr 2018 17:41:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-42daa7e9-4a00-491c-9903-049abd103f97
+      - req-b692b8dc-6665-489e-9701-8e2bc443bbaf
       Content-Length:
       - '4131'
       Connection:
@@ -2409,10 +2409,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:37.702087", "expires":
-        "2018-04-09T17:32:37Z", "id": "082070b5b08646a6b00e5c4fca84da6f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:19.544876", "expires":
+        "2018-04-19T18:41:19Z", "id": "e2122beb71c24f5bacfa61114f61fc07", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nHwF6OgYScmpAqKA8gqc3g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7v_7yvt3TiahxhVPfirT1g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2456,7 +2456,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2471,7 +2471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '082070b5b08646a6b00e5c4fca84da6f'
+      - e2122beb71c24f5bacfa61114f61fc07
   response:
     status:
       code: 200
@@ -2482,16 +2482,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3d2fc8a6-3f76-4464-9af8-50335f5fbd6d
+      - req-aac6664f-caff-47cf-94ba-19da3e2800b1
       Date:
-      - Mon, 09 Apr 2018 16:32:37 GMT
+      - Thu, 19 Apr 2018 17:41:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2506,7 +2506,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174d3147fc324963a13bf19453bd8362
+      - 6507cd4d2f474589b2bd5dbfe9b825bc
   response:
     status:
       code: 200
@@ -2517,16 +2517,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b661ba98-2300-4931-831a-548ff544ace8
+      - req-e33cc597-d212-48c2-b414-8380a14ac9c3
       Date:
-      - Mon, 09 Apr 2018 16:32:38 GMT
+      - Thu, 19 Apr 2018 17:41:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2544,13 +2544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:38 GMT
+      - Thu, 19 Apr 2018 17:41:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0d90ec74-5632-4217-b27c-c58a0886fd42
+      - req-3e697055-8ba3-41a3-a168-dfa4eff163c2
       Content-Length:
       - '4118'
       Connection:
@@ -2559,10 +2559,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:38.703087", "expires":
-        "2018-04-09T17:32:38Z", "id": "0ca021fbe46b4fd8b1d8ec2ab8576b1e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:20.552642", "expires":
+        "2018-04-19T18:41:20Z", "id": "dba9749dc8fe4076a5fdbd76b05689c2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DHLuXI-NRdSN-nWBNVH0ng"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["fe90a4FyS1-fm6NjQ75f_g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2606,7 +2606,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ca021fbe46b4fd8b1d8ec2ab8576b1e
+      - dba9749dc8fe4076a5fdbd76b05689c2
   response:
     status:
       code: 200
@@ -2632,16 +2632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a39932ef-658c-4369-8f87-86a6ce70782d
+      - req-d2fb7119-c6de-4572-bbb9-9384248962b5
       Date:
-      - Mon, 09 Apr 2018 16:32:38 GMT
+      - Thu, 19 Apr 2018 17:41:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2656,7 +2656,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2669,9 +2669,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2f353a69-920f-4967-ad99-bd3d363fadcd
+      - req-6bc521dc-00c5-499b-84ae-c61c51832aa1
       Date:
-      - Mon, 09 Apr 2018 16:32:39 GMT
+      - Thu, 19 Apr 2018 17:41:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2681,7 +2681,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2696,7 +2696,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2709,9 +2709,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-4df430c9-5878-4014-a065-2380c3814b6f
+      - req-ad269932-5bdd-4672-98c1-b72a23a99ea5
       Date:
-      - Mon, 09 Apr 2018 16:32:39 GMT
+      - Thu, 19 Apr 2018 17:41:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2721,7 +2721,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2739,13 +2739,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:39 GMT
+      - Thu, 19 Apr 2018 17:41:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b2b76317-1ea1-499c-b852-ae5946095d7b
+      - req-e206797e-c1ba-4795-ba71-748b219a1837
       Content-Length:
       - '4117'
       Connection:
@@ -2754,10 +2754,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:39.432359", "expires":
-        "2018-04-09T17:32:39Z", "id": "859122fa7d5c48a6a99f954399d1f5a8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:21.220483", "expires":
+        "2018-04-19T18:41:21Z", "id": "53a837c09100431893567de7f1c583f2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8-Mu7OWNTg-XLNY8Ghuwrw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0cIzfNX0TVKiwlkqMtixEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2801,7 +2801,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2816,7 +2816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -2827,9 +2827,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-7704b92c-778f-43d6-a667-44c0afc01ade
+      - req-4f73fdd8-ed60-4418-bcd4-1eade61bc356
       Date:
-      - Mon, 09 Apr 2018 16:32:39 GMT
+      - Thu, 19 Apr 2018 17:41:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2863,7 +2863,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2878,7 +2878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -2889,14 +2889,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5d96e345-2a8a-4664-80e2-1f412409a65b
+      - req-e3d24765-338b-4827-b6bf-5df2dc68a1e3
       Date:
-      - Mon, 09 Apr 2018 16:32:39 GMT
+      - Thu, 19 Apr 2018 17:41:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2914,13 +2914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:40 GMT
+      - Thu, 19 Apr 2018 17:41:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0c5f888-37c7-4827-99af-3e0d8ab96a65
+      - req-9f47cf12-7c62-4056-b712-c5fe5832e36d
       Content-Length:
       - '4131'
       Connection:
@@ -2929,10 +2929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:40.204422", "expires":
-        "2018-04-09T17:32:40Z", "id": "0788bfae6c4e41c4a9d613e04a7007a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:22.236473", "expires":
+        "2018-04-19T18:41:22Z", "id": "35ce957ffa31449a83bc15aa3a1b9c24", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eTWQvCiZQ36lAez4efNMZg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xJee-OAlTQWwkRGmBn5a-w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2976,7 +2976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2991,7 +2991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0788bfae6c4e41c4a9d613e04a7007a5'
+      - 35ce957ffa31449a83bc15aa3a1b9c24
   response:
     status:
       code: 200
@@ -3002,14 +3002,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4af82253-0ced-4ae4-874c-fa5f83758c74
+      - req-2ab25ed7-b818-4303-961c-b460ea332787
       Date:
-      - Mon, 09 Apr 2018 16:32:40 GMT
+      - Thu, 19 Apr 2018 17:41:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3024,7 +3024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72b58872a8034333811fa38cc764a821
+      - e92b23ff513e4ac9a4cc287e1288bbaf
   response:
     status:
       code: 200
@@ -3035,14 +3035,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-17c7e766-58b7-4eea-ae2a-67a916807e7c
+      - req-0f0263e3-72e7-41f6-bbc4-a46d8a4a39b5
       Date:
-      - Mon, 09 Apr 2018 16:32:40 GMT
+      - Thu, 19 Apr 2018 17:41:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3060,13 +3060,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:41 GMT
+      - Thu, 19 Apr 2018 17:41:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5e0fa420-c14b-48f4-8937-a9632149a6d2
+      - req-b9972566-3d37-4507-b606-d011e5eee1af
       Content-Length:
       - '4118'
       Connection:
@@ -3075,10 +3075,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:41.246642", "expires":
-        "2018-04-09T17:32:41Z", "id": "728b0fd6feba4410a45b2881a10606f2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:23.088954", "expires":
+        "2018-04-19T18:41:23Z", "id": "7edc8bdfe9c348328ae3b2b599c8f5f2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Cdy7omdbS0ShoAh57v_3Fg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["22iaW2hLRN-Uu6Ivl62YKw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3122,7 +3122,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3137,7 +3137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 728b0fd6feba4410a45b2881a10606f2
+      - 7edc8bdfe9c348328ae3b2b599c8f5f2
   response:
     status:
       code: 200
@@ -3148,14 +3148,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f3f4b9ac-e51e-4241-839c-d453b6d37a10
+      - req-8773fa4c-fce3-4687-9347-605232135bed
       Date:
-      - Mon, 09 Apr 2018 16:32:41 GMT
+      - Thu, 19 Apr 2018 17:41:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3170,7 +3170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3181,9 +3181,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e04f1967-2ddc-450d-9c94-fe7f767d7477
+      - req-658c181e-82c8-4bf0-977f-ce9539239e80
       Date:
-      - Mon, 09 Apr 2018 16:32:42 GMT
+      - Thu, 19 Apr 2018 17:41:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3210,7 +3210,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3225,7 +3225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3236,9 +3236,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0db2e9d1-ab04-43f6-80d4-3325f48a0a93
+      - req-548fc96c-4d05-44de-ada0-56cc244b50ba
       Date:
-      - Mon, 09 Apr 2018 16:32:43 GMT
+      - Thu, 19 Apr 2018 17:41:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3265,7 +3265,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3280,7 +3280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3291,9 +3291,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-04ac6bb9-592e-4b3e-8679-aa97b6bf4258
+      - req-80189702-93c5-4508-91b7-51a85ec633b3
       Date:
-      - Mon, 09 Apr 2018 16:32:44 GMT
+      - Thu, 19 Apr 2018 17:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3320,7 +3320,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3335,7 +3335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3346,9 +3346,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5831539c-a711-4bb6-bb03-475d028a8814
+      - req-e7100f4a-80ab-4cab-a55c-518eb69d74aa
       Date:
-      - Mon, 09 Apr 2018 16:32:44 GMT
+      - Thu, 19 Apr 2018 17:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3360,7 +3360,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3375,7 +3375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3386,9 +3386,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d7df0c86-b884-4798-85cc-3e03e75609a0
+      - req-c2c02ab9-2680-474b-8ab7-3317aeb7ba8b
       Date:
-      - Mon, 09 Apr 2018 16:32:44 GMT
+      - Thu, 19 Apr 2018 17:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3444,7 +3444,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3459,7 +3459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3470,9 +3470,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ea810668-1f8d-45b4-a5fb-8440f09a0c55
+      - req-f121bcc1-c5bc-4ecf-9123-69579a1163dd
       Date:
-      - Mon, 09 Apr 2018 16:32:45 GMT
+      - Thu, 19 Apr 2018 17:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3484,7 +3484,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3510,9 +3510,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-dfe060f9-bed0-41ba-adae-98e5690ebb32
+      - req-6db193db-66c2-4cd3-b164-f86105fd747c
       Date:
-      - Mon, 09 Apr 2018 16:32:45 GMT
+      - Thu, 19 Apr 2018 17:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3568,7 +3568,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3583,7 +3583,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3594,9 +3594,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1e20dafd-4df9-4b07-bc0b-c5ef36daf6e4
+      - req-cd511462-020a-4c36-875b-728de12378f4
       Date:
-      - Mon, 09 Apr 2018 16:32:45 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3608,7 +3608,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3623,7 +3623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 859122fa7d5c48a6a99f954399d1f5a8
+      - 53a837c09100431893567de7f1c583f2
   response:
     status:
       code: 200
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-062ec2bc-d03e-437a-8576-7fd21b1ee063
+      - req-35402bad-51fc-4e53-bdef-ac7f5c3dadb7
       Date:
-      - Mon, 09 Apr 2018 16:32:45 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3692,7 +3692,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3707,7 +3707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3718,14 +3718,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8b53a8ad-9ae1-4d18-a4f5-3f948a11fa99
+      - req-fdd81aa3-b117-4410-8652-f57b64dbe889
       Date:
-      - Mon, 09 Apr 2018 16:32:45 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3751,9 +3751,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-98e501f6-57bb-4d2e-aeda-103f5248fb2f
+      - req-2967efdf-6d26-476f-aecd-16132065069f
       Date:
-      - Mon, 09 Apr 2018 16:32:46 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3795,7 +3795,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3810,7 +3810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3821,14 +3821,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6f7a0c6d-e9b9-47f8-ac84-2ffdf213e197
+      - req-ae3ad079-4a6c-4828-b676-d76a5d97b4dc
       Date:
-      - Mon, 09 Apr 2018 16:32:46 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3843,7 +3843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3854,14 +3854,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-904585ae-4587-479b-9d70-8e832fc2c349
+      - req-165caccc-f56d-4920-ae06-ceb2db389941
       Date:
-      - Mon, 09 Apr 2018 16:32:46 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3887,14 +3887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-780e3cb3-c3d2-4616-a2e4-06968fb4be01
+      - req-18c97f68-55a9-471e-8146-9e1b0cfbaf57
       Date:
-      - Mon, 09 Apr 2018 16:32:46 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3909,7 +3909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8044216de6654b7dac82c7a5e0bdf1d7
+      - a2c3413caab543c99a245aaa557c51b8
   response:
     status:
       code: 200
@@ -3920,14 +3920,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-64c60b20-e159-43f9-a5b0-aaab8ebd875a
+      - req-2fff5d58-56e8-491d-a368-16ef2b56b65d
       Date:
-      - Mon, 09 Apr 2018 16:32:46 GMT
+      - Thu, 19 Apr 2018 17:41:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3942,7 +3942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3955,9 +3955,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-fd8f80e4-ec1e-470f-a5fb-f8585b943c4b
+      - req-7e9965b3-fc29-486a-a18d-80679b13b98f
       Date:
-      - Mon, 09 Apr 2018 16:32:47 GMT
+      - Thu, 19 Apr 2018 17:41:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -4003,7 +4003,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -4018,7 +4018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4031,9 +4031,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-a2dc63b8-200f-4dbe-946a-2505731ec646
+      - req-422e8475-03e0-4687-8cec-3409aeec6f7b
       Date:
-      - Mon, 09 Apr 2018 16:32:47 GMT
+      - Thu, 19 Apr 2018 17:41:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -4079,7 +4079,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -4094,7 +4094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4107,9 +4107,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-637c0f84-e69b-4d93-8705-bff9e22ba449
+      - req-210ad582-41c7-43ca-9b1a-4cb3c865d6ae
       Date:
-      - Mon, 09 Apr 2018 16:32:48 GMT
+      - Thu, 19 Apr 2018 17:41:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -4157,7 +4157,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4172,7 +4172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4185,9 +4185,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-f07cd378-fc9c-4c29-b353-6788e394aeef
+      - req-75c77a5e-2ed4-448a-978a-3e6655cffa14
       Date:
-      - Mon, 09 Apr 2018 16:32:49 GMT
+      - Thu, 19 Apr 2018 17:41:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4229,7 +4229,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4244,7 +4244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4257,9 +4257,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-855e0809-64d0-42ba-9d82-6865cd6ae4dc
+      - req-4c1fbb1a-9d0e-4c78-af58-82fd3ed5ce86
       Date:
-      - Mon, 09 Apr 2018 16:32:49 GMT
+      - Thu, 19 Apr 2018 17:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4282,7 +4282,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4297,7 +4297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4310,14 +4310,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-1ed154bf-1562-40f9-9e60-18dc45cc86ff
+      - req-900df42d-48c8-4ae1-acea-e87b4c78f30b
       Date:
-      - Mon, 09 Apr 2018 16:32:50 GMT
+      - Thu, 19 Apr 2018 17:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4332,7 +4332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4345,14 +4345,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-35d9167e-bdb6-4986-ba83-29f23299faf4
+      - req-03a0df4f-caa6-4a8d-af12-cfb0903dd5c6
       Date:
-      - Mon, 09 Apr 2018 16:32:50 GMT
+      - Thu, 19 Apr 2018 17:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4367,7 +4367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4380,14 +4380,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-599d495f-329a-4417-98c3-b71b98798ff0
+      - req-53b4500b-a5f5-4cc1-8164-efe72fdefb7f
       Date:
-      - Mon, 09 Apr 2018 16:32:50 GMT
+      - Thu, 19 Apr 2018 17:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4402,7 +4402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4415,14 +4415,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0e9f59bf-226a-4bcb-bb90-3029cc261947
+      - req-13685a48-107b-404e-a2c4-262292710d43
       Date:
-      - Mon, 09 Apr 2018 16:32:50 GMT
+      - Thu, 19 Apr 2018 17:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4437,7 +4437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4450,14 +4450,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b8f2b600-b994-459a-96d5-bba10cc8405b
+      - req-d27b08ad-c4d4-4752-8bbf-bb997c2a1de8
       Date:
-      - Mon, 09 Apr 2018 16:32:51 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4472,7 +4472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4485,14 +4485,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e349a2d6-0aab-4b96-8fa8-a09d4ea9b082
+      - req-2364839c-0f47-41de-9fa7-a508bfca85cb
       Date:
-      - Mon, 09 Apr 2018 16:32:51 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4507,7 +4507,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4520,14 +4520,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a294860e-36c5-4a7d-a9c4-86e45e7f6ac3
+      - req-0dd78dd6-56c7-416c-a572-904bbf6218d9
       Date:
-      - Mon, 09 Apr 2018 16:32:51 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4542,7 +4542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4555,14 +4555,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-567e7c77-47e2-4c66-82b0-44db7636ebe7
+      - req-aba9cd58-464b-46e4-a4db-8e446a87e3b3
       Date:
-      - Mon, 09 Apr 2018 16:32:51 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4577,7 +4577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4590,14 +4590,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-79566375-d697-475a-bd58-48f7940be3b0
+      - req-5e71548a-f861-4209-9ab9-5d367bab5709
       Date:
-      - Mon, 09 Apr 2018 16:32:52 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4612,7 +4612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4625,26 +4625,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d6a32552-aec6-4db6-9c3e-8f2a786b91b6
+      - req-ee4deb71-1ddd-49bc-9ede-8928cf0b6a11
       Date:
-      - Mon, 09 Apr 2018 16:32:52 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:32:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:41:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:32:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:41:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:32:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:41:35.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:32:44.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:41:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:32:44.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:41:35.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4659,7 +4659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f76b2be1cb421cacc9e69577ecf63b
+      - 6bb818ab4fc24084a5bf0d2adc342273
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4672,26 +4672,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a084f710-9eb5-47b8-8cbd-9574ae6c606d
+      - req-58d0dced-6e82-4371-8484-5bcab7d637ed
       Date:
-      - Mon, 09 Apr 2018 16:32:52 GMT
+      - Thu, 19 Apr 2018 17:41:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:32:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:41:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:32:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:41:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:32:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:41:35.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:32:44.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:41:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:32:44.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:41:35.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4709,13 +4709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:53 GMT
+      - Thu, 19 Apr 2018 17:41:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3f3cb28e-6620-454d-8834-3ad8266b444f
+      - req-dd440cfc-e5b1-4934-8379-9fd26f196b8a
       Content-Length:
       - '4170'
       Connection:
@@ -4724,10 +4724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:53.559676", "expires":
-        "2018-04-09T17:32:53Z", "id": "d31f5c8972f44128bf2e6580544cdb7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:39.850179", "expires":
+        "2018-04-19T18:41:39Z", "id": "ad4251093c874e038f87302bbcb30e46", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["lyo5-OmzRJ2M1e5X_Ji2Wg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DMZB7mddRDqX1YvyJSUUpQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4772,7 +4772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4790,13 +4790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:53 GMT
+      - Thu, 19 Apr 2018 17:41:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-79138fda-051f-4b51-afd1-3c7d572db71c
+      - req-282bf7f7-396b-4784-b0ed-3092b44a129e
       Content-Length:
       - '4170'
       Connection:
@@ -4805,10 +4805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:53.860550", "expires":
-        "2018-04-09T17:32:53Z", "id": "7bd436f8107142d6aec1e16dff6f0315", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:40.072369", "expires":
+        "2018-04-19T18:41:40Z", "id": "9a0cf70973a94338a61ce5337b4ff491", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ccAZ05KTSLWpets3aOYLIw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["z3unR_zwRj6sCgUbJchmBg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4853,7 +4853,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4868,7 +4868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -4879,9 +4879,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-daca9054-72bf-44ca-8656-e4d20a82afcc
+      - req-fd0bf402-a0e1-43ec-b21f-d26f13206fc7
       Date:
-      - Mon, 09 Apr 2018 16:32:54 GMT
+      - Thu, 19 Apr 2018 17:41:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4923,7 +4923,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4938,7 +4938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -4949,9 +4949,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-458d62fe-e542-4e5f-ba85-03b2556aa3c5
+      - req-e162c3e5-f662-4ec4-84eb-f0de903b5d80
       Date:
-      - Mon, 09 Apr 2018 16:32:54 GMT
+      - Thu, 19 Apr 2018 17:41:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4994,7 +4994,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -5009,7 +5009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5020,9 +5020,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-b34fc28f-5270-4cfd-8bab-7df8108acb28
+      - req-8981737e-0a69-47ac-81d6-79050c7802f4
       Date:
-      - Mon, 09 Apr 2018 16:32:54 GMT
+      - Thu, 19 Apr 2018 17:41:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -5057,7 +5057,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5072,7 +5072,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5083,9 +5083,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-a4b68ae9-9e42-44ee-ad93-725ca66dc05a
+      - req-6c6b97da-1df3-43fd-9a15-9ab0863e0d1d
       Date:
-      - Mon, 09 Apr 2018 16:32:54 GMT
+      - Thu, 19 Apr 2018 17:41:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -5172,7 +5172,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5187,7 +5187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5198,42 +5198,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-371a6c37-d366-4fe5-bd6a-d9d1d5df63b5
+      - req-e13d8d38-a10d-499f-a9c1-e4344ec9706d
       Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
+      - Thu, 19 Apr 2018 17:41:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -5263,14 +5248,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5285,7 +5285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5296,9 +5296,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-be6a057f-91f1-4d95-bcb8-009f34db7ca1
+      - req-1e4eaafe-193a-467a-9d20-869097f513a5
       Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
+      - Thu, 19 Apr 2018 17:41:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:41:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 9a0cf70973a94338a61ce5337b4ff491
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1565ea8e-7b95-4309-91ac-45a582053467
+      Date:
+      - Thu, 19 Apr 2018 17:41:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -5402,271 +5534,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-223c3aec-073b-4d9c-92c7-8fe39e505197
-      Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b98482bb-5241-43f9-8d95-53302e85e96e
-      Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5681,7 +5549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5692,9 +5560,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-7114814f-83b2-4515-9c09-417ed5eb4224
+      - req-f7116acc-a412-42ec-9a13-11babceee5b0
       Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
+      - Thu, 19 Apr 2018 17:41:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5726,7 +5594,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5741,7 +5609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5752,9 +5620,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-26d802ad-582c-465e-ad0a-e2acd34d5ffe
+      - req-010366d9-2717-45df-89be-7c7566da9158
       Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
+      - Thu, 19 Apr 2018 17:41:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5786,7 +5654,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5801,7 +5669,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -5812,9 +5680,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9ec88537-a2c3-4188-8764-7b79e9f4ae95
+      - req-c3a5cbeb-ba6b-4ec3-8c24-0a60d8389d62
       Date:
-      - Mon, 09 Apr 2018 16:32:55 GMT
+      - Thu, 19 Apr 2018 17:41:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6217,7 +6085,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6232,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -6243,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-587c7317-e95f-4d2a-93e0-17b9c0639547
+      - req-e59e7150-193e-4e5c-9c07-64b31fad134c
       Date:
-      - Mon, 09 Apr 2018 16:32:56 GMT
+      - Thu, 19 Apr 2018 17:41:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6648,7 +6516,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6663,7 +6531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -6674,9 +6542,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7fe330cc-816c-4424-a169-7c84f4d03986
+      - req-03fddfe6-36f1-4fe6-b520-59d344f7640a
       Date:
-      - Mon, 09 Apr 2018 16:32:56 GMT
+      - Thu, 19 Apr 2018 17:41:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6718,7 +6586,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6733,7 +6601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bd436f8107142d6aec1e16dff6f0315
+      - 9a0cf70973a94338a61ce5337b4ff491
   response:
     status:
       code: 200
@@ -6744,9 +6612,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-44b17a7e-84d7-4459-b089-39a435280e00
+      - req-7aacb755-b65d-425e-9699-3a79e5a2c389
       Date:
-      - Mon, 09 Apr 2018 16:32:56 GMT
+      - Thu, 19 Apr 2018 17:41:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6788,7 +6656,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6806,13 +6674,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:57 GMT
+      - Thu, 19 Apr 2018 17:41:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7bc80d2c-7bdd-4665-94c2-9f05ce506c88
+      - req-cef45f97-f147-4b67-b25e-77826f806897
       Content-Length:
       - '4170'
       Connection:
@@ -6821,10 +6689,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:57.415837", "expires":
-        "2018-04-09T17:32:57Z", "id": "2c78ca0465a54d92a06f4d0cde99b038", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:46.483593", "expires":
+        "2018-04-19T18:41:46Z", "id": "130a0c4c137e4e3c9b283a9faa676375", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["r5WaDJKcTAC-gIgSOlRy6g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jhmTz25JTL2A2I3t2MtLGA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6869,7 +6737,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6887,13 +6755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:57 GMT
+      - Thu, 19 Apr 2018 17:41:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d02cc195-f57b-4692-8515-4bac0b4a0a84
+      - req-8fd24a9a-018a-4112-8707-b83c82287e50
       Content-Length:
       - '4170'
       Connection:
@@ -6902,10 +6770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:57.747043", "expires":
-        "2018-04-09T17:32:57Z", "id": "f1acf40e906142f28a26ec4a28b621e6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:46.693150", "expires":
+        "2018-04-19T18:41:46Z", "id": "cd4d5f1df538437381bfcd41d3ee1183", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RhgiNoPzTQ2Fasne5iFnjw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["u4GKPfDdRk2kNVH7STC7qg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6950,7 +6818,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6968,13 +6836,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:57 GMT
+      - Thu, 19 Apr 2018 17:41:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0320d6e2-d95c-427e-98d3-8846485837e0
+      - req-d2100868-c0db-4ae2-820b-a9fc296a9294
       Content-Length:
       - '4170'
       Connection:
@@ -6983,10 +6851,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:58.021791", "expires":
-        "2018-04-09T17:32:57Z", "id": "174a335b77f64bb1a74b68f3e6db3125", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:46.868407", "expires":
+        "2018-04-19T18:41:46Z", "id": "a26f548de74a4135b6749dfaa921c8e7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zM4fZNd4TfuA9MJ2Oi3jGA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dk9yQ-xuSomXrRVHTbonCA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7031,7 +6899,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7049,13 +6917,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:58 GMT
+      - Thu, 19 Apr 2018 17:41:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-78b0d592-5c9d-40ad-b4bc-69ae48fc7dc2
+      - req-f2aec632-c902-42f8-a463-9b9432e18719
       Content-Length:
       - '370'
       Connection:
@@ -7064,13 +6932,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:58.220655", "expires":
-        "2018-04-09T17:32:58Z", "id": "df7b35b8a0b74608adad1dadad329eea", "audit_ids":
-        ["Zw3_FixMQHGJQjCYwvu2KA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:47.033817", "expires":
+        "2018-04-19T18:41:47Z", "id": "9e577e26dd4c4165a0d79957c84a38df", "audit_ids":
+        ["KQAKys8SROys7-dsavp3Aw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:47 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7085,20 +6953,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df7b35b8a0b74608adad1dadad329eea
+      - 9e577e26dd4c4165a0d79957c84a38df
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:58 GMT
+      - Thu, 19 Apr 2018 17:41:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1b7a731c-8f16-4280-bd5b-2a37dc949edd
+      - req-639bcbcc-fc7a-4dc3-be0d-565d7abc4216
       Content-Length:
       - '500'
       Connection:
@@ -7115,13 +6983,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"df7b35b8a0b74608adad1dadad329eea"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"9e577e26dd4c4165a0d79957c84a38df"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7133,13 +7001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:58 GMT
+      - Thu, 19 Apr 2018 17:41:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f7eae9d-f5ce-46c9-8cce-fa4a389e5740
+      - req-60a7c08b-ab85-4c9c-bc24-2d78c0d41070
       Content-Length:
       - '4143'
       Connection:
@@ -7148,11 +7016,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:58.686968", "expires":
-        "2018-04-09T17:32:58Z", "id": "a27353288bab434b905779c5a06d8597", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:47.569401", "expires":
+        "2018-04-19T18:41:47Z", "id": "1c55aae56ab24c80bbd9a72dfb65555e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kyMcwdxiQTe9f53-hYi-2g",
-        "Zw3_FixMQHGJQjCYwvu2KA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YkFb767mR-O2MHQiqjdTsg",
+        "KQAKys8SROys7-dsavp3Aw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7196,7 +7064,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:47 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7211,20 +7079,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df7b35b8a0b74608adad1dadad329eea
+      - 9e577e26dd4c4165a0d79957c84a38df
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:58 GMT
+      - Thu, 19 Apr 2018 17:41:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-92fd9b08-d959-4ab7-9e3c-d0e99b3ef517
+      - req-a5ab5c30-f588-4d43-ae70-4bd98384c314
       Content-Length:
       - '500'
       Connection:
@@ -7241,7 +7109,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7259,13 +7127,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:58 GMT
+      - Thu, 19 Apr 2018 17:41:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-700b8911-2d18-40d2-8610-e17330bef3f6
+      - req-fa4c29f6-3389-4fd1-8290-0895aae33d2c
       Content-Length:
       - '4117'
       Connection:
@@ -7274,10 +7142,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:59.125638", "expires":
-        "2018-04-09T17:32:59Z", "id": "78a1a7e74ac746d88c2b38ac79fc7a8f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:48.135163", "expires":
+        "2018-04-19T18:41:48Z", "id": "c8777915c4e042d8b41ba90df07c05a6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["aIu08w3sSSyHqr3vFzx10A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DwQrqaD6T_KyYJBnqv4m-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7321,7 +7189,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7339,13 +7207,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:59 GMT
+      - Thu, 19 Apr 2018 17:41:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e8e5e94f-5539-445b-86e1-34c0492364c3
+      - req-a0d65de4-1227-49ed-b3a2-1a0ce84e2a70
       Content-Length:
       - '4131'
       Connection:
@@ -7354,10 +7222,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:59.384584", "expires":
-        "2018-04-09T17:32:59Z", "id": "cc050c2d852e44279d562d188ee79021", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:48.906039", "expires":
+        "2018-04-19T18:41:48Z", "id": "2bf535163582497a906d7ce179704157", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yXXVuqlZQja8ONAsjjfGRQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DAHXlFwgQQyqYEerxQD_yA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7401,7 +7269,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7419,13 +7287,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:59 GMT
+      - Thu, 19 Apr 2018 17:41:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d436c4df-0118-4f91-bc5e-bb74dced00d0
+      - req-5bf59406-ef3d-4685-85c2-66e4044a3c69
       Content-Length:
       - '4118'
       Connection:
@@ -7434,10 +7302,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:59.681973", "expires":
-        "2018-04-09T17:32:59Z", "id": "375023caec4c448ebe8900815a63edeb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:49.176582", "expires":
+        "2018-04-19T18:41:49Z", "id": "b25c4873491c46cbaeb0d25c16fea93b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QJjZqwYMSuK4GUAGUyZnqw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qUjRvcU5R6-7S1Q2CxiFQA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7481,7 +7349,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7499,13 +7367,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:32:59 GMT
+      - Thu, 19 Apr 2018 17:41:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1b456a14-1c61-46aa-8022-641af2303108
+      - req-6be94c70-7839-41d6-b098-b062bb613984
       Content-Length:
       - '4117'
       Connection:
@@ -7514,10 +7382,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:32:59.958511", "expires":
-        "2018-04-09T17:32:59Z", "id": "a15db2cc44614c72ae2e245da3e3f061", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:54.547003", "expires":
+        "2018-04-19T18:41:54Z", "id": "87b57135b92846cb909e60a8cd771451", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2aN9CAHJSt2O2KsNhr-JMQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lDFShtmLSlOwq649Y94vQA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7561,7 +7429,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:32:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -7576,22 +7444,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7d7d00b4-e60a-4a51-92fc-198bffccce56
+      - req-0cdc2844-7069-4223-980f-c9157c54bb75
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-7d7d00b4-e60a-4a51-92fc-198bffccce56
+      - req-0cdc2844-7069-4223-980f-c9157c54bb75
       Date:
-      - Mon, 09 Apr 2018 16:33:00 GMT
+      - Thu, 19 Apr 2018 17:41:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -7624,7 +7492,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -7639,22 +7507,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-625c130b-b87b-469d-99ea-3c7a7a32611b
+      - req-bf1fd97d-424d-4c35-b80d-f98c15a7c968
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-625c130b-b87b-469d-99ea-3c7a7a32611b
+      - req-bf1fd97d-424d-4c35-b80d-f98c15a7c968
       Date:
-      - Mon, 09 Apr 2018 16:33:01 GMT
+      - Thu, 19 Apr 2018 17:41:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -7695,7 +7563,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7710,22 +7578,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ce195b9-feff-45d9-9513-32a8b0307a26
+      - req-71516810-81f6-48b0-a01d-422bcf564c79
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-4ce195b9-feff-45d9-9513-32a8b0307a26
+      - req-71516810-81f6-48b0-a01d-422bcf564c79
       Date:
-      - Mon, 09 Apr 2018 16:33:01 GMT
+      - Thu, 19 Apr 2018 17:41:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7759,7 +7627,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7774,27 +7642,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1fc0b625-2664-4fbe-b4af-8ac52c20db4d
+      - req-de4eb00d-33e4-426b-b193-cf55b17a3d39
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1fc0b625-2664-4fbe-b4af-8ac52c20db4d
+      - req-de4eb00d-33e4-426b-b193-cf55b17a3d39
       Date:
-      - Mon, 09 Apr 2018 16:33:01 GMT
+      - Thu, 19 Apr 2018 17:41:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7812,13 +7680,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:01 GMT
+      - Thu, 19 Apr 2018 17:41:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46ba6ada-f8ad-47b8-bca8-70fe663f6743
+      - req-9b9eff3d-7fae-40c0-9639-5b4e3f8526e7
       Content-Length:
       - '4131'
       Connection:
@@ -7827,10 +7695,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:01.760825", "expires":
-        "2018-04-09T17:33:01Z", "id": "0a36bf31d50f4c54b6c8fe30d33e6b72", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:56.211116", "expires":
+        "2018-04-19T18:41:56Z", "id": "baf8e6692dfe41cb90d02bc1b2f57c5e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["V2KgN4XXTzeYk-KJqqXx1w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SNVCqY2ySJmpSn7TF5pJjg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7874,7 +7742,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7889,27 +7757,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a36bf31d50f4c54b6c8fe30d33e6b72
+      - baf8e6692dfe41cb90d02bc1b2f57c5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6e99949-93a3-4e95-adc4-8b0e73694af2
+      - req-707ee51b-912c-478a-ac2e-c9e0ed85d22a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c6e99949-93a3-4e95-adc4-8b0e73694af2
+      - req-707ee51b-912c-478a-ac2e-c9e0ed85d22a
       Date:
-      - Mon, 09 Apr 2018 16:33:02 GMT
+      - Thu, 19 Apr 2018 17:41:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7924,27 +7792,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174a335b77f64bb1a74b68f3e6db3125
+      - a26f548de74a4135b6749dfaa921c8e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d85cd091-e5b8-4cc1-9b53-fbe05c362607
+      - req-663c8133-bd6e-4be0-8cf0-f330ce9571da
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d85cd091-e5b8-4cc1-9b53-fbe05c362607
+      - req-663c8133-bd6e-4be0-8cf0-f330ce9571da
       Date:
-      - Mon, 09 Apr 2018 16:33:02 GMT
+      - Thu, 19 Apr 2018 17:41:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7962,13 +7830,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:02 GMT
+      - Thu, 19 Apr 2018 17:41:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-39560262-cbae-45c2-84a6-fe7fba3f6924
+      - req-a6537c51-82bb-4d0f-9d89-9aa13d617b0a
       Content-Length:
       - '4118'
       Connection:
@@ -7977,10 +7845,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:02.859894", "expires":
-        "2018-04-09T17:33:02Z", "id": "f7080d3f3e91439fbf59a918af4711be", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:56.961445", "expires":
+        "2018-04-19T18:41:56Z", "id": "523a4867dbcd4277bd5c871f8e96dae8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ko-BgE75S0Sp97leBTOwvQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["idTR3mGKRzinOMHBYHezaQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8024,7 +7892,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -8039,27 +7907,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7080d3f3e91439fbf59a918af4711be
+      - 523a4867dbcd4277bd5c871f8e96dae8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2a177532-a73e-4649-b4cb-2f9106015e3e
+      - req-5916870b-e1c9-475f-b797-9042b91261fe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2a177532-a73e-4649-b4cb-2f9106015e3e
+      - req-5916870b-e1c9-475f-b797-9042b91261fe
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -8074,22 +7942,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8247e895-d24d-4d16-bea7-cf683bedd02d
+      - req-846c23de-98f5-4579-98dd-6a59ac0c3504
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-8247e895-d24d-4d16-bea7-cf683bedd02d
+      - req-846c23de-98f5-4579-98dd-6a59ac0c3504
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8104,7 +7972,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -8119,22 +7987,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbba3032-cf26-41b9-8cda-979b0371e210
+      - req-43e654ee-66fc-43a1-9998-33decac4284a
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-dbba3032-cf26-41b9-8cda-979b0371e210
+      - req-43e654ee-66fc-43a1-9998-33decac4284a
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8149,7 +8017,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -8164,27 +8032,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a36bf31d50f4c54b6c8fe30d33e6b72
+      - baf8e6692dfe41cb90d02bc1b2f57c5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c4532b9-378d-4a19-b1f8-a191cc18157a
+      - req-95176f5c-4b80-4cd8-a569-5fae58ad5dfb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6c4532b9-378d-4a19-b1f8-a191cc18157a
+      - req-95176f5c-4b80-4cd8-a569-5fae58ad5dfb
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -8199,27 +8067,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a36bf31d50f4c54b6c8fe30d33e6b72
+      - baf8e6692dfe41cb90d02bc1b2f57c5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-282ad5e8-eb42-40da-ab6e-3e2a3ca98bf6
+      - req-82facee0-8610-4562-a47a-9c8bd0f32919
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-282ad5e8-eb42-40da-ab6e-3e2a3ca98bf6
+      - req-82facee0-8610-4562-a47a-9c8bd0f32919
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8234,27 +8102,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174a335b77f64bb1a74b68f3e6db3125
+      - a26f548de74a4135b6749dfaa921c8e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-622d3daa-a9f5-4cd7-aeae-724bf5c290ad
+      - req-7564ce0e-6e3e-4f97-8289-9c7ceb0c05f6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-622d3daa-a9f5-4cd7-aeae-724bf5c290ad
+      - req-7564ce0e-6e3e-4f97-8289-9c7ceb0c05f6
       Date:
-      - Mon, 09 Apr 2018 16:33:03 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8269,27 +8137,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174a335b77f64bb1a74b68f3e6db3125
+      - a26f548de74a4135b6749dfaa921c8e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3013ef8e-8a87-4ff2-a752-523e8eb102fb
+      - req-795e2311-49e3-4df1-82da-37594c9b581e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3013ef8e-8a87-4ff2-a752-523e8eb102fb
+      - req-795e2311-49e3-4df1-82da-37594c9b581e
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8304,27 +8172,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7080d3f3e91439fbf59a918af4711be
+      - 523a4867dbcd4277bd5c871f8e96dae8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37903838-1cd3-459d-be9e-4679f105cf3f
+      - req-9b5cdb80-2a73-4d04-b4e0-f00af38c69cd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-37903838-1cd3-459d-be9e-4679f105cf3f
+      - req-9b5cdb80-2a73-4d04-b4e0-f00af38c69cd
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8339,27 +8207,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7080d3f3e91439fbf59a918af4711be
+      - 523a4867dbcd4277bd5c871f8e96dae8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-450ea18c-8583-4d30-a6c4-b69f0e095eef
+      - req-48643e77-0a63-4b6c-af35-4100a421d46a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-450ea18c-8583-4d30-a6c4-b69f0e095eef
+      - req-48643e77-0a63-4b6c-af35-4100a421d46a
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8374,27 +8242,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29e4f7b7-e9ce-41ac-bbb1-55055bb1dfdd
+      - req-4c85c56d-1f81-418b-8439-841adce234b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-29e4f7b7-e9ce-41ac-bbb1-55055bb1dfdd
+      - req-4c85c56d-1f81-418b-8439-841adce234b7
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8409,27 +8277,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a15db2cc44614c72ae2e245da3e3f061
+      - 87b57135b92846cb909e60a8cd771451
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a0e635b-5c14-4184-aa10-afa3b8a3538c
+      - req-a3b0fbc9-bb30-4c5e-8ce7-03bca2d0c5cf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6a0e635b-5c14-4184-aa10-afa3b8a3538c
+      - req-a3b0fbc9-bb30-4c5e-8ce7-03bca2d0c5cf
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8444,27 +8312,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a36bf31d50f4c54b6c8fe30d33e6b72
+      - baf8e6692dfe41cb90d02bc1b2f57c5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-11bc2f84-c365-4388-bb2a-a93e2ad22d61
+      - req-3a23a5ba-27d1-4b4d-939b-4093a3873a5a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-11bc2f84-c365-4388-bb2a-a93e2ad22d61
+      - req-3a23a5ba-27d1-4b4d-939b-4093a3873a5a
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -8479,27 +8347,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a36bf31d50f4c54b6c8fe30d33e6b72
+      - baf8e6692dfe41cb90d02bc1b2f57c5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e99fdc1f-840c-4754-b401-6e6412529466
+      - req-7d2939f7-af4d-4038-b2b9-c8fc814fb05f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e99fdc1f-840c-4754-b401-6e6412529466
+      - req-7d2939f7-af4d-4038-b2b9-c8fc814fb05f
       Date:
-      - Mon, 09 Apr 2018 16:33:04 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -8514,27 +8382,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174a335b77f64bb1a74b68f3e6db3125
+      - a26f548de74a4135b6749dfaa921c8e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4fc9ac72-0c25-4d83-a7ca-529d8b3c1e5c
+      - req-44aa3b23-e79b-49a8-b2ee-6d8c95a704b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4fc9ac72-0c25-4d83-a7ca-529d8b3c1e5c
+      - req-44aa3b23-e79b-49a8-b2ee-6d8c95a704b5
       Date:
-      - Mon, 09 Apr 2018 16:33:05 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -8549,27 +8417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 174a335b77f64bb1a74b68f3e6db3125
+      - a26f548de74a4135b6749dfaa921c8e7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dba32752-84cd-43f4-8cad-d89c3224601f
+      - req-14908164-f542-45ca-85e5-d7387ed5db63
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dba32752-84cd-43f4-8cad-d89c3224601f
+      - req-14908164-f542-45ca-85e5-d7387ed5db63
       Date:
-      - Mon, 09 Apr 2018 16:33:05 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -8584,27 +8452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7080d3f3e91439fbf59a918af4711be
+      - 523a4867dbcd4277bd5c871f8e96dae8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-efa9b290-d92d-4420-8656-7db46eb46f12
+      - req-2b481d55-5b19-42d9-b43d-cc65be859ecb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-efa9b290-d92d-4420-8656-7db46eb46f12
+      - req-2b481d55-5b19-42d9-b43d-cc65be859ecb
       Date:
-      - Mon, 09 Apr 2018 16:33:05 GMT
+      - Thu, 19 Apr 2018 17:41:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -8619,27 +8487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7080d3f3e91439fbf59a918af4711be
+      - 523a4867dbcd4277bd5c871f8e96dae8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-75cdb7f0-4cc0-48c3-866a-d9215399d489
+      - req-a529d0e5-e62c-4ca7-9bd0-f0a55ce9f848
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-75cdb7f0-4cc0-48c3-866a-d9215399d489
+      - req-a529d0e5-e62c-4ca7-9bd0-f0a55ce9f848
       Date:
-      - Mon, 09 Apr 2018 16:33:05 GMT
+      - Thu, 19 Apr 2018 17:41:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8657,13 +8525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:05 GMT
+      - Thu, 19 Apr 2018 17:41:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b96458b4-4c6e-4426-8304-a47ba05cb023
+      - req-837b0518-761d-43b2-87e5-682c4862730f
       Content-Length:
       - '4170'
       Connection:
@@ -8672,10 +8540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:06.080807", "expires":
-        "2018-04-09T17:33:06Z", "id": "8ea18c9f077749c28089f4676c16c8a6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:59.356889", "expires":
+        "2018-04-19T18:41:59Z", "id": "92bdb5d8205e4662bdb14f0b65b1c55d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["E8pVVxhxRlKeAk_QJKNWHA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["WJZfl04VQ9SEonbZEYOcig"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8720,7 +8588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8738,13 +8606,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:06 GMT
+      - Thu, 19 Apr 2018 17:41:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0a896500-3d1f-40b2-8b4b-f1418cb4d3bc
+      - req-8f0bc58c-439d-45cb-ad0f-0d51b19f72a8
       Content-Length:
       - '4170'
       Connection:
@@ -8753,10 +8621,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:06.343514", "expires":
-        "2018-04-09T17:33:06Z", "id": "cb799187e63841b1b61ab58c8831468d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:59.610801", "expires":
+        "2018-04-19T18:41:59Z", "id": "f45d2026294e4368b29d4d69bd20c70d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0JyoEy0FRnSIki8-mVZrXQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["McAXjm2QQH2uKLx7jPlQ8w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8801,7 +8669,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8819,13 +8687,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:06 GMT
+      - Thu, 19 Apr 2018 17:41:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-adb311d3-3520-4e62-ac75-dd92f88c7a6c
+      - req-fce414e5-91f1-49f7-a2f2-d39850204e15
       Content-Length:
       - '370'
       Connection:
@@ -8834,13 +8702,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:06.754598", "expires":
-        "2018-04-09T17:33:06Z", "id": "49225451bfcc408bbb74ddecf2876301", "audit_ids":
-        ["0jznSIPCQn---yl2wa568w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:41:59.785729", "expires":
+        "2018-04-19T18:41:59Z", "id": "a98bd850a9f7428090851be855ca69f2", "audit_ids":
+        ["Sagr4OswR7OuBut6xsGV0g"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:41:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8855,20 +8723,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49225451bfcc408bbb74ddecf2876301
+      - a98bd850a9f7428090851be855ca69f2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:06 GMT
+      - Thu, 19 Apr 2018 17:41:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-710bce85-e27e-4e23-b85b-a12365127f89
+      - req-a28eb563-864f-4742-ae27-5c948b676dca
       Content-Length:
       - '500'
       Connection:
@@ -8885,13 +8753,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"49225451bfcc408bbb74ddecf2876301"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"a98bd850a9f7428090851be855ca69f2"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8903,13 +8771,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:07 GMT
+      - Thu, 19 Apr 2018 17:42:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-31709759-ba4e-401e-b002-3a7c9d2eabbd
+      - req-bc35d6be-9f62-4b5d-9bef-5f0c6f7262b6
       Content-Length:
       - '4143'
       Connection:
@@ -8918,11 +8786,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:07.140560", "expires":
-        "2018-04-09T17:33:06Z", "id": "3e61250228ad4889ba9b2a290c0af10b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:00.241650", "expires":
+        "2018-04-19T18:41:59Z", "id": "aaecf3b24158424e8117fa879998503e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0QhceBIQQ9KaSqcZN1MhDg",
-        "0jznSIPCQn---yl2wa568w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZBRRu8RXQ82R0jNKe11CWw",
+        "Sagr4OswR7OuBut6xsGV0g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8966,7 +8834,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:00 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8981,20 +8849,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49225451bfcc408bbb74ddecf2876301
+      - a98bd850a9f7428090851be855ca69f2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:07 GMT
+      - Thu, 19 Apr 2018 17:42:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ab18c99-f450-4a70-bede-71faba423ed3
+      - req-1c84ee38-f1bc-4c94-aa7e-e4d5830aeb81
       Content-Length:
       - '500'
       Connection:
@@ -9011,7 +8879,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9029,13 +8897,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:07 GMT
+      - Thu, 19 Apr 2018 17:42:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8904f593-f6a7-4f06-9a53-4aa15d3eeeb7
+      - req-c532d903-a4d8-48b2-974f-b94585e7f952
       Content-Length:
       - '4117'
       Connection:
@@ -9044,10 +8912,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:07.552940", "expires":
-        "2018-04-09T17:33:07Z", "id": "f3478fb2ed964241a9a510439370dda8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:00.621677", "expires":
+        "2018-04-19T18:42:00Z", "id": "ff4126d3817b4558b165c262f20ffc85", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kWC4U9GOReycKkb7NnqgAQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-7sK03xqQ6GqR_bHatkxWA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9091,7 +8959,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9109,13 +8977,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:07 GMT
+      - Thu, 19 Apr 2018 17:42:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e8c6443e-0884-41f7-bc13-c748f1d6206c
+      - req-cebe19ac-0847-4f01-ae1c-7ec27551b04e
       Content-Length:
       - '4131'
       Connection:
@@ -9124,10 +8992,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:07.849979", "expires":
-        "2018-04-09T17:33:07Z", "id": "43ac5d01f23b434bbe66c21d50dc01ee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:00.850959", "expires":
+        "2018-04-19T18:42:00Z", "id": "af44fc8e4a274a72bfe2164153e274f6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["l7-u8rmJQFWhfNx88RHDEA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XWCkYI2JSoqovAIcBBiiRg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9171,7 +9039,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9189,13 +9057,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:07 GMT
+      - Thu, 19 Apr 2018 17:42:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-970cce46-5bf5-4951-9feb-adee078a3548
+      - req-18fdaea3-db21-49af-b6ca-ea247403987c
       Content-Length:
       - '4118'
       Connection:
@@ -9204,10 +9072,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:08.248544", "expires":
-        "2018-04-09T17:33:08Z", "id": "9923e457cf30439390b60efce5c652f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:01.067153", "expires":
+        "2018-04-19T18:42:01Z", "id": "a12012fb6984429ebefc7853ec3c40be", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4avV0f9sRhmNAs0Vny2UEQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Q_Ujp596TQqVbZVaCaJLuQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9251,7 +9119,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9269,13 +9137,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:08 GMT
+      - Thu, 19 Apr 2018 17:42:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b4f59630-952b-4de3-a308-a7763e14edc9
+      - req-dfe0747e-dbc2-4915-8a43-2c1a31757c6f
       Content-Length:
       - '4117'
       Connection:
@@ -9284,10 +9152,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:08.535016", "expires":
-        "2018-04-09T17:33:08Z", "id": "952dc2dd9203489cb756223fa1bb096e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:01.277074", "expires":
+        "2018-04-19T18:42:01Z", "id": "47474f03c64e40ab9a18087aa2c8276f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4lY31MiNRVefX2XL_5DIKQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sK2wBA85RhasUtbO8Avxag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9331,7 +9199,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9346,7 +9214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 952dc2dd9203489cb756223fa1bb096e
+      - 47474f03c64e40ab9a18087aa2c8276f
   response:
     status:
       code: 200
@@ -9375,15 +9243,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf90b275336a5404aad17f-005acb95c4
+      - tx234c47616d6b439782fe2-005ad8d4e9
       Date:
-      - Mon, 09 Apr 2018 16:33:08 GMT
+      - Thu, 19 Apr 2018 17:42:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -9398,7 +9266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 952dc2dd9203489cb756223fa1bb096e
+      - 47474f03c64e40ab9a18087aa2c8276f
   response:
     status:
       code: 200
@@ -9427,14 +9295,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txbafe0c3023424b29bdee3-005acb95c4
+      - txc0e8418d6b3a4ee8b267c-005ad8d4e9
       Date:
-      - Mon, 09 Apr 2018 16:33:08 GMT
+      - Thu, 19 Apr 2018 17:42:01 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9452,13 +9320,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:09 GMT
+      - Thu, 19 Apr 2018 17:42:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-468d6ed7-4da9-49c0-bba4-88a4ab6c1f7e
+      - req-8a770a39-ed71-4842-a9fb-cc0a52dcddb5
       Content-Length:
       - '4131'
       Connection:
@@ -9467,10 +9335,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:09.265090", "expires":
-        "2018-04-09T17:33:09Z", "id": "dadc6590b0764f12b0d9afc340393a8f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:01.957222", "expires":
+        "2018-04-19T18:42:01Z", "id": "a643c30e1c034e4eae40b25017f3c8fd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7b-wplIVRcKZKK43bT311Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["K0vcaCeRTBCg0zQj_yF25Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9514,7 +9382,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -9529,7 +9397,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dadc6590b0764f12b0d9afc340393a8f
+      - a643c30e1c034e4eae40b25017f3c8fd
   response:
     status:
       code: 200
@@ -9542,22 +9410,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291589.58042'
+      - '1524159722.32901'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291589.58042'
+      - '1524159722.32901'
       X-Trans-Id:
-      - tx926c1caf8c37453db7327-005acb95c5
+      - txc60a4b78f7ed4e5a81446-005ad8d4ea
       Date:
-      - Mon, 09 Apr 2018 16:33:09 GMT
+      - Thu, 19 Apr 2018 17:42:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -9572,7 +9440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb799187e63841b1b61ab58c8831468d
+      - f45d2026294e4368b29d4d69bd20c70d
   response:
     status:
       code: 200
@@ -9585,22 +9453,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291589.84415'
+      - '1524159722.60226'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291589.84415'
+      - '1524159722.60226'
       X-Trans-Id:
-      - tx6363f2c8dc4946cc8a3e3-005acb95c5
+      - txacc4e205be844f509c650-005ad8d4ea
       Date:
-      - Mon, 09 Apr 2018 16:33:09 GMT
+      - Thu, 19 Apr 2018 17:42:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9618,13 +9486,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:09 GMT
+      - Thu, 19 Apr 2018 17:42:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-39fa8fc7-4087-44f6-98cb-54fe052c6f46
+      - req-cbde49c8-cd0d-401b-89a7-4a976dedd2e6
       Content-Length:
       - '4118'
       Connection:
@@ -9633,10 +9501,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:10.090218", "expires":
-        "2018-04-09T17:33:10Z", "id": "6a857eece3df4a92ac3b98724e39abdd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:42:02.830957", "expires":
+        "2018-04-19T18:42:02Z", "id": "64d090f81d5a4de79e1e2c0cb5c434e3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WhK9FTT9SIq4ggqmzwT8GQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0jzxmkssS3-PJryFbC-_fQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9680,7 +9548,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -9695,7 +9563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a857eece3df4a92ac3b98724e39abdd
+      - 64d090f81d5a4de79e1e2c0cb5c434e3
   response:
     status:
       code: 200
@@ -9708,22 +9576,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291590.39521'
+      - '1524159723.13714'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291590.39521'
+      - '1524159723.13714'
       X-Trans-Id:
-      - txb070c21f63844ba79a37c-005acb95c6
+      - tx68a5b2425a0443b9891da-005ad8d4ea
       Date:
-      - Mon, 09 Apr 2018 16:33:10 GMT
+      - Thu, 19 Apr 2018 17:42:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -9738,7 +9606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 952dc2dd9203489cb756223fa1bb096e
+      - 47474f03c64e40ab9a18087aa2c8276f
   response:
     status:
       code: 200
@@ -9759,9 +9627,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx3635ccbed0044861b1bcb-005acb95c6
+      - tx64202bd258884c7e9244b-005ad8d4eb
       Date:
-      - Mon, 09 Apr 2018 16:33:10 GMT
+      - Thu, 19 Apr 2018 17:42:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -9771,7 +9639,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -9786,7 +9654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 952dc2dd9203489cb756223fa1bb096e
+      - 47474f03c64e40ab9a18087aa2c8276f
   response:
     status:
       code: 200
@@ -9807,14 +9675,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txed20f6f9e59a46f3bdc70-005acb95c6
+      - tx18d2f6ee964543a181da3-005ad8d4eb
       Date:
-      - Mon, 09 Apr 2018 16:33:10 GMT
+      - Thu, 19 Apr 2018 17:42:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -9829,7 +9697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 952dc2dd9203489cb756223fa1bb096e
+      - 47474f03c64e40ab9a18087aa2c8276f
   response:
     status:
       code: 200
@@ -9850,12 +9718,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx54a6b06f2cea4d02a9f21-005acb95c6
+      - txbc6d2db7cb4f4bfb9f211-005ad8d4eb
       Date:
-      - Mon, 09 Apr 2018 16:33:10 GMT
+      - Thu, 19 Apr 2018 17:42:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:42:03 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:31 GMT
+      - Thu, 19 Apr 2018 17:45:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b15ff8b-74ab-4940-ac70-b622121214b0
+      - req-5feb28fc-e382-4a69-b626-a73f8aca955c
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:31.314813", "expires":
-        "2018-04-09T17:33:31Z", "id": "6af2868192d6462bbfc87cd2e02ced9d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:16.871198", "expires":
+        "2018-04-19T18:45:16Z", "id": "887b249baa2b4c09b96da8e2a117ee7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1el1yIyYR_qMiDhR8XquVw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iN8hT-LqTga7UOozI6JcVQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:31 GMT
+      - Thu, 19 Apr 2018 17:45:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-8b868dcf-18f0-493b-96e4-5b00b4efaa2e
+      - req-2f03f65f-86bc-4918-87e2-371aec845e90
       Date:
-      - Mon, 09 Apr 2018 16:33:31 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:31 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2c47da8c-b4ba-4de2-98a5-06695de43681
+      - req-c28a2576-deea-49ee-9ca6-441768b595e4
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:32.008280", "expires":
-        "2018-04-09T17:33:31Z", "id": "0f6f7d22301a48a791ddb78dfd05b6a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:17.344421", "expires":
+        "2018-04-19T18:45:17Z", "id": "00af18fa85d743199800cfbcc2d9e579", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1WUF8_rTTtC7Vik8MON3vw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["OCErkSKiQPumsYKQ1iDUpw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f6f7d22301a48a791ddb78dfd05b6a5
+      - 00af18fa85d743199800cfbcc2d9e579
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2c9f907-47ce-460c-9c7c-4a084cc3f445
+      - req-3eb3bbe8-906f-4c0d-80f9-b9f405a764cd
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-b2c9f907-47ce-460c-9c7c-4a084cc3f445
+      - req-3eb3bbe8-906f-4c0d-80f9-b9f405a764cd
       Date:
-      - Mon, 09 Apr 2018 16:33:32 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:32 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c9db7bf1-222a-45f1-ad20-4a32a1f30c7c
+      - req-9bd49733-9671-4163-a56c-f93e0c6186e7
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:32.478764", "expires":
-        "2018-04-09T17:33:32Z", "id": "8f6bcbaf72774ee4a513840fe3508e77", "audit_ids":
-        ["RiWlFKvLREKODOgzsF0E6Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:17.661182", "expires":
+        "2018-04-19T18:45:17Z", "id": "6cb716ddafd4458898683f833e84c5c9", "audit_ids":
+        ["nKc9rN5cRPy2wb6ZoG9I_g"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8f6bcbaf72774ee4a513840fe3508e77
+      - 6cb716ddafd4458898683f833e84c5c9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:32 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-31299d62-48f8-4264-96c3-fd4b3322b0e0
+      - req-de1530b3-6690-4c19-acef-ec1e69be7328
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"8f6bcbaf72774ee4a513840fe3508e77"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"6cb716ddafd4458898683f833e84c5c9"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:32 GMT
+      - Thu, 19 Apr 2018 17:45:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4df869a9-06a2-4068-8646-da0388369c80
+      - req-52a72af3-03e0-476b-88e6-df85d3e984e8
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:32.955215", "expires":
-        "2018-04-09T17:33:32Z", "id": "27e5029cab054a588b244f3b96439672", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:17.980708", "expires":
+        "2018-04-19T18:45:17Z", "id": "de66a4cdb45f47f4bcbf581776547d4f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["adMxh3lCSzmderDJqEeqjQ",
-        "RiWlFKvLREKODOgzsF0E6Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["cRFUHwhKQvaSGu2b-mtG4Q",
+        "nKc9rN5cRPy2wb6ZoG9I_g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8f6bcbaf72774ee4a513840fe3508e77
+      - 6cb716ddafd4458898683f833e84c5c9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bd16011d-cae2-47b4-94f2-4c44540d6dfa
+      - req-60154df0-dfee-439d-acd6-7f3e4a454652
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e950509e-2a6e-45ac-b5fe-9c46318d3034
+      - req-38fa8fc5-ab8a-4366-925d-5dfc6bb20ab9
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:33.389516", "expires":
-        "2018-04-09T17:33:33Z", "id": "622b2953b3f34082a7985b39b8fdf31b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:18.273358", "expires":
+        "2018-04-19T18:45:18Z", "id": "06cb86afcb5247a49fd01bc7400c4313", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W6vTwvvaT7SgVXVDW9sDeg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZwAqYxbAQwax_my5IyLfsw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-90088856-2f18-4e3a-adc5-816d14b834ed
+      - req-59588d7d-e102-4674-89ed-9625d6de3b84
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:33.721003", "expires":
-        "2018-04-09T17:33:33Z", "id": "11e71f607f1f420bb01782fa55096d97", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:18.498798", "expires":
+        "2018-04-19T18:45:18Z", "id": "89fdfe3ee47d487bbcf9a20d5217dc65", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FS0syoc_TlyfcqJ5O81j4w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["S7OIoji4QS-AD6BpClJbTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:33 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-07a79ee6-e635-4b36-a28f-8b7ab32ca99e
+      - req-d6534922-4918-4185-b845-47a2ce375368
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:34.120928", "expires":
-        "2018-04-09T17:33:34Z", "id": "0ac6008f140b423da86c34e2413b809c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:18.755076", "expires":
+        "2018-04-19T18:45:18Z", "id": "bcfde811c7ac4eae8b200c9e8f66b4a3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QytHdi0VRmuIJOL3UPZX5g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dG3tgSU_QFCjR2hSCYF1hQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:34 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e4f27d97-10c6-4ab7-934e-76cde02cafdc
+      - req-cc0a3ae8-19a6-4f24-8ce9-80f238954b1d
       Date:
-      - Mon, 09 Apr 2018 16:33:34 GMT
+      - Thu, 19 Apr 2018 17:45:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:24.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:24.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fc29e3d0-12c1-4a6b-a64b-001572dc42a5
+      - req-e362a374-c8bc-46f8-9cb5-6eceeffe7603
       Date:
-      - Mon, 09 Apr 2018 16:33:34 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2e6424d2-8cf6-4aa5-a0d6-8193518254c3
+      - req-b4d72753-f8c5-4307-9a4d-56dd9451f6b4
       Date:
-      - Mon, 09 Apr 2018 16:33:35 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c3b0568e-3b2f-4880-a167-eaa224dbc68a
+      - req-2c4d293d-d96e-4bf5-aa16-a3794bca6505
       Date:
-      - Mon, 09 Apr 2018 16:33:35 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b7372ef7-6c53-4b2d-b891-c25157d80b8c
+      - req-699914e2-1cb8-4244-98e8-0dd3ba4d9e49
       Date:
-      - Mon, 09 Apr 2018 16:33:35 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-49f58bea-5a1e-449b-8a8e-41152fb5303f
+      - req-fd30d084-c785-44ad-93e1-0da5f1d1a828
       Date:
-      - Mon, 09 Apr 2018 16:33:35 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b112f92d-f457-4bc4-9f7e-d58a92a28edf
+      - req-ceb8da60-6ba4-4b1a-9f7f-2d95cf3f031b
       Date:
-      - Mon, 09 Apr 2018 16:33:36 GMT
+      - Thu, 19 Apr 2018 17:45:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fc44f0b5-b274-4b9d-9a08-76d4b5a71eb5
+      - req-643f324e-cf47-4308-98b0-7ba3710a828e
       Date:
-      - Mon, 09 Apr 2018 16:33:36 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-09T16:33:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-04-19T17:45:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-04-09T16:33:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-04-19T17:45:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-09T16:33:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-04-19T17:45:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-04-09T16:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-04-19T17:45:14.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-09T16:33:34.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-04-19T17:45:15.000000"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-28b6240f-b5b6-40ec-a92d-ae83b0a66235
+      - req-55a19474-05b4-416f-b13b-2ff265b09e6a
       Date:
-      - Mon, 09 Apr 2018 16:33:36 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-9a7ef525-5adf-424f-a1af-a06db7c86cae
+      - req-4ca417a4-dafb-4b9d-9161-ed2c70c5e1dd
       Date:
-      - Mon, 09 Apr 2018 16:33:36 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-e528733b-07c0-496b-b27b-6d1b3ab13da7
+      - req-c37893ea-b965-47b3-b364-d009ed2c8e02
       Date:
-      - Mon, 09 Apr 2018 16:33:37 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-46dd02dd-5966-4257-bf79-57d097506ee1
+      - req-6d8e5fb8-5942-41fc-a2f5-cdab0bf12ef5
       Date:
-      - Mon, 09 Apr 2018 16:33:37 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,9 +1400,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-f3acb4e6-0aa1-4e60-8560-5043461204dc
+      - req-57170576-809b-4a76-99ce-045e81f514dd
       Date:
-      - Mon, 09 Apr 2018 16:33:37 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/1",
@@ -1416,7 +1416,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2
@@ -1431,7 +1431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1444,9 +1444,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-982e28d8-4936-4f19-a084-030f86b61212
+      - req-883e88b4-5ef2-4798-b307-3ca406efee8f
       Date:
-      - Mon, 09 Apr 2018 16:33:37 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/3",
@@ -1460,7 +1460,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4
@@ -1475,7 +1475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1488,9 +1488,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-f6b01f2d-e65a-41da-9751-91912490cc14
+      - req-7da464a0-25ed-44af-ab71-bc1cbf48761b
       Date:
-      - Mon, 09 Apr 2018 16:33:37 GMT
+      - Thu, 19 Apr 2018 17:45:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/5",
@@ -1505,7 +1505,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6
@@ -1520,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1533,14 +1533,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-8ae75c1a-c69b-4132-97f8-5464a7ae530c
+      - req-d3c82c9d-cc63-42a8-ac38-cb054dbb3842
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000
@@ -1555,7 +1555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1568,9 +1568,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-cc93b0fc-86ab-4b44-8fc4-80f1cc2c0deb
+      - req-b22fbed7-324c-4d3b-bb5d-8117864688d2
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1584,7 +1584,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2
@@ -1599,7 +1599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1612,9 +1612,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-add9b270-39cb-47df-9be8-2f881b14c1de
+      - req-de0ae4c7-05de-498d-b94f-95cc71877ce4
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1628,7 +1628,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4
@@ -1643,7 +1643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1656,9 +1656,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-b1f2319a-2c14-4a52-b91a-e985aa8026cc
+      - req-61668bc2-c3ae-4ffe-823b-abdc99b23344
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1673,7 +1673,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6
@@ -1688,7 +1688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1701,14 +1701,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-c62a9641-67de-4462-8c83-d12a3baf2748
+      - req-6e96dbf2-2816-45af-be99-b495e4c418b5
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000
@@ -1723,7 +1723,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1736,9 +1736,9 @@ http_interactions:
       Content-Length:
       - '978'
       X-Compute-Request-Id:
-      - req-89ce3510-f8b7-4f3c-96a5-29cc966fe812
+      - req-b9ec4be0-18cc-4959-8b9e-a20b369ef58b
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/1",
@@ -1752,7 +1752,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2
@@ -1767,7 +1767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1780,9 +1780,9 @@ http_interactions:
       Content-Length:
       - '982'
       X-Compute-Request-Id:
-      - req-18f7a0e6-de91-4991-9fce-56ce4eb53371
+      - req-5aa0480d-dd1d-4346-802f-583185129bfe
       Date:
-      - Mon, 09 Apr 2018 16:33:38 GMT
+      - Thu, 19 Apr 2018 17:45:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/3",
@@ -1796,7 +1796,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4
@@ -1811,7 +1811,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1824,9 +1824,9 @@ http_interactions:
       Content-Length:
       - '994'
       X-Compute-Request-Id:
-      - req-1b9ed253-2e15-4a76-91be-3196c7a4854a
+      - req-1d90120a-9b1f-4032-8538-92d78bab3062
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/5",
@@ -1841,7 +1841,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6
@@ -1856,7 +1856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1869,14 +1869,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-2cc44294-e499-4907-a43d-f85657bfdc2f
+      - req-cf2b8530-876f-48c2-8311-47214919728c
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1891,7 +1891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1904,15 +1904,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-e46587ef-7705-4c80-a47b-2a673768078b
+      - req-a24646cd-857a-4d3e-83ad-d0751b2d9c6c
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1930,13 +1930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f7fde1c-fe08-41ee-8240-e2f3840067b5
+      - req-814c199b-0bd0-413c-a1d9-0fcab52bf875
       Content-Length:
       - '4170'
       Connection:
@@ -1945,10 +1945,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:39.665765", "expires":
-        "2018-04-09T17:33:39Z", "id": "2d7b9f3591dc4384b63c89c86366700c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:23.384234", "expires":
+        "2018-04-19T18:45:23Z", "id": "71f2f5fdb9ef4cae95a43bba10b3fd11", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["p9ymTG8sTaa-cvBR3RFRKA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sDj9j66jSdS_qTV8X_VLxg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1993,7 +1993,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -2008,7 +2008,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d7b9f3591dc4384b63c89c86366700c
+      - 71f2f5fdb9ef4cae95a43bba10b3fd11
   response:
     status:
       code: 300
@@ -2019,7 +2019,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -2032,7 +2032,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2050,13 +2050,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:39 GMT
+      - Thu, 19 Apr 2018 17:45:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-88d5c460-bba7-4706-bec5-3b2e2f07dd04
+      - req-d32db110-b3a0-4af5-b7b0-feb9a06f2209
       Content-Length:
       - '4117'
       Connection:
@@ -2065,10 +2065,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:40.007672", "expires":
-        "2018-04-09T17:33:39Z", "id": "b92631d4eb9546fb98ac0ac700467bc9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:23.698828", "expires":
+        "2018-04-19T18:45:23Z", "id": "18444f6c1e0e4b8db416a515df9206ea", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wirBUdVHRKec1nAcIXCayA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["q0wahiQGTqO2hUTxMwSx7Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2112,7 +2112,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2127,7 +2127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b92631d4eb9546fb98ac0ac700467bc9
+      - 18444f6c1e0e4b8db416a515df9206ea
   response:
     status:
       code: 200
@@ -2138,9 +2138,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c7597da6-7316-4fd4-a1df-723e77e0ccb7
+      - req-69fead1a-2c5a-403a-afcc-c7f56f451f22
       Date:
-      - Mon, 09 Apr 2018 16:33:40 GMT
+      - Thu, 19 Apr 2018 17:45:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2182,7 +2182,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2197,7 +2197,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b92631d4eb9546fb98ac0ac700467bc9
+      - 18444f6c1e0e4b8db416a515df9206ea
   response:
     status:
       code: 200
@@ -2208,14 +2208,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e96b71c5-310f-4e3d-b9dd-5363aada4263
+      - req-a72bf0e8-e306-4072-b1d4-8c6bd96458ea
       Date:
-      - Mon, 09 Apr 2018 16:33:40 GMT
+      - Thu, 19 Apr 2018 17:45:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2233,13 +2233,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:40 GMT
+      - Thu, 19 Apr 2018 17:45:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e21cf5fb-6f8d-4e37-9866-23e756b866a0
+      - req-9d9c41c4-6d83-46b9-8020-53626b199365
       Content-Length:
       - '4131'
       Connection:
@@ -2248,10 +2248,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:41.057225", "expires":
-        "2018-04-09T17:33:41Z", "id": "9bbf656174bf412ea4b1197e1f36cdd6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:24.903134", "expires":
+        "2018-04-19T18:45:24Z", "id": "e686ade984e54d2fb79ac5fc6f44903e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["d-flNf97QTimiStCmhSctw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["cj0w-mAlTaqs_gjWHAEG6g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2295,7 +2295,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bbf656174bf412ea4b1197e1f36cdd6
+      - e686ade984e54d2fb79ac5fc6f44903e
   response:
     status:
       code: 200
@@ -2321,9 +2321,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8705e0ec-0459-4da3-8e12-8d38cb35fe57
+      - req-c07f9593-f861-49de-8278-e9266cdbe3ff
       Date:
-      - Mon, 09 Apr 2018 16:33:41 GMT
+      - Thu, 19 Apr 2018 17:45:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2365,7 +2365,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2380,7 +2380,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bbf656174bf412ea4b1197e1f36cdd6
+      - e686ade984e54d2fb79ac5fc6f44903e
   response:
     status:
       code: 200
@@ -2391,14 +2391,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-95483778-babc-4dd7-8af3-8d366fced14d
+      - req-f203e6db-cb8c-4927-96cd-2f88902102eb
       Date:
-      - Mon, 09 Apr 2018 16:33:41 GMT
+      - Thu, 19 Apr 2018 17:45:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2413,7 +2413,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d7b9f3591dc4384b63c89c86366700c
+      - 71f2f5fdb9ef4cae95a43bba10b3fd11
   response:
     status:
       code: 200
@@ -2424,9 +2424,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a83ce58d-c1ae-4999-ad49-fb0fe0b01bf6
+      - req-bb0fa91a-42fa-4b7a-93bc-acd5256226fb
       Date:
-      - Mon, 09 Apr 2018 16:33:41 GMT
+      - Thu, 19 Apr 2018 17:45:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2468,7 +2468,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2483,7 +2483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d7b9f3591dc4384b63c89c86366700c
+      - 71f2f5fdb9ef4cae95a43bba10b3fd11
   response:
     status:
       code: 200
@@ -2494,14 +2494,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-69710644-7f0b-4bea-ac9f-157f52da75dc
+      - req-031052a9-d207-4cf7-9420-9ef12edc3423
       Date:
-      - Mon, 09 Apr 2018 16:33:42 GMT
+      - Thu, 19 Apr 2018 17:45:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2519,13 +2519,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:42 GMT
+      - Thu, 19 Apr 2018 17:45:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4707923b-8ae1-43c4-9b8f-471edfd93337
+      - req-8930ec90-dc7c-42ad-ab89-392d7383a820
       Content-Length:
       - '4118'
       Connection:
@@ -2534,10 +2534,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:42.677224", "expires":
-        "2018-04-09T17:33:42Z", "id": "899917787e6642729b4c7b0c53722c46", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:26.520298", "expires":
+        "2018-04-19T18:45:26Z", "id": "76491625f9ee44feb119d1031400e897", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mkfb9Pk1RESlGnrPudUizg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qlZkF_NlSL2lRtj5rKET4A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:42 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2596,7 +2596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 899917787e6642729b4c7b0c53722c46
+      - 76491625f9ee44feb119d1031400e897
   response:
     status:
       code: 200
@@ -2607,9 +2607,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-31c4b7eb-0935-45f2-9e89-9733ccfdef1c
+      - req-e99e2c34-2923-4dfc-a82a-966368a4e372
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2651,7 +2651,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2666,7 +2666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 899917787e6642729b4c7b0c53722c46
+      - 76491625f9ee44feb119d1031400e897
   response:
     status:
       code: 200
@@ -2677,14 +2677,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4f60b391-66ac-44e9-a9a1-ffe79fcf5571
+      - req-a25546b5-0349-4b4f-8c2a-cc9483e17303
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2699,7 +2699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2712,9 +2712,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2a320a12-13a1-46d8-ac78-8cb4567eeda6
+      - req-046b0c43-af03-45d9-a0f1-e3d713119928
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2724,7 +2724,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2739,7 +2739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2752,9 +2752,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-90506111-5388-41f1-8d58-6e73585968e9
+      - req-a6ef0f7b-f47f-45b6-a21e-b9b3c8aac804
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2764,7 +2764,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2779,7 +2779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2792,9 +2792,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-526151d9-8d9b-4905-8e39-184edcc78acc
+      - req-df4489f0-c374-4bd5-8364-5fae51c447b0
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2804,7 +2804,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2819,7 +2819,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2832,9 +2832,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ede60c88-c2e6-4f34-a9f0-84b3b694a382
+      - req-c60e5307-3a79-4963-8234-7a3171f95f8c
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2844,7 +2844,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2859,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2872,9 +2872,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e2970eb3-8302-41c4-a752-4f6434df78fb
+      - req-6507d5c9-bd83-4ea7-b7a8-0f62a6ef050e
       Date:
-      - Mon, 09 Apr 2018 16:33:43 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2884,7 +2884,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:43 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2899,7 +2899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2912,9 +2912,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ab3027a2-0f9e-4575-83ca-25b8702f1f84
+      - req-2057e6b4-8b8a-4e30-8fa1-71acdfe38042
       Date:
-      - Mon, 09 Apr 2018 16:33:44 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2924,7 +2924,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2939,7 +2939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2952,9 +2952,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ecc195ed-1a2b-4118-9798-7291a253e17f
+      - req-01ab9810-58a5-4431-a095-42a600c2fb25
       Date:
-      - Mon, 09 Apr 2018 16:33:44 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2964,7 +2964,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2979,7 +2979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2992,9 +2992,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d882fb6e-c6ab-46a9-91b7-4d0ea4d81e4c
+      - req-a85da195-c952-4a88-9a38-603a41c84d8c
       Date:
-      - Mon, 09 Apr 2018 16:33:44 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -3004,7 +3004,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3022,13 +3022,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:44 GMT
+      - Thu, 19 Apr 2018 17:45:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8db24060-ebe7-4be9-a24c-f8aab5a3aecf
+      - req-212aa024-a64f-4cee-addc-7f12a7917e3a
       Content-Length:
       - '4170'
       Connection:
@@ -3037,10 +3037,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:44.482081", "expires":
-        "2018-04-09T17:33:44Z", "id": "e20592fb9d78442cbd77b30fa75128a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:28.108527", "expires":
+        "2018-04-19T18:45:27Z", "id": "d6ab9fb8c39246388488b4ad0f935cec", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["dwRoRe8BRSG38IQjRti8gQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["oHi5bkSKQaKqT-E2d-pFzA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3085,7 +3085,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3103,13 +3103,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:44 GMT
+      - Thu, 19 Apr 2018 17:45:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5b72f9f7-02fa-4d49-9413-6c87b77a0989
+      - req-b40104e9-9889-46f7-9ef4-e66a867a44d4
       Content-Length:
       - '4117'
       Connection:
@@ -3118,10 +3118,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:44.814991", "expires":
-        "2018-04-09T17:33:44Z", "id": "49c80856ccea42eeb6766c186cd52856", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:28.471648", "expires":
+        "2018-04-19T18:45:28Z", "id": "7966befef9e94243b93ded1b6a79dd4d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jqQ5NDWOQzWR5-o-i2PVCw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KfsvXIizQrK-SFvt0sHvWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3165,7 +3165,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:44 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -3180,7 +3180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3191,9 +3191,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-02fd22a3-c4a9-4b53-a1af-df6db3be94fc
+      - req-1b32cf9d-5679-42b6-b26f-a3a30732f790
       Date:
-      - Mon, 09 Apr 2018 16:33:45 GMT
+      - Thu, 19 Apr 2018 17:45:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -3227,7 +3227,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -3242,7 +3242,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3253,14 +3253,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3fe95739-d573-4410-97b9-af027c25e8eb
+      - req-acd41181-b67c-4562-8ccd-9304b19493f4
       Date:
-      - Mon, 09 Apr 2018 16:33:45 GMT
+      - Thu, 19 Apr 2018 17:45:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3278,13 +3278,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:45 GMT
+      - Thu, 19 Apr 2018 17:45:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e0b395d9-a4b4-483f-b549-a0060f669b6b
+      - req-4dd9cd3a-48bf-4114-9261-5bb4547cd0d1
       Content-Length:
       - '4131'
       Connection:
@@ -3293,10 +3293,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:45.604126", "expires":
-        "2018-04-09T17:33:45Z", "id": "9348dbadf9c04f46ae9d7f5a315e4bdf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:29.910124", "expires":
+        "2018-04-19T18:45:29Z", "id": "7719c9cadc734806b825153fc4a26d84", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4djvdNIgQ-uzd6DiK63bsg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1LhTeAKHSGGfQDy519wsOg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3340,7 +3340,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -3355,7 +3355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9348dbadf9c04f46ae9d7f5a315e4bdf
+      - 7719c9cadc734806b825153fc4a26d84
   response:
     status:
       code: 200
@@ -3366,14 +3366,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-02cb7691-3f31-47ac-9184-318ded5cc0d5
+      - req-a1eb342e-5def-40ad-9216-dd7daf5ba679
       Date:
-      - Mon, 09 Apr 2018 16:33:45 GMT
+      - Thu, 19 Apr 2018 17:45:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:45 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3388,7 +3388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e20592fb9d78442cbd77b30fa75128a0
+      - d6ab9fb8c39246388488b4ad0f935cec
   response:
     status:
       code: 200
@@ -3399,14 +3399,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b5f00350-e68d-475f-a54b-247d75a1e9b3
+      - req-08d9a768-0d0c-4b72-9626-f291675bc6bc
       Date:
-      - Mon, 09 Apr 2018 16:33:46 GMT
+      - Thu, 19 Apr 2018 17:45:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3424,13 +3424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:46 GMT
+      - Thu, 19 Apr 2018 17:45:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-acb743fc-ba27-424d-a148-facf9c5d179a
+      - req-ca7c46cd-2be9-401c-ab8b-3ba0e98740e3
       Content-Length:
       - '4118'
       Connection:
@@ -3439,10 +3439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:46.475401", "expires":
-        "2018-04-09T17:33:46Z", "id": "2a6b4e02be8a4b86ac1f0f0a90e6413e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:30.832547", "expires":
+        "2018-04-19T18:45:30Z", "id": "96f680c9eb4141ac924bce38343203fb", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["TXUwYwzhSJGX1dPwmOX5cA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-Q7tY5VLT2WhfmE_IBAGrg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3486,7 +3486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3501,7 +3501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a6b4e02be8a4b86ac1f0f0a90e6413e
+      - 96f680c9eb4141ac924bce38343203fb
   response:
     status:
       code: 200
@@ -3512,14 +3512,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a9c89ff1-8395-4248-b5a3-1fda7bdf1bb3
+      - req-bdeb0460-4662-4374-8aec-9254ac13aa8a
       Date:
-      - Mon, 09 Apr 2018 16:33:46 GMT
+      - Thu, 19 Apr 2018 17:45:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3534,7 +3534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3545,9 +3545,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-26bf67bf-e19b-4c3c-be76-a642f8810bad
+      - req-a1de6d1b-080d-48e2-b190-8da26fe9f448
       Date:
-      - Mon, 09 Apr 2018 16:33:47 GMT
+      - Thu, 19 Apr 2018 17:45:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3574,7 +3574,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3589,7 +3589,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3600,9 +3600,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c9e36d82-32e9-4c9c-9287-4754e31df267
+      - req-4973414e-4130-490f-a08c-f2d4e924e74b
       Date:
-      - Mon, 09 Apr 2018 16:33:49 GMT
+      - Thu, 19 Apr 2018 17:45:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3629,7 +3629,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3644,7 +3644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3655,9 +3655,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ad9ba39e-4ec5-4c3d-92db-a76bd999a4fd
+      - req-ee83f7a1-99ac-4bf8-ae41-53a243bab2ac
       Date:
-      - Mon, 09 Apr 2018 16:33:49 GMT
+      - Thu, 19 Apr 2018 17:45:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3684,7 +3684,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3699,7 +3699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3710,9 +3710,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-60d655ec-d1fe-46c7-bc3f-ead14e12faa8
+      - req-99ce541c-63af-4403-acce-4ad1949a84f1
       Date:
-      - Mon, 09 Apr 2018 16:33:49 GMT
+      - Thu, 19 Apr 2018 17:45:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3768,7 +3768,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3783,7 +3783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -3794,9 +3794,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-66919792-10e0-44d5-8001-ccad4cd93d8e
+      - req-d4e046a2-cc40-453d-8233-ee54fac54331
       Date:
-      - Mon, 09 Apr 2018 16:33:50 GMT
+      - Thu, 19 Apr 2018 17:45:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3808,7 +3808,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3823,7 +3823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3836,9 +3836,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-59ee9b31-d979-4707-a8de-ff59bd70cc77
+      - req-a25508e7-be8d-456c-a026-a99b1ed33c40
       Date:
-      - Mon, 09 Apr 2018 16:33:50 GMT
+      - Thu, 19 Apr 2018 17:45:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3884,7 +3884,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3899,7 +3899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3912,9 +3912,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-6f1b3d3e-639a-40fc-b33c-ddb411a2b904
+      - req-5024ca06-00e9-4bc1-a0c6-3c0798380e22
       Date:
-      - Mon, 09 Apr 2018 16:33:51 GMT
+      - Thu, 19 Apr 2018 17:45:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3960,7 +3960,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3975,7 +3975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3988,9 +3988,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-4a9b22a7-d1ce-43e0-804b-4a8e23a77c30
+      - req-e44353a8-2cfd-4bb4-9e96-37568555d4b6
       Date:
-      - Mon, 09 Apr 2018 16:33:52 GMT
+      - Thu, 19 Apr 2018 17:45:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -4038,7 +4038,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4053,7 +4053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4066,9 +4066,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-415b4e14-5902-4a8b-9fc7-166c638dc7f4
+      - req-87d6668c-91b2-4227-a7b3-9bda9c4d5b2f
       Date:
-      - Mon, 09 Apr 2018 16:33:52 GMT
+      - Thu, 19 Apr 2018 17:45:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4110,7 +4110,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4125,7 +4125,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4138,9 +4138,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-54a54c12-65a1-4e5e-83e3-6a572d1c4225
+      - req-73d607f3-c0b3-4d15-bbf5-c963c8786bb3
       Date:
-      - Mon, 09 Apr 2018 16:33:53 GMT
+      - Thu, 19 Apr 2018 17:45:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4163,7 +4163,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -4178,7 +4178,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4191,14 +4191,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-4be9525d-a64b-419f-8d63-00219fb83efc
+      - req-700d717f-9a07-4872-9b94-97ef3bdab803
       Date:
-      - Mon, 09 Apr 2018 16:33:53 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -4213,7 +4213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4226,14 +4226,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-42d33c48-df70-4608-9f1f-0c4b508b8a44
+      - req-6d39808a-68f9-4abd-bfda-ffe7a68eda13
       Date:
-      - Mon, 09 Apr 2018 16:33:53 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -4248,7 +4248,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4261,14 +4261,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-71e20aab-a18a-4a67-b2c1-e5214d74fb3d
+      - req-9123bfd8-0cf6-4047-8ee5-fb68856b51c5
       Date:
-      - Mon, 09 Apr 2018 16:33:53 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -4283,7 +4283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -4294,9 +4294,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c52c58de-5454-442b-aa26-a53cc41b3a33
+      - req-a9a9ef49-dde0-4052-94ce-3e08af1285e2
       Date:
-      - Mon, 09 Apr 2018 16:33:53 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4352,7 +4352,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -4367,7 +4367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -4378,9 +4378,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4a1c2262-b303-4bcd-a440-bccf1c0ad222
+      - req-71f4f365-3e93-41e2-ad66-037567cbf6e5
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4392,7 +4392,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -4407,7 +4407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -4418,9 +4418,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9afb81d3-d70d-45df-a2aa-1a82c3c8f20d
+      - req-92109287-5344-448d-bf1e-fbdac5d93ff2
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4476,7 +4476,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -4491,7 +4491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c80856ccea42eeb6766c186cd52856
+      - 7966befef9e94243b93ded1b6a79dd4d
   response:
     status:
       code: 200
@@ -4502,9 +4502,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6b60f99b-a028-4593-9b0d-e7ee82ccd2ea
+      - req-a3ff01e6-0d3b-4bea-9ac3-82f1a48f8876
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4516,7 +4516,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4531,7 +4531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4544,9 +4544,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f2182897-176c-4d02-b3d9-083bf461fd82
+      - req-293a07c8-a95e-40f6-9f3f-3ae3c2ac8fb7
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4555,7 +4555,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4570,7 +4570,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e71f607f1f420bb01782fa55096d97
+      - 89fdfe3ee47d487bbcf9a20d5217dc65
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4583,9 +4583,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8138064e-ce13-4aec-865a-e685a7c493b7
+      - req-e4a913e7-de26-4891-afe1-7eb007d467dd
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4594,7 +4594,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4609,7 +4609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4622,9 +4622,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9a6c0f8a-419a-4619-af6c-91c128926061
+      - req-786716ac-7738-4b0d-b4c9-87932748865a
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4633,7 +4633,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4648,7 +4648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ac6008f140b423da86c34e2413b809c
+      - bcfde811c7ac4eae8b200c9e8f66b4a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4661,9 +4661,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3f3dc522-e350-4ced-9634-ba416027ba8c
+      - req-52a164da-d81e-4f05-bb57-11a9cd57075e
       Date:
-      - Mon, 09 Apr 2018 16:33:54 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4672,7 +4672,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4690,13 +4690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:55 GMT
+      - Thu, 19 Apr 2018 17:45:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c8d880aa-9201-4fcc-8f53-d1b5979d3e89
+      - req-cf108e0f-dd53-475b-b7a8-def914fcf5f3
       Content-Length:
       - '4117'
       Connection:
@@ -4705,10 +4705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:55.235547", "expires":
-        "2018-04-09T17:33:55Z", "id": "c7f8d9ee40b144d7853196a0464c4e92", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:38.596506", "expires":
+        "2018-04-19T18:45:38Z", "id": "b313a45d25a44e88841a03de92f91e48", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bxqx3OoZQnqcngrELNRPeQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dP1wyfv9RbyCvulEvF2f7Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4752,7 +4752,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4767,22 +4767,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7f8d9ee40b144d7853196a0464c4e92
+      - b313a45d25a44e88841a03de92f91e48
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ba99e7cc-b075-4953-a0a9-829436d84fc5
+      - req-ed3f0236-c6a9-4ede-bdca-2a72830de6a8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ba99e7cc-b075-4953-a0a9-829436d84fc5
+      - req-ed3f0236-c6a9-4ede-bdca-2a72830de6a8
       Date:
-      - Mon, 09 Apr 2018 16:33:55 GMT
+      - Thu, 19 Apr 2018 17:45:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4792,7 +4792,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4810,13 +4810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:56 GMT
+      - Thu, 19 Apr 2018 17:45:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4fc79309-dacd-414c-845e-fadf5635ead6
+      - req-a25c0b1c-008b-4342-9036-37a6179b3b75
       Content-Length:
       - '4131'
       Connection:
@@ -4825,10 +4825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:56.204194", "expires":
-        "2018-04-09T17:33:56Z", "id": "6c16d2bc7bf74adc91250b5dab45a778", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:42.062424", "expires":
+        "2018-04-19T18:45:41Z", "id": "f5f5baa41297435eb9f6a5dcb4f607a1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JpKgnbE9Qxi9aOasbXmi-g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["J-cH41nJROeH259Xs2-2jQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4872,7 +4872,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4887,22 +4887,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c16d2bc7bf74adc91250b5dab45a778
+      - f5f5baa41297435eb9f6a5dcb4f607a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf9b9370-8827-4efb-a204-916c7b13e0aa
+      - req-57c2305f-620b-428c-ba35-6ab7d7b342d3
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cf9b9370-8827-4efb-a204-916c7b13e0aa
+      - req-57c2305f-620b-428c-ba35-6ab7d7b342d3
       Date:
-      - Mon, 09 Apr 2018 16:33:57 GMT
+      - Thu, 19 Apr 2018 17:45:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4912,7 +4912,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4927,22 +4927,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f6f7d22301a48a791ddb78dfd05b6a5
+      - 00af18fa85d743199800cfbcc2d9e579
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ddbae0dd-50af-4781-ac65-fbb47076e448
+      - req-01cd89d3-d099-4723-992b-4b57613620a3
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ddbae0dd-50af-4781-ac65-fbb47076e448
+      - req-01cd89d3-d099-4723-992b-4b57613620a3
       Date:
-      - Mon, 09 Apr 2018 16:33:57 GMT
+      - Thu, 19 Apr 2018 17:45:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4952,7 +4952,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4970,13 +4970,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:57 GMT
+      - Thu, 19 Apr 2018 17:45:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7c0503c5-3d5b-40ad-be19-f482146ac030
+      - req-eaf0e6cb-9726-4023-96f7-ae7ab15516df
       Content-Length:
       - '4118'
       Connection:
@@ -4985,10 +4985,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:57.790719", "expires":
-        "2018-04-09T17:33:57Z", "id": "7a2692a0a8b3421a9d37e77c9b59ec37", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:43.497771", "expires":
+        "2018-04-19T18:45:43Z", "id": "28d278905f764ae49223f3b3a42346f0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tCwMZv2XRf2RuvsQ9e0-6Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["t0FaD_7xRXS1GPOmXCCFTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5032,7 +5032,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -5047,22 +5047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a2692a0a8b3421a9d37e77c9b59ec37
+      - 28d278905f764ae49223f3b3a42346f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cb9a2a0c-6d33-4fab-a669-4809420bab64
+      - req-3cca1424-627e-471d-95d5-f9a06bff40fc
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cb9a2a0c-6d33-4fab-a669-4809420bab64
+      - req-3cca1424-627e-471d-95d5-f9a06bff40fc
       Date:
-      - Mon, 09 Apr 2018 16:33:58 GMT
+      - Thu, 19 Apr 2018 17:45:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5072,7 +5072,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5090,13 +5090,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:58 GMT
+      - Thu, 19 Apr 2018 17:45:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6077c192-9692-4038-b1d0-cd8b3c685fef
+      - req-1cdcaf3b-ac1c-4b40-aed4-5840cf087b66
       Content-Length:
       - '4170'
       Connection:
@@ -5105,10 +5105,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:58.646116", "expires":
-        "2018-04-09T17:33:58Z", "id": "90d4f4497e0f4a94b09b5b619352775b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:44.824761", "expires":
+        "2018-04-19T18:45:44Z", "id": "3a35fead76f54ec99dc48cbed43842ea", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RXaUYIplQeOFXpBzG5ENPw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vmpBY0PWRAaoBIvu84eedg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5153,7 +5153,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -5168,7 +5168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90d4f4497e0f4a94b09b5b619352775b
+      - 3a35fead76f54ec99dc48cbed43842ea
   response:
     status:
       code: 200
@@ -5179,13 +5179,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:33:58 GMT
+      - Thu, 19 Apr 2018 17:45:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5203,13 +5203,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:58 GMT
+      - Thu, 19 Apr 2018 17:45:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49cf8d98-9d4b-4c2a-aec7-da72de8e147c
+      - req-a8aa83af-548e-4c75-8990-344b84233b98
       Content-Length:
       - '4117'
       Connection:
@@ -5218,10 +5218,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:58.989656", "expires":
-        "2018-04-09T17:33:58Z", "id": "6245b2cd7a334a5baa723808f90338d6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:45.172528", "expires":
+        "2018-04-19T18:45:45Z", "id": "7ef0bca7482044f287f560f4a3463aac", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WvhfDJ7CQ8G7rm-rDPrv_g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VcGuWpsqQw6EapNsukoZgA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5265,7 +5265,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -5280,7 +5280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6245b2cd7a334a5baa723808f90338d6
+      - 7ef0bca7482044f287f560f4a3463aac
   response:
     status:
       code: 200
@@ -5291,16 +5291,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-981b6597-b041-4fb3-bee6-87de97de398d
+      - req-3998de28-fa89-4091-b0cf-462c808b041b
       Date:
-      - Mon, 09 Apr 2018 16:33:59 GMT
+      - Thu, 19 Apr 2018 17:45:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5318,13 +5318,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:59 GMT
+      - Thu, 19 Apr 2018 17:45:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-869089fb-5542-4c24-a9fd-e4c1dd540119
+      - req-f674f946-af10-487a-8898-ae9c9fc0624d
       Content-Length:
       - '4131'
       Connection:
@@ -5333,10 +5333,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:59.505264", "expires":
-        "2018-04-09T17:33:59Z", "id": "d375bd3cdf104b0180024f3cfede8c5c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:46.043220", "expires":
+        "2018-04-19T18:45:45Z", "id": "b1c0a7d942944c20b68544894a2ce6b8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5xhHJp7rSsSzAattBFjn6A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SLpg3q5fT96tKzpm2M7lgw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5380,7 +5380,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -5395,7 +5395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -5406,16 +5406,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d63caec7-d319-47de-9431-6f31160739b2
+      - req-19895f5d-d4dd-4fce-821d-b51123028ec6
       Date:
-      - Mon, 09 Apr 2018 16:33:59 GMT
+      - Thu, 19 Apr 2018 17:45:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90d4f4497e0f4a94b09b5b619352775b
+      - 3a35fead76f54ec99dc48cbed43842ea
   response:
     status:
       code: 200
@@ -5441,16 +5441,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-588fdf29-b8ce-4a6a-b6fa-d381cb04dffb
+      - req-0f0868bc-5fd3-4a47-a5ef-a16e8eed0b6c
       Date:
-      - Mon, 09 Apr 2018 16:34:00 GMT
+      - Thu, 19 Apr 2018 17:45:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5468,13 +5468,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:00 GMT
+      - Thu, 19 Apr 2018 17:45:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-82b58b86-b4e7-4c95-8a1c-79a7f21256f9
+      - req-7395b159-4a16-433d-9300-53c9fa53fa5e
       Content-Length:
       - '4118'
       Connection:
@@ -5483,10 +5483,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:00.286546", "expires":
-        "2018-04-09T17:34:00Z", "id": "87b985928aaa4dba9fd52335bafb6685", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:46.883452", "expires":
+        "2018-04-19T18:45:46Z", "id": "c07d74089e5842e897015e0ea650b3a8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SqOLBt7tQreMJskQ5ZIq4A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BvgzNh9sQ4mQZrz4-zI2Jg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5530,7 +5530,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5545,7 +5545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -5556,16 +5556,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b6cb38f0-1970-440e-bd16-22cfa1afe0d5
+      - req-18eaab4d-84b6-4a10-b51b-41f84e5e0159
       Date:
-      - Mon, 09 Apr 2018 16:34:00 GMT
+      - Thu, 19 Apr 2018 17:45:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5580,7 +5580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5593,9 +5593,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-97616925-1943-4765-a7d3-4591949a40f0
+      - req-e944a152-e5fe-418c-b273-682caf9e26e2
       Date:
-      - Mon, 09 Apr 2018 16:34:01 GMT
+      - Thu, 19 Apr 2018 17:45:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5618,7 +5618,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5633,7 +5633,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5646,9 +5646,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-997d565b-1cef-441f-9635-7ac61287d6da
+      - req-00eec4a2-6bcb-4459-b92e-c424e39c2e1c
       Date:
-      - Mon, 09 Apr 2018 16:34:01 GMT
+      - Thu, 19 Apr 2018 17:45:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5671,7 +5671,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5686,7 +5686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5699,9 +5699,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a241a0f2-3785-4660-a2f4-7d5742734eb1
+      - req-f7d1ed0d-1cef-4a1b-9dd2-39615ed56c5a
       Date:
-      - Mon, 09 Apr 2018 16:34:01 GMT
+      - Thu, 19 Apr 2018 17:45:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5724,7 +5724,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5739,7 +5739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5752,9 +5752,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-35d57af4-e6c5-4fdf-be79-002192641ae4
+      - req-fa867803-2ae1-4619-8262-e4679b13cf90
       Date:
-      - Mon, 09 Apr 2018 16:34:02 GMT
+      - Thu, 19 Apr 2018 17:45:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5777,7 +5777,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5792,7 +5792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5805,9 +5805,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-201a8d73-74af-463a-b532-ec285fbf62ec
+      - req-67015bc0-bfbe-4b7e-8f76-c5d85eeacff6
       Date:
-      - Mon, 09 Apr 2018 16:34:02 GMT
+      - Thu, 19 Apr 2018 17:45:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5830,7 +5830,43 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:49 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 06cb86afcb5247a49fd01bc7400c4313
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-9d82136c-f142-4996-b43f-d4feb13fac9a
+      Date:
+      - Thu, 19 Apr 2018 17:45:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
+        "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5845,7 +5881,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5858,9 +5894,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-8d3aeff6-25b9-4754-820f-0bf1da83268a
+      - req-a1b62b06-a37d-4dc2-8d31-e97020a7f54d
       Date:
-      - Mon, 09 Apr 2018 16:34:02 GMT
+      - Thu, 19 Apr 2018 17:45:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5883,7 +5919,43 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:50 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 06cb86afcb5247a49fd01bc7400c4313
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-062ecd7d-3ed1-42dd-abf7-79e2c5097077
+      Date:
+      - Thu, 19 Apr 2018 17:45:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5898,7 +5970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5911,9 +5983,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1847eb86-16de-4e8f-b263-a485f0f40429
+      - req-fd7bf498-819d-4ae2-bd7a-f5f677d33789
       Date:
-      - Mon, 09 Apr 2018 16:34:03 GMT
+      - Thu, 19 Apr 2018 17:45:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5936,7 +6008,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5951,7 +6023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5964,9 +6036,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-72814389-a500-4150-8b7e-4431efc2eafe
+      - req-ef88b9fe-be1b-4f16-a486-510573c0204d
       Date:
-      - Mon, 09 Apr 2018 16:34:03 GMT
+      - Thu, 19 Apr 2018 17:45:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5989,7 +6061,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -6004,7 +6076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 622b2953b3f34082a7985b39b8fdf31b
+      - 06cb86afcb5247a49fd01bc7400c4313
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6017,9 +6089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-079a057c-ffb8-4561-ab51-1cc5a6f21ec7
+      - req-2ddd4378-b5d6-461c-a405-1e1a8fbf2989
       Date:
-      - Mon, 09 Apr 2018 16:34:03 GMT
+      - Thu, 19 Apr 2018 17:45:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -6042,7 +6114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6060,13 +6132,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:03 GMT
+      - Thu, 19 Apr 2018 17:45:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-663202a8-f236-4cc2-a60b-699a88021e94
+      - req-f20c36af-fdd2-4ae0-8c27-44993ebec6af
       Content-Length:
       - '4170'
       Connection:
@@ -6075,10 +6147,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:04.128544", "expires":
-        "2018-04-09T17:34:04Z", "id": "807f4112dfee4e1bb3820b049c00f98f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:51.692112", "expires":
+        "2018-04-19T18:45:51Z", "id": "ecc39a8381054379b292fa9750dddced", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ucAhoAX7SduXhCJFeo8hcQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HSgcUdFHTJq3GiQUCtAqyA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6123,13 +6195,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"807f4112dfee4e1bb3820b049c00f98f"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"ecc39a8381054379b292fa9750dddced"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6141,13 +6213,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:04 GMT
+      - Thu, 19 Apr 2018 17:45:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a6021c5e-5e26-4ccd-91a0-ce35654a633e
+      - req-e02f9557-6be3-425b-89ad-097dcacf3ddd
       Content-Length:
       - '4196'
       Connection:
@@ -6156,10 +6228,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:04.396984", "expires":
-        "2018-04-09T17:34:04Z", "id": "26c4b9f6c6d245cfb737d32e3b30a3cf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:51.968797", "expires":
+        "2018-04-19T18:45:51Z", "id": "c24584951e554de48ef05150f0b42a6e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DuHYPM-mRryoE9fo3v7_VQ", "ucAhoAX7SduXhCJFeo8hcQ"]},
+        "name": "admin"}, "audit_ids": ["9-BEBna7Qz-U3tnrLCUYEg", "HSgcUdFHTJq3GiQUCtAqyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6204,7 +6276,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6222,13 +6294,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:04 GMT
+      - Thu, 19 Apr 2018 17:45:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cf6331d8-cf53-47e1-ac15-04f56456a5c3
+      - req-2a1d26d9-fb99-4514-a426-e5f31b9b7ca1
       Content-Length:
       - '4170'
       Connection:
@@ -6237,10 +6309,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:04.810377", "expires":
-        "2018-04-09T17:34:04Z", "id": "e22ecd692d3f4083981fecb467bf5cb8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:52.300991", "expires":
+        "2018-04-19T18:45:52Z", "id": "0ec23fc45cc84712aeb37c86abfcca04", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["GQPrNNHVRKKwuDwsKX5Pew"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jiiIe4fWRSqxfUQYFKw2XQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6285,13 +6357,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"e22ecd692d3f4083981fecb467bf5cb8"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"0ec23fc45cc84712aeb37c86abfcca04"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6303,13 +6375,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:04 GMT
+      - Thu, 19 Apr 2018 17:45:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e453966-d525-426b-8e6f-ae739a5b5d44
+      - req-6d6468e2-2f48-4bc0-b64f-91f307b6bc6c
       Content-Length:
       - '4196'
       Connection:
@@ -6318,10 +6390,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:05.100504", "expires":
-        "2018-04-09T17:34:04Z", "id": "5a69aad087ad410db0622910c16eca53", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:52.520973", "expires":
+        "2018-04-19T18:45:52Z", "id": "30ef319c46b74d8fa82883e801e2df36", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["g3TtvlW7Tri-BLwWOjV0dw", "GQPrNNHVRKKwuDwsKX5Pew"]},
+        "name": "admin"}, "audit_ids": ["I2FnzD66RduXy5tkPkcKaQ", "jiiIe4fWRSqxfUQYFKw2XQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6366,7 +6438,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -6381,7 +6453,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6af2868192d6462bbfc87cd2e02ced9d
+      - 887b249baa2b4c09b96da8e2a117ee7f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6394,14 +6466,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-2b91c57a-7e30-4fa6-841b-38f62a5583a7
+      - req-9587026f-d939-4e71-8010-0155ee32ff81
       Date:
-      - Mon, 09 Apr 2018 16:34:05 GMT
+      - Thu, 19 Apr 2018 17:45:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -6416,22 +6488,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7f8d9ee40b144d7853196a0464c4e92
+      - b313a45d25a44e88841a03de92f91e48
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1817933-2234-4a4a-8c7d-b24f4d64dd4e
+      - req-c6a275da-0b96-4fc5-9bbc-76b1708c0cc8
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-a1817933-2234-4a4a-8c7d-b24f4d64dd4e
+      - req-c6a275da-0b96-4fc5-9bbc-76b1708c0cc8
       Date:
-      - Mon, 09 Apr 2018 16:34:05 GMT
+      - Thu, 19 Apr 2018 17:45:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6464,7 +6536,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6479,22 +6551,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7f8d9ee40b144d7853196a0464c4e92
+      - b313a45d25a44e88841a03de92f91e48
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37014800-611c-487b-b48f-a2d5e5d45d26
+      - req-6002d89c-f7a4-499a-9587-5e81ccf84edd
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-37014800-611c-487b-b48f-a2d5e5d45d26
+      - req-6002d89c-f7a4-499a-9587-5e81ccf84edd
       Date:
-      - Mon, 09 Apr 2018 16:34:05 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6511,7 +6583,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6526,27 +6598,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c16d2bc7bf74adc91250b5dab45a778
+      - f5f5baa41297435eb9f6a5dcb4f607a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af3ff649-c673-4ddf-9cdf-36483a2caaf2
+      - req-3cf2924f-a255-4f79-a477-d37264a15a45
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-af3ff649-c673-4ddf-9cdf-36483a2caaf2
+      - req-3cf2924f-a255-4f79-a477-d37264a15a45
       Date:
-      - Mon, 09 Apr 2018 16:34:06 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6561,27 +6633,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f6f7d22301a48a791ddb78dfd05b6a5
+      - 00af18fa85d743199800cfbcc2d9e579
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-35419708-b9b8-4238-b2a3-92d7767ab7d1
+      - req-cb43e35f-9a41-423f-92a7-21a1d47ce67f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-35419708-b9b8-4238-b2a3-92d7767ab7d1
+      - req-cb43e35f-9a41-423f-92a7-21a1d47ce67f
       Date:
-      - Mon, 09 Apr 2018 16:34:06 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6596,27 +6668,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a2692a0a8b3421a9d37e77c9b59ec37
+      - 28d278905f764ae49223f3b3a42346f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29a5314f-2e9a-4f33-bbad-6d426c32eaff
+      - req-fde51435-1667-460a-bdac-8c43a7c4955a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-29a5314f-2e9a-4f33-bbad-6d426c32eaff
+      - req-fde51435-1667-460a-bdac-8c43a7c4955a
       Date:
-      - Mon, 09 Apr 2018 16:34:06 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6631,22 +6703,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7f8d9ee40b144d7853196a0464c4e92
+      - b313a45d25a44e88841a03de92f91e48
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-585e97e2-a8dc-4f60-8749-4169ad699b81
+      - req-a9985ef7-d36f-42e3-8d92-b4050713d72e
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-585e97e2-a8dc-4f60-8749-4169ad699b81
+      - req-a9985ef7-d36f-42e3-8d92-b4050713d72e
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6661,7 +6733,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6676,22 +6748,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7f8d9ee40b144d7853196a0464c4e92
+      - b313a45d25a44e88841a03de92f91e48
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-924d669f-31f3-4ef3-a4af-4c7eb4ea7982
+      - req-bb18684b-34fa-4823-80c6-251643c6b24c
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-924d669f-31f3-4ef3-a4af-4c7eb4ea7982
+      - req-bb18684b-34fa-4823-80c6-251643c6b24c
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6706,7 +6778,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6721,27 +6793,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c16d2bc7bf74adc91250b5dab45a778
+      - f5f5baa41297435eb9f6a5dcb4f607a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2d8547a-cfd8-459b-b72f-f120f2e4960b
+      - req-1d932c3e-ad0e-4c41-a0e8-ad27e5848e3a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a2d8547a-cfd8-459b-b72f-f120f2e4960b
+      - req-1d932c3e-ad0e-4c41-a0e8-ad27e5848e3a
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6756,27 +6828,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c16d2bc7bf74adc91250b5dab45a778
+      - f5f5baa41297435eb9f6a5dcb4f607a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ac8e237-4475-4963-92b5-87b6a367683f
+      - req-1291ccb4-9554-419c-8a7d-fe75e376f953
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3ac8e237-4475-4963-92b5-87b6a367683f
+      - req-1291ccb4-9554-419c-8a7d-fe75e376f953
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6791,27 +6863,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f6f7d22301a48a791ddb78dfd05b6a5
+      - 00af18fa85d743199800cfbcc2d9e579
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52936ae2-6246-4adb-a4ab-356da224bba2
+      - req-5496b2ef-43ea-42c3-a9d6-acc79f3b79a7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-52936ae2-6246-4adb-a4ab-356da224bba2
+      - req-5496b2ef-43ea-42c3-a9d6-acc79f3b79a7
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6826,27 +6898,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f6f7d22301a48a791ddb78dfd05b6a5
+      - 00af18fa85d743199800cfbcc2d9e579
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-92b5028a-6811-455f-82f9-6bca86c7a82d
+      - req-1961c34e-531b-4fb2-aaae-221790bbb5fa
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-92b5028a-6811-455f-82f9-6bca86c7a82d
+      - req-1961c34e-531b-4fb2-aaae-221790bbb5fa
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6861,27 +6933,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a2692a0a8b3421a9d37e77c9b59ec37
+      - 28d278905f764ae49223f3b3a42346f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7e85778-b96a-4102-8937-b65222ce1ce1
+      - req-3e46ab79-c192-428f-8e7c-18eeb6f213d9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f7e85778-b96a-4102-8937-b65222ce1ce1
+      - req-3e46ab79-c192-428f-8e7c-18eeb6f213d9
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6896,27 +6968,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a2692a0a8b3421a9d37e77c9b59ec37
+      - 28d278905f764ae49223f3b3a42346f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f02a9588-9920-4709-9f12-682cdc5363c3
+      - req-94e58910-fac0-4cb5-9a71-9cee98f4fccc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f02a9588-9920-4709-9f12-682cdc5363c3
+      - req-94e58910-fac0-4cb5-9a71-9cee98f4fccc
       Date:
-      - Mon, 09 Apr 2018 16:34:07 GMT
+      - Thu, 19 Apr 2018 17:45:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6934,13 +7006,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:08 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1e49357-7e60-422e-9e23-5d2926f85fbe
+      - req-2f77b909-7c63-494d-8279-b7fb43bf02bc
       Content-Length:
       - '4170'
       Connection:
@@ -6949,10 +7021,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:08.868896", "expires":
-        "2018-04-09T17:34:08Z", "id": "2317a62a312b4e98b1745a1fa764f876", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:56.160240", "expires":
+        "2018-04-19T18:45:56Z", "id": "6eda622a8f1249e69473287da6fa608f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pVpZx0RXSeOzI_dHY7ovBQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GI5AecD9T0yoQ6kq9uNXxQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6997,7 +7069,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7015,13 +7087,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:08 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-afe8da33-6f27-4006-8e6e-4456cbf98bf1
+      - req-aebea3a1-fc60-43af-876c-2155b43e66a5
       Content-Length:
       - '4170'
       Connection:
@@ -7030,10 +7102,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:09.130387", "expires":
-        "2018-04-09T17:34:09Z", "id": "792434ac220a40e5b34fd0ce307de31b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:56.355633", "expires":
+        "2018-04-19T18:45:56Z", "id": "bbaa39148df74cd880ceac3078f8f697", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["h6yLac8-S4G0yj8pIt6y-A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rC1fH-tARf6X7E2A_hYNIA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7078,7 +7150,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -7093,7 +7165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -7104,42 +7176,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-8dcb6ab4-e346-4e2a-947c-48014022ffd8
+      - req-97b11702-184d-4fe2-8650-c347f4ef5ba9
       Date:
-      - Mon, 09 Apr 2018 16:34:09 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -7164,19 +7206,49 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7194,13 +7266,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:09 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e67677c8-be10-4821-a1aa-d7c4d76de5c9
+      - req-1d0b3764-1407-4257-967b-bbd07e21a1d6
       Content-Length:
       - '4170'
       Connection:
@@ -7209,10 +7281,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:09.798713", "expires":
-        "2018-04-09T17:34:09Z", "id": "6a055d28aaec4bbca31d7ca15c6f36d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:56.759176", "expires":
+        "2018-04-19T18:45:56Z", "id": "81547fd451c44e69b70e9ddd9e7dede2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["s-jJF-yPSputT7mRq2XZKA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["r3u7XDD0TJadk5DP5Jn9bA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7257,7 +7329,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7275,13 +7347,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:09 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2369aa8-3cb1-4613-b884-6d1ef4dd08bb
+      - req-fd217d52-c511-4981-ae44-43e9759932d6
       Content-Length:
       - '370'
       Connection:
@@ -7290,13 +7362,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:09.993097", "expires":
-        "2018-04-09T17:34:09Z", "id": "0a062ec9603a412a897dc88302366526", "audit_ids":
-        ["KKoj4qr5TF6_4AyQkYrBcQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:56.894828", "expires":
+        "2018-04-19T18:45:56Z", "id": "61415e8bfb07429a9e5541061e7781bc", "audit_ids":
+        ["0IXATl2cRuimzWA-psMjEA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:56 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7311,20 +7383,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a062ec9603a412a897dc88302366526
+      - 61415e8bfb07429a9e5541061e7781bc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:10 GMT
+      - Thu, 19 Apr 2018 17:45:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fd8e93fc-32dd-4200-9c4c-f37d9c704e5f
+      - req-6b744c98-f796-4bce-94f1-ae26519c8154
       Content-Length:
       - '500'
       Connection:
@@ -7341,13 +7413,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"0a062ec9603a412a897dc88302366526"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"61415e8bfb07429a9e5541061e7781bc"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7359,13 +7431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:10 GMT
+      - Thu, 19 Apr 2018 17:45:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-41c4fd40-f2c0-4cb3-b2f8-0ad49bc1e548
+      - req-c8c094e1-7c8e-4b95-8389-f4299f282d21
       Content-Length:
       - '4143'
       Connection:
@@ -7374,11 +7446,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:10.409156", "expires":
-        "2018-04-09T17:34:09Z", "id": "945f8eb3d6b64382bae82df6211dbd69", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:57.204143", "expires":
+        "2018-04-19T18:45:56Z", "id": "7164e27827324b549b07d65d691d5013", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HliNP6ySS7C8o_DxN7A_HA",
-        "KKoj4qr5TF6_4AyQkYrBcQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["6p1cjw-qROKDvorrVKYvPQ",
+        "0IXATl2cRuimzWA-psMjEA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7422,7 +7494,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7437,20 +7509,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a062ec9603a412a897dc88302366526
+      - 61415e8bfb07429a9e5541061e7781bc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:10 GMT
+      - Thu, 19 Apr 2018 17:45:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-607cfc53-2228-4d88-ba37-288af7823a37
+      - req-5273d91c-8ce3-4109-978f-d4093f97f91a
       Content-Length:
       - '500'
       Connection:
@@ -7467,7 +7539,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7485,13 +7557,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:10 GMT
+      - Thu, 19 Apr 2018 17:45:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e4db714e-ee5f-4a66-93e1-4e2e9392f8dd
+      - req-3e990082-9319-403a-9698-663ad2db82b5
       Content-Length:
       - '4117'
       Connection:
@@ -7500,10 +7572,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:10.948766", "expires":
-        "2018-04-09T17:34:10Z", "id": "2719c0c1f9284c0182a98b6e44d99059", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:57.558160", "expires":
+        "2018-04-19T18:45:57Z", "id": "12ee66fd8e244f28b7f139f33615e279", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jNlXXXIiR6SWzofj03P69Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["nMOugyYQRBWre54RK86NlA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7547,7 +7619,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7565,13 +7637,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:11 GMT
+      - Thu, 19 Apr 2018 17:45:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a1227f3-2725-42fe-9e4c-cdbc2189dd5e
+      - req-a0542821-ff76-4c70-9a3e-9cd25277bc51
       Content-Length:
       - '4131'
       Connection:
@@ -7580,10 +7652,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:11.236645", "expires":
-        "2018-04-09T17:34:11Z", "id": "4f476027c9ba43d9aaa9c8d0a728fa1a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:57.765862", "expires":
+        "2018-04-19T18:45:57Z", "id": "d725c2eded1c4edbb7466a1595243ec8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qQGModP2Q-21OQNRnKtw9Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SvRW3D8CS26W6kgqppC1fQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7627,7 +7699,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7645,13 +7717,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:11 GMT
+      - Thu, 19 Apr 2018 17:45:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-31b4f215-3700-435c-b24e-4a5d8250f975
+      - req-bba34331-eda5-4f23-b813-6225aa5078cc
       Content-Length:
       - '4118'
       Connection:
@@ -7660,10 +7732,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:11.539918", "expires":
-        "2018-04-09T17:34:11Z", "id": "13add9075e844f3bab4db0508ad45149", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:57.999035", "expires":
+        "2018-04-19T18:45:57Z", "id": "1d51c1a3b194448999ceb6bef68cabf6", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0CeKtj_BR4eoDf2hngr_Eg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hjvZzMsmTFKOtzATj-pyKw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7707,7 +7779,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7725,13 +7797,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:11 GMT
+      - Thu, 19 Apr 2018 17:45:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f42fc2c-8840-4c4f-9456-a54bdb1e25fa
+      - req-ac4b19f3-b819-44ec-9b43-46e459c5fa12
       Content-Length:
       - '4117'
       Connection:
@@ -7740,10 +7812,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:11.802693", "expires":
-        "2018-04-09T17:34:11Z", "id": "ef3ddb90c627429eaf39cf5faaa0da1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:58.204656", "expires":
+        "2018-04-19T18:45:58Z", "id": "8a9be245a94f4ad59ac6e5ae5783ea7d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wuLoeEYPTPuCX-9OOW5n6A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IuCcq1RFRNKkWolEHCMV0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7787,7 +7859,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7802,7 +7874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -7813,9 +7885,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-fb4dab79-fe2f-4d20-ae1f-f8a0ffbc792d
+      - req-f81d4a40-cc6b-40d3-b2ec-e693539fcb74
       Date:
-      - Mon, 09 Apr 2018 16:34:12 GMT
+      - Thu, 19 Apr 2018 17:45:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7849,7 +7921,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7864,7 +7936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -7875,14 +7947,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6a7785e1-0830-4351-9e34-d11e2d13c614
+      - req-f1f3ad84-23b3-41cc-b4d7-ef429d104db9
       Date:
-      - Mon, 09 Apr 2018 16:34:12 GMT
+      - Thu, 19 Apr 2018 17:45:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7900,13 +7972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:12 GMT
+      - Thu, 19 Apr 2018 17:45:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f890f1e2-25c3-41af-b790-70a4909cf963
+      - req-37e44c47-1460-4acf-b03d-54a36362a5fb
       Content-Length:
       - '4131'
       Connection:
@@ -7915,10 +7987,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:12.600671", "expires":
-        "2018-04-09T17:34:12Z", "id": "333b0795628f47eebd8bc126f1cff9fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:58.739012", "expires":
+        "2018-04-19T18:45:58Z", "id": "9d527519453e40629acf9150d18d6609", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qvedC4E3SQKlrNFphBPeDg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SH4FOr8QTpuSn8Aawa_7fw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7962,7 +8034,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7977,7 +8049,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 333b0795628f47eebd8bc126f1cff9fc
+      - 9d527519453e40629acf9150d18d6609
   response:
     status:
       code: 200
@@ -7988,14 +8060,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-13825ac7-f8aa-41a3-9874-921bd453c184
+      - req-17affeb3-9293-4783-b70c-4dcf28803ed4
       Date:
-      - Mon, 09 Apr 2018 16:34:13 GMT
+      - Thu, 19 Apr 2018 17:45:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -8010,7 +8082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a055d28aaec4bbca31d7ca15c6f36d5
+      - 81547fd451c44e69b70e9ddd9e7dede2
   response:
     status:
       code: 200
@@ -8021,14 +8093,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ae4c4bae-4a65-4750-8ee8-54cfd9798de7
+      - req-45894237-55d2-485a-b6ac-4f870523ccbf
       Date:
-      - Mon, 09 Apr 2018 16:34:13 GMT
+      - Thu, 19 Apr 2018 17:45:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8046,13 +8118,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:13 GMT
+      - Thu, 19 Apr 2018 17:45:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-181786df-5389-42ae-a9a5-da42c861b572
+      - req-199f520c-2d51-49ba-b276-0548089f0c7e
       Content-Length:
       - '4118'
       Connection:
@@ -8061,10 +8133,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:13.613635", "expires":
-        "2018-04-09T17:34:13Z", "id": "0afe789925714be2944e376d11967d0a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:59.307838", "expires":
+        "2018-04-19T18:45:59Z", "id": "0f35683da7f04e479bf8cd5fa5bdaaf3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Qrd9eEcxSzuIv4YS8Qwqtw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["St_QWvezTjKqNrewPlXi3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8108,7 +8180,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8123,7 +8195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0afe789925714be2944e376d11967d0a
+      - 0f35683da7f04e479bf8cd5fa5bdaaf3
   response:
     status:
       code: 200
@@ -8134,14 +8206,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4ff27aa2-3737-4cda-a2c1-3f42db5bdaec
+      - req-a6e3e65a-7cd0-446d-b007-ed7b2dfe877d
       Date:
-      - Mon, 09 Apr 2018 16:34:13 GMT
+      - Thu, 19 Apr 2018 17:45:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8156,7 +8228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8167,9 +8239,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-eaf31f96-f1d5-44be-8dd6-aaf78651a299
+      - req-05d30362-388b-40c1-ab73-15b24d11dade
       Date:
-      - Mon, 09 Apr 2018 16:34:15 GMT
+      - Thu, 19 Apr 2018 17:46:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8196,7 +8268,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8211,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8222,9 +8294,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b181c7f3-7610-42f9-9f42-4163e8f7825d
+      - req-fe22dce8-1ebd-4bca-ab3a-5e692074baa2
       Date:
-      - Mon, 09 Apr 2018 16:34:16 GMT
+      - Thu, 19 Apr 2018 17:46:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8251,7 +8323,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8266,7 +8338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8277,9 +8349,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7e14ac4f-eda5-43ce-9af1-d0ea1a983bfe
+      - req-55ab77e6-447b-4483-811c-c97d520d4491
       Date:
-      - Mon, 09 Apr 2018 16:34:16 GMT
+      - Thu, 19 Apr 2018 17:46:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8306,7 +8378,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8321,7 +8393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8332,9 +8404,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-058fc883-ca6d-43e1-b0f6-1c4a35701bd8
+      - req-c28f912c-7095-414e-84b1-446e2ebf4520
       Date:
-      - Mon, 09 Apr 2018 16:34:16 GMT
+      - Thu, 19 Apr 2018 17:46:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8346,7 +8418,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8361,7 +8433,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8372,9 +8444,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1b207b2d-1c25-4d71-a31f-25ceffba6374
+      - req-90491ff2-73e4-4ac0-b0d0-b32dd7f3c99d
       Date:
-      - Mon, 09 Apr 2018 16:34:17 GMT
+      - Thu, 19 Apr 2018 17:46:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8386,7 +8458,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8401,7 +8473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef3ddb90c627429eaf39cf5faaa0da1c
+      - 8a9be245a94f4ad59ac6e5ae5783ea7d
   response:
     status:
       code: 200
@@ -8412,9 +8484,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-822319e3-77dc-4d13-b4fb-9ce75e0ba86f
+      - req-957f4e63-1ac1-4439-a1eb-60118a57d6e4
       Date:
-      - Mon, 09 Apr 2018 16:34:17 GMT
+      - Thu, 19 Apr 2018 17:46:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8426,7 +8498,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8444,13 +8516,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:17 GMT
+      - Thu, 19 Apr 2018 17:46:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87d92201-024b-4e35-84b7-597a48683685
+      - req-bd6e5aa2-f324-4e45-838d-87223d045198
       Content-Length:
       - '4117'
       Connection:
@@ -8459,10 +8531,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:17.535620", "expires":
-        "2018-04-09T17:34:17Z", "id": "a758de89650a443897802e00a4929013", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:01.503486", "expires":
+        "2018-04-19T18:46:01Z", "id": "b34dd3ccbd1c4a6ba413b8eaccf575ab", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MTaeWYRWQ261Rp9zKxCGzA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["erb-7ve3QiO1NkeSuh-y-w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8506,7 +8578,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8521,7 +8593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -8532,16 +8604,69 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-aca29208-c8a0-4292-bc5b-04bf363237d4
+      - req-797e985e-2bfc-4b77-a98a-be27928dbfd3
       Date:
-      - Mon, 09 Apr 2018 16:34:17 GMT
+      - Thu, 19 Apr 2018 17:46:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -8551,6 +8676,73 @@ http_interactions:
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
         "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:46:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c8f02806-4aa4-4313-8a57-09136bf02313
+      Date:
+      - Thu, 19 Apr 2018 17:46:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -8625,20 +8817,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -8653,7 +8857,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -8664,52 +8868,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5a72dfd1-4ca5-4226-be41-e654398b50ed
+      - req-77f3ad5b-cf74-4e44-a8b9-414199080404
       Date:
-      - Mon, 09 Apr 2018 16:34:18 GMT
+      - Thu, 19 Apr 2018 17:46:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8757,20 +8937,176 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:46:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c02df00e-1d34-49a2-9c24-dbd2dddda3c4
+      Date:
+      - Thu, 19 Apr 2018 17:46:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8788,13 +9124,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:18 GMT
+      - Thu, 19 Apr 2018 17:46:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-85444cb0-8915-44c6-813e-d07edc29470c
+      - req-3f1b7ed1-6301-4623-8efc-c578658311bd
       Content-Length:
       - '4131'
       Connection:
@@ -8803,10 +9139,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:18.516846", "expires":
-        "2018-04-09T17:34:18Z", "id": "807bbd23234b42e482daeab9e02e60a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:02.546397", "expires":
+        "2018-04-19T18:46:02Z", "id": "ad072aed5efa43cdaf6ebbb5d4d6f258", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Bt-59KUcTwm89F7XVrrgLA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fvJFOfsjSYi26Cvk2hcn3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8850,7 +9186,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8865,7 +9201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -8876,9 +9212,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bb2f79d1-03ec-4317-803b-80327bde8929
+      - req-288c808b-b555-4380-bd04-18e4ec7b61ba
       Date:
-      - Mon, 09 Apr 2018 16:34:18 GMT
+      - Thu, 19 Apr 2018 17:46:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -8982,7 +9318,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8997,7 +9333,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -9008,52 +9344,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-59b25525-9bc6-4e68-9e7b-9fff6a2ce4e9
+      - req-bd455b88-1f87-416b-9ae2-768352e2ad88
       Date:
-      - Mon, 09 Apr 2018 16:34:19 GMT
+      - Thu, 19 Apr 2018 17:46:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9101,183 +9402,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f8386ef2-8ebe-4e72-9959-fd3ae3901336
-      Date:
-      - Mon, 09 Apr 2018 16:34:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a4e879f4-6217-4850-ba56-c4253dfdc41a
-      Date:
-      - Mon, 09 Apr 2018 16:34:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -9301,12 +9426,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -9318,185 +9437,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-dc510fd5-03c6-4cdb-99ce-021326238fe3
-      Date:
-      - Mon, 09 Apr 2018 16:34:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9510,139 +9450,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f555d901-d4b3-481a-bd96-79ed83cb4e7f
-      Date:
-      - Mon, 09 Apr 2018 16:34:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9657,7 +9465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -9668,141 +9476,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-eb5cf7bb-6220-437f-98ea-b4630561701e
+      - req-2f041f8b-331a-464c-ad08-73d40a463039
       Date:
-      - Mon, 09 Apr 2018 16:34:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-549993c6-7319-4dc5-8f09-1a1388b4d9c1
-      Date:
-      - Mon, 09 Apr 2018 16:34:20 GMT
+      - Thu, 19 Apr 2018 17:46:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -9906,7 +9582,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9921,7 +9597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -9932,52 +9608,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8f9db79c-5532-44ec-8d04-f38789e2a40f
+      - req-067dde88-b18e-4e93-a06b-f6d76d2e0750
       Date:
-      - Mon, 09 Apr 2018 16:34:20 GMT
+      - Thu, 19 Apr 2018 17:46:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -10025,51 +9666,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fcbc5386-dda6-4024-815c-08e3059dbcd7
-      Date:
-      - Mon, 09 Apr 2018 16:34:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -10093,12 +9690,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -10110,67 +9701,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10188,13 +9732,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:21 GMT
+      - Thu, 19 Apr 2018 17:46:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3046e3c8-21c9-482d-bc92-7047694f4175
+      - req-aaed68ee-47d7-4ac1-80c7-918706625530
       Content-Length:
       - '4118'
       Connection:
@@ -10203,10 +9747,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:21.293159", "expires":
-        "2018-04-09T17:34:21Z", "id": "f7794a9f350d49f291ef79f277440d53", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:03.771119", "expires":
+        "2018-04-19T18:46:03Z", "id": "71fa4b272f5c4db9847d30eb55a332d2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dqaozbz1Q8S533nydeb6gA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6h7CRjnuRnGzCAn4RT46Eg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10250,7 +9794,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -10265,7 +9809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -10276,9 +9820,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ac4de8a1-2778-424c-b4f2-a09ed56f7918
+      - req-7aedfdcb-14c2-44b4-b6d4-6fbe980009a0
       Date:
-      - Mon, 09 Apr 2018 16:34:21 GMT
+      - Thu, 19 Apr 2018 17:46:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -10382,7 +9926,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -10397,7 +9941,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -10408,52 +9952,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a75b36e9-30ce-4c67-9a80-9b99c050149c
+      - req-d0b6bae2-ccaf-48a2-8622-447b30bc8078
       Date:
-      - Mon, 09 Apr 2018 16:34:21 GMT
+      - Thu, 19 Apr 2018 17:46:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -10501,108 +10010,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b691fc4f-9555-4c84-9b61-26ac70f6637d
-      Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -10616,155 +10028,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7d0cbe8e-d454-42cf-a710-4b27f432509e
-      Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -10778,7 +10058,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10793,7 +10073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -10804,9 +10084,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-eb695da4-26b3-4fd6-a17a-53b1aa901a27
+      - req-c766d13d-ad1d-43f5-8f54-5a78396c6854
       Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10848,7 +10128,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10863,7 +10143,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -10874,9 +10154,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-364e7697-fea1-4fa0-8215-afd79bd961a1
+      - req-4e514a03-a7f8-4bfb-aebc-7930591722e1
       Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10918,7 +10198,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10933,7 +10213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -10944,9 +10224,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-85b64498-cd51-4b4a-a5f0-399aa4702179
+      - req-f01c9248-67fe-42b2-baee-d7084bf825e4
       Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10988,7 +10268,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11003,7 +10283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -11014,9 +10294,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-08cf3756-d3af-493c-b307-77d69e5972b3
+      - req-148df810-c7bb-4885-bc1e-dc5025e4a167
       Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11058,7 +10338,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -11073,7 +10353,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -11084,9 +10364,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-64248032-bcf2-4366-8aff-c068ba3cca89
+      - req-e6aa1938-430f-45f6-92ab-dca4f32a10aa
       Date:
-      - Mon, 09 Apr 2018 16:34:22 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11128,7 +10408,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11143,7 +10423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -11154,9 +10434,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c7b80341-79d1-4fa9-b393-9d0af584037d
+      - req-a3ac9ab3-fbb1-41d0-bc4d-ba761a73ca5d
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11198,7 +10478,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -11213,7 +10493,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -11224,9 +10504,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-85f4d032-c029-4781-8eb8-caa2b3e06334
+      - req-37ee1d27-7349-41f4-92a1-5564b6ddb93b
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11268,7 +10548,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11283,7 +10563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -11294,9 +10574,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a10b2ab5-6583-4565-a8b2-ce70d99b393a
+      - req-c53e41a6-8850-4952-84ef-0eff2cf64032
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11338,7 +10618,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11353,7 +10633,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -11364,9 +10644,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6eeb5857-f287-4482-9c35-42a9e91d434c
+      - req-0965d6dc-603c-491c-9eae-0cb1c0e4ce38
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11769,7 +11049,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11784,7 +11064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -11795,9 +11075,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7d0c179f-8af5-420e-8341-a6c42620ad13
+      - req-4fd02978-1bf3-47d8-a2eb-f1293a60c3f6
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12200,7 +11480,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12215,7 +11495,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -12226,9 +11506,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dade5ef7-6264-40ad-a31c-2dacfd75fcb5
+      - req-668ab618-e7b4-4d3c-8a4f-d42d5acfa02c
       Date:
-      - Mon, 09 Apr 2018 16:34:23 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12631,7 +11911,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12646,7 +11926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -12657,9 +11937,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7f56c8f2-a511-43a6-b38d-7b1781fda3a0
+      - req-f9880cf1-a34d-4056-843a-98d3450b3671
       Date:
-      - Mon, 09 Apr 2018 16:34:24 GMT
+      - Thu, 19 Apr 2018 17:46:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13062,7 +12342,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13077,7 +12357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -13088,9 +12368,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ce5b5f9c-6325-4ee4-a3ff-2e63fc85300c
+      - req-059f31e5-9b50-4e7a-a5ac-3ee0378e5c78
       Date:
-      - Mon, 09 Apr 2018 16:34:24 GMT
+      - Thu, 19 Apr 2018 17:46:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13493,7 +12773,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13508,7 +12788,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -13519,9 +12799,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-60dfb83a-0569-41b6-be17-5adc1b6192ad
+      - req-e7fc8eee-c8bd-47d1-b77e-da6c56a19bd8
       Date:
-      - Mon, 09 Apr 2018 16:34:24 GMT
+      - Thu, 19 Apr 2018 17:46:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13924,7 +13204,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:24 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13939,7 +13219,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -13950,9 +13230,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5b662308-30c6-4f34-addf-49073f15ef17
+      - req-140b0768-ef96-4316-a8c7-e2674cfecbf1
       Date:
-      - Mon, 09 Apr 2018 16:34:25 GMT
+      - Thu, 19 Apr 2018 17:46:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14355,7 +13635,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -14370,7 +13650,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -14381,9 +13661,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bfa590d7-b943-49e0-94e2-0a7e816c5977
+      - req-aaefc01c-677d-4527-a271-5867941ae171
       Date:
-      - Mon, 09 Apr 2018 16:34:25 GMT
+      - Thu, 19 Apr 2018 17:46:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14786,7 +14066,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14801,7 +14081,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -14812,9 +14092,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-dce570c0-f155-4b9e-8942-dff08fb3cb53
+      - req-3a7abc1c-1871-45c3-87bf-512d42eb593c
       Date:
-      - Mon, 09 Apr 2018 16:34:25 GMT
+      - Thu, 19 Apr 2018 17:46:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14846,7 +14126,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14861,7 +14141,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -14872,9 +14152,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-598332d3-af2e-4bb5-b2e2-10f0a89cd5ce
+      - req-6e22c6ca-f6d7-4477-9b04-6d28d19bf0c8
       Date:
-      - Mon, 09 Apr 2018 16:34:25 GMT
+      - Thu, 19 Apr 2018 17:46:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14906,7 +14186,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14921,7 +14201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -14932,9 +14212,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-956d2d40-e169-4e66-b869-b536c69b7e85
+      - req-7246a089-6c9d-4890-aa30-376e68b6be55
       Date:
-      - Mon, 09 Apr 2018 16:34:25 GMT
+      - Thu, 19 Apr 2018 17:46:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14966,7 +14246,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14981,7 +14261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -14992,9 +14272,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-efa2779b-ac31-4c43-945c-4f02f8cd554e
+      - req-d0166393-21ee-46fa-bd80-134696d658cb
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15026,7 +14306,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -15041,7 +14321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -15052,9 +14332,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-731c4947-74d2-44e6-bd27-e477d2b2e637
+      - req-74221b99-feb5-458e-81f3-909403613f5a
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15086,7 +14366,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -15101,7 +14381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -15112,9 +14392,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6dd1fad8-102a-4afb-83c7-22224b8b4793
+      - req-5375b606-2de8-43cb-8b24-e780b1323009
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15146,7 +14426,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -15161,7 +14441,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -15172,9 +14452,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-50007435-55f0-4d42-86d1-7053072ccd1c
+      - req-f0fcf866-9e13-48c8-8681-cb4b4e8e23a9
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15206,7 +14486,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -15221,7 +14501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -15232,9 +14512,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b9c9c9f2-61a9-48de-b543-d7c28b4c655b
+      - req-4e79d8b3-a9b9-4ba4-b200-fee8e9cf94a5
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15266,7 +14546,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15281,7 +14561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -15292,9 +14572,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-54b15faa-9b39-4a9b-bf59-3e780218f8c2
+      - req-be0b540a-80cd-4401-9b3f-cd4f0301f8ec
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15336,7 +14616,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15351,7 +14631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -15362,9 +14642,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-04af3bb9-19e6-4953-9562-d11a57c7f4ed
+      - req-a3245dd7-3e7e-4196-98a4-c55123003dc2
       Date:
-      - Mon, 09 Apr 2018 16:34:26 GMT
+      - Thu, 19 Apr 2018 17:46:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15407,7 +14687,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:26 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15422,7 +14702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -15433,9 +14713,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-50420452-fc30-409c-9703-0aa77d6fecd3
+      - req-32386249-c589-4b6b-ab5e-ded9d2456b62
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15470,7 +14750,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15485,7 +14765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a758de89650a443897802e00a4929013
+      - b34dd3ccbd1c4a6ba413b8eaccf575ab
   response:
     status:
       code: 200
@@ -15496,9 +14776,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-3f03ecc1-33e3-4797-83ab-04d3fe909e2d
+      - req-2afa6ffe-2ae1-4ec8-bfaa-e1a9889da5e4
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15585,7 +14865,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15600,7 +14880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -15611,9 +14891,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f54a023f-3b83-48fd-8337-bf5e0e87b89f
+      - req-d89ba214-cb57-4373-a90b-60903cc8bf7f
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15655,7 +14935,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15670,7 +14950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -15681,9 +14961,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-571db355-5926-4e64-a550-b577b8705377
+      - req-f23dd654-57e6-4e7c-87cf-a760301a03ff
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15726,7 +15006,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15741,7 +15021,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -15752,9 +15032,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-35db6eff-42d0-42d5-b5ec-b77208840ecc
+      - req-62b8f488-8d34-4104-9ceb-8fce46ae87ae
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15789,7 +15069,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15804,7 +15084,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 807bbd23234b42e482daeab9e02e60a1
+      - ad072aed5efa43cdaf6ebbb5d4d6f258
   response:
     status:
       code: 200
@@ -15815,9 +15095,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-ef43202d-9bab-4f0a-9518-7cf0c205a088
+      - req-510724c9-b504-4de1-811a-06b4c338dc6f
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15904,7 +15184,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:27 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15919,7 +15199,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -15930,9 +15210,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b558bae7-f746-4d3a-9da7-f7323198085d
+      - req-37032735-1cd4-4831-b640-a314c608cedb
       Date:
-      - Mon, 09 Apr 2018 16:34:27 GMT
+      - Thu, 19 Apr 2018 17:46:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15974,7 +15254,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:28 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15989,7 +15269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -16000,9 +15280,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-991111d9-8ad0-4f19-9f85-4eaf977f82a2
+      - req-350bb64f-89a4-4f2f-acd3-2289e75721e0
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -16045,7 +15325,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -16060,7 +15340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -16071,9 +15351,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-3a71fb63-59bc-43f6-9990-1d3c3581db65
+      - req-dc730f84-fe03-43e4-b339-4797aedf8fbb
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -16108,7 +15388,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -16123,7 +15403,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 792434ac220a40e5b34fd0ce307de31b
+      - bbaa39148df74cd880ceac3078f8f697
   response:
     status:
       code: 200
@@ -16134,9 +15414,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-e3041fdf-a995-45d8-841b-60c7dde20b83
+      - req-12cfce9f-315f-4929-b9bc-8eb4473ef430
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -16223,7 +15503,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -16238,7 +15518,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -16249,9 +15529,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a79ff720-5cf9-458a-bf3a-5aa36cee87ca
+      - req-6a20fc6a-c681-4ba2-a9a1-487bb5d79446
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -16293,7 +15573,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -16308,7 +15588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -16319,9 +15599,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-87b75eda-fd13-412c-8f50-a2eda62797c6
+      - req-553921e6-3c96-4471-84fa-d063ebfaafb9
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -16364,7 +15644,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -16379,7 +15659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -16390,9 +15670,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-da81a075-b159-4a0e-9fa2-c57c2b4bab3b
+      - req-6208b92e-f6e0-442c-9db6-a87a0b5e7bad
       Date:
-      - Mon, 09 Apr 2018 16:34:29 GMT
+      - Thu, 19 Apr 2018 17:46:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -16427,7 +15707,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:29 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -16442,7 +15722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7794a9f350d49f291ef79f277440d53
+      - 71fa4b272f5c4db9847d30eb55a332d2
   response:
     status:
       code: 200
@@ -16453,9 +15733,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-9767ddfe-0fa5-4bf5-8e4b-c747ac8d6669
+      - req-19c5794a-bc1c-404a-9656-92cf6d549c14
       Date:
-      - Mon, 09 Apr 2018 16:34:30 GMT
+      - Thu, 19 Apr 2018 17:46:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -16542,7 +15822,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16560,13 +15840,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:30 GMT
+      - Thu, 19 Apr 2018 17:46:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a7ca6e18-5cd7-4eaa-add2-1ecbfb0d0f57
+      - req-85ad6e82-4c65-4515-8ed1-583c77336fd1
       Content-Length:
       - '4170'
       Connection:
@@ -16575,10 +15855,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:30.793448", "expires":
-        "2018-04-09T17:34:30Z", "id": "fd292d4b0b83499a8a97681e63a791e1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:13.736510", "expires":
+        "2018-04-19T18:46:13Z", "id": "0f6dc31514194f1183aed3ab7ae11430", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["625z329tRvOg-TyJlWNVKw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GKvZT5jxQBKhEUFgH8n_hA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16623,7 +15903,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:30 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16641,13 +15921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:30 GMT
+      - Thu, 19 Apr 2018 17:46:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b0405257-6664-4b51-b7c9-b8642dcba75f
+      - req-adf47a36-0ff8-47bb-9520-19037712168a
       Content-Length:
       - '4170'
       Connection:
@@ -16656,10 +15936,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:31.070543", "expires":
-        "2018-04-09T17:34:31Z", "id": "a84d0ea74fd643b0bdbca7f8447e9fcc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:14.108502", "expires":
+        "2018-04-19T18:46:13Z", "id": "ba8a4dcfd3804b4890e2a0adff14e2e9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kXVOHToAStKbnt_Nx-8X2w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YZNn3nWSToSL3RDmRosQlw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16704,7 +15984,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16722,13 +16002,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:31 GMT
+      - Thu, 19 Apr 2018 17:46:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f6f925b0-aabe-4960-aea6-4257a7020c22
+      - req-8525e41e-56ef-43d9-af69-638617d37a71
       Content-Length:
       - '370'
       Connection:
@@ -16737,13 +16017,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:31.261985", "expires":
-        "2018-04-09T17:34:31Z", "id": "6e1a9b4588824c06955a92becb480533", "audit_ids":
-        ["2CYuPwjEQeKM_sXwDe85BA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:14.344181", "expires":
+        "2018-04-19T18:46:14Z", "id": "88c6a0a3bc19412381ca84aa7fee5aa5", "audit_ids":
+        ["ztB_pYGKQ6OkaseeEOzoTQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:14 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16758,20 +16038,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e1a9b4588824c06955a92becb480533
+      - 88c6a0a3bc19412381ca84aa7fee5aa5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:31 GMT
+      - Thu, 19 Apr 2018 17:46:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-864c6d78-7eb3-4eab-afc8-c15162eebf70
+      - req-dcaf99e9-23bf-4eb3-998e-96321acafdd6
       Content-Length:
       - '500'
       Connection:
@@ -16788,13 +16068,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"6e1a9b4588824c06955a92becb480533"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"88c6a0a3bc19412381ca84aa7fee5aa5"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16806,13 +16086,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:31 GMT
+      - Thu, 19 Apr 2018 17:46:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55c86a56-ca9b-4270-92ca-ec8ae6772e24
+      - req-e38284f4-3c3c-4af1-b582-18709671aa08
       Content-Length:
       - '4143'
       Connection:
@@ -16821,11 +16101,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:31.661211", "expires":
-        "2018-04-09T17:34:31Z", "id": "a7b4a2f5856e4fff8dc6c6e2820df983", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:14.785749", "expires":
+        "2018-04-19T18:46:14Z", "id": "75162b1f97314911be459389091f732c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UergJPwNSkmkc2b4lESbHg",
-        "2CYuPwjEQeKM_sXwDe85BA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8SkvG3M5TSG1Jke8BK5Uzg",
+        "ztB_pYGKQ6OkaseeEOzoTQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16869,7 +16149,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:14 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16884,20 +16164,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e1a9b4588824c06955a92becb480533
+      - 88c6a0a3bc19412381ca84aa7fee5aa5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:31 GMT
+      - Thu, 19 Apr 2018 17:46:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55ebec11-c504-438b-805f-cd3fb156c658
+      - req-67260686-ffb6-48c4-b1dc-f1ab07e95d18
       Content-Length:
       - '500'
       Connection:
@@ -16914,7 +16194,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:31 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16932,13 +16212,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:31 GMT
+      - Thu, 19 Apr 2018 17:46:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55e68a94-98c4-4f66-b7c3-5c7242f29141
+      - req-edfca350-188d-4c8f-97f2-0df970a917f8
       Content-Length:
       - '4117'
       Connection:
@@ -16947,10 +16227,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:32.112577", "expires":
-        "2018-04-09T17:34:32Z", "id": "02cb3685a1b644a685689cb36aefa7ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:15.260080", "expires":
+        "2018-04-19T18:46:15Z", "id": "31c7b1eef29442c3a12e43a5d3b46207", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uvfdbKiMTISHW_0HFQg_Sw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wCwMFdG-SLOZpBbbsW6b9A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16994,7 +16274,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17012,13 +16292,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:32 GMT
+      - Thu, 19 Apr 2018 17:46:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0b65ac6a-debb-472d-a017-99f82a04ec2c
+      - req-befc2db1-49b5-4767-a4b2-79cea2a9e4d8
       Content-Length:
       - '4131'
       Connection:
@@ -17027,10 +16307,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:32.388015", "expires":
-        "2018-04-09T17:34:32Z", "id": "6b896121b082409cb091ef13ffee1e4c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:15.543542", "expires":
+        "2018-04-19T18:46:15Z", "id": "7d10a61f3453494c92222aafde3e19c6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2szBXnTXT36sCysFvVA8hQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["6pbHtUZEQmuE_IF8TrlwYA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17074,7 +16354,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17092,13 +16372,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:32 GMT
+      - Thu, 19 Apr 2018 17:46:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d6f8326c-9b8a-475b-aac4-441ea31cc51d
+      - req-e32cbbab-6d76-4c43-9c2a-1e6cdf1a51cf
       Content-Length:
       - '4118'
       Connection:
@@ -17107,10 +16387,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:32.692809", "expires":
-        "2018-04-09T17:34:32Z", "id": "29e8c52b0a464e84b88cf168e95eeefb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:15.793865", "expires":
+        "2018-04-19T18:46:15Z", "id": "8f6ad6a3ba3b4d5c8608eb7cf8d49f44", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JY_wz5CNT2OcrEl58ToMwg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["fY-iJVaFSyyFvPUcdw7xCg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17154,7 +16434,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:32 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17172,13 +16452,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:32 GMT
+      - Thu, 19 Apr 2018 17:46:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-97060fd7-af84-48e6-b11a-e1307a37a79d
+      - req-85df6345-3800-404a-989a-b21b1571e90e
       Content-Length:
       - '4117'
       Connection:
@@ -17187,10 +16467,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:32.999140", "expires":
-        "2018-04-09T17:34:32Z", "id": "904d87eeed694c609d83250e39ca4ac5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:16.085231", "expires":
+        "2018-04-19T18:46:16Z", "id": "732b706213fb40b785287d5ce15dffd2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jgaBEH7fTPKWU-Gkygz1Ag"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-BJJKI_cRDGgPguF1dKuuw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17234,7 +16514,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -17249,22 +16529,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4b6c699-db4d-40e6-8749-b14a7c8b5948
+      - req-92da2828-a2e4-4045-bcc0-48fb88064146
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-a4b6c699-db4d-40e6-8749-b14a7c8b5948
+      - req-92da2828-a2e4-4045-bcc0-48fb88064146
       Date:
-      - Mon, 09 Apr 2018 16:34:33 GMT
+      - Thu, 19 Apr 2018 17:46:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -17297,7 +16577,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -17312,22 +16592,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2bb4462c-a389-4ea9-8f8f-aeddec420860
+      - req-d7f7888c-1c8d-4e8e-868b-d0d6b8149459
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-2bb4462c-a389-4ea9-8f8f-aeddec420860
+      - req-d7f7888c-1c8d-4e8e-868b-d0d6b8149459
       Date:
-      - Mon, 09 Apr 2018 16:34:33 GMT
+      - Thu, 19 Apr 2018 17:46:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -17368,7 +16648,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:33 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -17383,22 +16663,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f330cc0-177f-44dc-9b58-bfeb3bf236f1
+      - req-a4fcb4d6-3b60-487c-8063-43588a1502f6
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-4f330cc0-177f-44dc-9b58-bfeb3bf236f1
+      - req-a4fcb4d6-3b60-487c-8063-43588a1502f6
       Date:
-      - Mon, 09 Apr 2018 16:34:34 GMT
+      - Thu, 19 Apr 2018 17:46:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -17432,7 +16712,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -17447,27 +16727,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f468c874-4e01-42bd-b2df-eb45efbcd109
+      - req-6fde75da-bf9c-402d-ae24-a781a0517bbf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f468c874-4e01-42bd-b2df-eb45efbcd109
+      - req-6fde75da-bf9c-402d-ae24-a781a0517bbf
       Date:
-      - Mon, 09 Apr 2018 16:34:34 GMT
+      - Thu, 19 Apr 2018 17:46:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:34 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17485,13 +16765,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:34 GMT
+      - Thu, 19 Apr 2018 17:46:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e1726c1a-4268-422a-89e5-dc2a742e64b7
+      - req-d61351c3-63b5-4f82-b491-872b6098ce26
       Content-Length:
       - '4131'
       Connection:
@@ -17500,10 +16780,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:35.053260", "expires":
-        "2018-04-09T17:34:34Z", "id": "9af833a27f9b43e9b79540fee094505f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:18.054724", "expires":
+        "2018-04-19T18:46:17Z", "id": "0db158afef25478aa10ade72a785659f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vtTC_AbkSwqQOw9mBjuVTg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-RWHIw-QSiOHwzWMmQESWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17547,7 +16827,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -17562,27 +16842,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af833a27f9b43e9b79540fee094505f
+      - 0db158afef25478aa10ade72a785659f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4df8f565-74ed-416e-8abe-2d7d485ce218
+      - req-dd247afd-0090-4b4f-b9a0-1e7e1d1b88f0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4df8f565-74ed-416e-8abe-2d7d485ce218
+      - req-dd247afd-0090-4b4f-b9a0-1e7e1d1b88f0
       Date:
-      - Mon, 09 Apr 2018 16:34:35 GMT
+      - Thu, 19 Apr 2018 17:46:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -17597,27 +16877,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a84d0ea74fd643b0bdbca7f8447e9fcc
+      - ba8a4dcfd3804b4890e2a0adff14e2e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16798be1-74e6-4dd7-8969-f7f021f77e90
+      - req-99591622-a201-4d67-a8b2-2e641784a578
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-16798be1-74e6-4dd7-8969-f7f021f77e90
+      - req-99591622-a201-4d67-a8b2-2e641784a578
       Date:
-      - Mon, 09 Apr 2018 16:34:35 GMT
+      - Thu, 19 Apr 2018 17:46:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:35 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17635,13 +16915,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:35 GMT
+      - Thu, 19 Apr 2018 17:46:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0bdeff76-0568-489c-b2b3-0e9e4d0fa2a1
+      - req-3520e776-25b9-4a3b-b57f-d77b517d9f4b
       Content-Length:
       - '4118'
       Connection:
@@ -17650,10 +16930,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:36.075266", "expires":
-        "2018-04-09T17:34:36Z", "id": "4d01afd92f3f4d008f63a134c29d0e9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:19.130229", "expires":
+        "2018-04-19T18:46:19Z", "id": "93e2f505e0bb4bc38e34a85844f2da06", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["n3ZJ2P5bSG-qfpQJgIjgtw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ajrsGzfmQNSHCHW-_a5ucA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17697,7 +16977,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -17712,27 +16992,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d01afd92f3f4d008f63a134c29d0e9a
+      - 93e2f505e0bb4bc38e34a85844f2da06
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-731e72c3-7b10-4f39-a2f5-227864248210
+      - req-f9280821-b9cc-4ce3-9bce-877e3d0d6f83
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-731e72c3-7b10-4f39-a2f5-227864248210
+      - req-f9280821-b9cc-4ce3-9bce-877e3d0d6f83
       Date:
-      - Mon, 09 Apr 2018 16:34:36 GMT
+      - Thu, 19 Apr 2018 17:46:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -17747,22 +17027,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a955ec28-1e6f-49d6-850f-03264abee052
+      - req-63cfad81-e458-45f8-85bd-38526f03f1d9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-a955ec28-1e6f-49d6-850f-03264abee052
+      - req-63cfad81-e458-45f8-85bd-38526f03f1d9
       Date:
-      - Mon, 09 Apr 2018 16:34:36 GMT
+      - Thu, 19 Apr 2018 17:46:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17777,7 +17057,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -17792,22 +17072,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe49e70a-b368-4119-885e-2ab64ef2a8df
+      - req-d255c225-80d6-4628-bb05-558320c7c7e8
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-fe49e70a-b368-4119-885e-2ab64ef2a8df
+      - req-d255c225-80d6-4628-bb05-558320c7c7e8
       Date:
-      - Mon, 09 Apr 2018 16:34:36 GMT
+      - Thu, 19 Apr 2018 17:46:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17822,7 +17102,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:36 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -17837,27 +17117,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af833a27f9b43e9b79540fee094505f
+      - 0db158afef25478aa10ade72a785659f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31bb0402-a4d7-4afc-a45e-6421654c777d
+      - req-f0e8f93a-7bca-42aa-a9a6-9eb0511834d2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-31bb0402-a4d7-4afc-a45e-6421654c777d
+      - req-f0e8f93a-7bca-42aa-a9a6-9eb0511834d2
       Date:
-      - Mon, 09 Apr 2018 16:34:37 GMT
+      - Thu, 19 Apr 2018 17:46:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -17872,27 +17152,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af833a27f9b43e9b79540fee094505f
+      - 0db158afef25478aa10ade72a785659f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4eb1df35-297e-4220-b09e-a7e1254df694
+      - req-540b507e-08d8-4c10-89d8-3f6470b0585c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4eb1df35-297e-4220-b09e-a7e1254df694
+      - req-540b507e-08d8-4c10-89d8-3f6470b0585c
       Date:
-      - Mon, 09 Apr 2018 16:34:37 GMT
+      - Thu, 19 Apr 2018 17:46:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:37 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -17907,27 +17187,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a84d0ea74fd643b0bdbca7f8447e9fcc
+      - ba8a4dcfd3804b4890e2a0adff14e2e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6cb9f3fa-21d7-4302-b52d-fba49ff8f481
+      - req-78070d44-8f3f-45eb-8b20-3fadbbe1ff99
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6cb9f3fa-21d7-4302-b52d-fba49ff8f481
+      - req-78070d44-8f3f-45eb-8b20-3fadbbe1ff99
       Date:
-      - Mon, 09 Apr 2018 16:34:37 GMT
+      - Thu, 19 Apr 2018 17:46:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -17942,27 +17222,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a84d0ea74fd643b0bdbca7f8447e9fcc
+      - ba8a4dcfd3804b4890e2a0adff14e2e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7d34c48-5b83-45b7-9762-eccf105417ff
+      - req-235fe33b-c4ae-4a22-b9fc-e4b173344b82
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f7d34c48-5b83-45b7-9762-eccf105417ff
+      - req-235fe33b-c4ae-4a22-b9fc-e4b173344b82
       Date:
-      - Mon, 09 Apr 2018 16:34:38 GMT
+      - Thu, 19 Apr 2018 17:46:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -17977,27 +17257,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d01afd92f3f4d008f63a134c29d0e9a
+      - 93e2f505e0bb4bc38e34a85844f2da06
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-82026c3d-f110-48d5-a9cd-5ebb6110609f
+      - req-2e8f5685-712f-4553-bf0a-6721b7fdabf4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-82026c3d-f110-48d5-a9cd-5ebb6110609f
+      - req-2e8f5685-712f-4553-bf0a-6721b7fdabf4
       Date:
-      - Mon, 09 Apr 2018 16:34:38 GMT
+      - Thu, 19 Apr 2018 17:46:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:38 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -18012,27 +17292,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d01afd92f3f4d008f63a134c29d0e9a
+      - 93e2f505e0bb4bc38e34a85844f2da06
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c87eb071-0c42-4f73-86e6-6e1f5fd174fe
+      - req-e192b8d5-4711-48e6-ae58-663b03959b50
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c87eb071-0c42-4f73-86e6-6e1f5fd174fe
+      - req-e192b8d5-4711-48e6-ae58-663b03959b50
       Date:
-      - Mon, 09 Apr 2018 16:34:38 GMT
+      - Thu, 19 Apr 2018 17:46:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -18047,27 +17327,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-339c2918-4340-4c7e-9206-a4619a1cd695
+      - req-e9cf8975-6d31-42b8-ba4d-98422957cf4c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-339c2918-4340-4c7e-9206-a4619a1cd695
+      - req-e9cf8975-6d31-42b8-ba4d-98422957cf4c
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -18082,27 +17362,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 904d87eeed694c609d83250e39ca4ac5
+      - 732b706213fb40b785287d5ce15dffd2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68b663d8-ac58-42b9-abcc-b1d79f51e25b
+      - req-02a6de91-f1b4-4bbe-93e2-f2026c1be46a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-68b663d8-ac58-42b9-abcc-b1d79f51e25b
+      - req-02a6de91-f1b4-4bbe-93e2-f2026c1be46a
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -18117,27 +17397,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af833a27f9b43e9b79540fee094505f
+      - 0db158afef25478aa10ade72a785659f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-111127c9-4bfa-4f52-8b33-fad94f7701b8
+      - req-bcc92347-c9ae-46a3-beb3-ab58b64fa2ad
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-111127c9-4bfa-4f52-8b33-fad94f7701b8
+      - req-bcc92347-c9ae-46a3-beb3-ab58b64fa2ad
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -18152,27 +17432,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af833a27f9b43e9b79540fee094505f
+      - 0db158afef25478aa10ade72a785659f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df57ee9c-88f8-4078-a7f3-eac511a98437
+      - req-8cfff60e-ccdd-4ea8-b3bb-7b86430baa33
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-df57ee9c-88f8-4078-a7f3-eac511a98437
+      - req-8cfff60e-ccdd-4ea8-b3bb-7b86430baa33
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -18187,27 +17467,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a84d0ea74fd643b0bdbca7f8447e9fcc
+      - ba8a4dcfd3804b4890e2a0adff14e2e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab937abc-de13-4aee-b9f2-5c34db9593d8
+      - req-89722489-6551-4831-9a25-1079cc1bc7b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ab937abc-de13-4aee-b9f2-5c34db9593d8
+      - req-89722489-6551-4831-9a25-1079cc1bc7b7
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -18222,27 +17502,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a84d0ea74fd643b0bdbca7f8447e9fcc
+      - ba8a4dcfd3804b4890e2a0adff14e2e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad3f6148-713d-4b5e-819c-4bc79297c02c
+      - req-15caa912-d94e-4914-87c7-50be5f149e9f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ad3f6148-713d-4b5e-819c-4bc79297c02c
+      - req-15caa912-d94e-4914-87c7-50be5f149e9f
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -18257,27 +17537,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d01afd92f3f4d008f63a134c29d0e9a
+      - 93e2f505e0bb4bc38e34a85844f2da06
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-227fb64f-906d-4a0a-9831-3b62cbe4d7dc
+      - req-303c023f-20c2-43a6-8fa3-c514bb733bc4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-227fb64f-906d-4a0a-9831-3b62cbe4d7dc
+      - req-303c023f-20c2-43a6-8fa3-c514bb733bc4
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -18292,27 +17572,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d01afd92f3f4d008f63a134c29d0e9a
+      - 93e2f505e0bb4bc38e34a85844f2da06
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f4f29a07-d87d-4158-a5f4-7392b410cce8
+      - req-2dd1e3ec-9afb-4203-bac0-46850a2d6483
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f4f29a07-d87d-4158-a5f4-7392b410cce8
+      - req-2dd1e3ec-9afb-4203-bac0-46850a2d6483
       Date:
-      - Mon, 09 Apr 2018 16:34:39 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:39 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18330,13 +17610,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:40 GMT
+      - Thu, 19 Apr 2018 17:46:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a8886d6-61e7-441f-aefc-81cd4eb33eaa
+      - req-344cb8e7-76bb-4189-8a7e-7dd12d51d1c1
       Content-Length:
       - '4170'
       Connection:
@@ -18345,10 +17625,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:40.380702", "expires":
-        "2018-04-09T17:34:40Z", "id": "a2c37de199e34c9285d6b63c1baf54f8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:23.049730", "expires":
+        "2018-04-19T18:46:22Z", "id": "17b875345ad84d41ad730638295b7c29", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0nWSnvg8TBGFKHo2c3HQhw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ewEIIpX0SZ-XMxQBTIqmrg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18393,7 +17673,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18411,13 +17691,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:40 GMT
+      - Thu, 19 Apr 2018 17:46:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1fafbbd4-ea2a-4971-9661-c79385fabe8a
+      - req-70818945-f368-4fc8-a48c-5bdcdc6686c5
       Content-Length:
       - '4170'
       Connection:
@@ -18426,10 +17706,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:40.698775", "expires":
-        "2018-04-09T17:34:40Z", "id": "b38015fcb83a4cd78f55a24fb71211f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:23.350265", "expires":
+        "2018-04-19T18:46:23Z", "id": "a6fe104082024621922b5bfefed36a7c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NkaOcG4JTQ2o6tTtJfMv-A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wu1ERyuMQ_iX0NgCAL2M0Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18474,7 +17754,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18492,13 +17772,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:40 GMT
+      - Thu, 19 Apr 2018 17:46:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d89c117-7d1b-4046-a72d-6bb6f3aabe9d
+      - req-b622be94-2369-45b9-aa0a-fb979881a58e
       Content-Length:
       - '370'
       Connection:
@@ -18507,13 +17787,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:40.957098", "expires":
-        "2018-04-09T17:34:40Z", "id": "0ccf87c7b22847b0b76dcea0291d455f", "audit_ids":
-        ["S_h3UImbRU2ZgIrBSUiWGQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:23.516587", "expires":
+        "2018-04-19T18:46:23Z", "id": "d99da62b17c34237ad287bfb1dacbdd4", "audit_ids":
+        ["5EISoUl1RrWThiRDoSkKag"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:40 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18528,20 +17808,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ccf87c7b22847b0b76dcea0291d455f
+      - d99da62b17c34237ad287bfb1dacbdd4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:41 GMT
+      - Thu, 19 Apr 2018 17:46:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e422521f-41ba-4eae-8682-95aff6fbf056
+      - req-fef96e3a-f09a-491d-8114-0582adc2f0de
       Content-Length:
       - '500'
       Connection:
@@ -18558,13 +17838,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"0ccf87c7b22847b0b76dcea0291d455f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"d99da62b17c34237ad287bfb1dacbdd4"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18576,13 +17856,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:41 GMT
+      - Thu, 19 Apr 2018 17:46:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4363e87c-20be-4f8b-bd79-94e671aac020
+      - req-0bcb9fd8-cc40-4165-a867-6afa4d635202
       Content-Length:
       - '4143'
       Connection:
@@ -18591,11 +17871,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:41.380530", "expires":
-        "2018-04-09T17:34:40Z", "id": "207422ffce954da3b24f5e9561bb98e0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:23.852152", "expires":
+        "2018-04-19T18:46:23Z", "id": "464b6d3f10d244f0a97c4956ae662914", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qJlX5CciR7mz75s4yh-pfQ",
-        "S_h3UImbRU2ZgIrBSUiWGQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gLNhSdh1Rui01CxWKsctVg",
+        "5EISoUl1RrWThiRDoSkKag"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18639,7 +17919,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18654,20 +17934,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ccf87c7b22847b0b76dcea0291d455f
+      - d99da62b17c34237ad287bfb1dacbdd4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:41 GMT
+      - Thu, 19 Apr 2018 17:46:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54eeab76-0e34-4813-9486-8eb6b61c0c23
+      - req-5ab674b0-ad2e-44ef-bc79-937f85b4a3ff
       Content-Length:
       - '500'
       Connection:
@@ -18684,7 +17964,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:41 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18702,13 +17982,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:46 GMT
+      - Thu, 19 Apr 2018 17:46:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-56f9e559-5add-49bc-93bf-68e7bb386e76
+      - req-47473b1a-302f-44c7-b25d-57cf9358eef4
       Content-Length:
       - '4117'
       Connection:
@@ -18717,10 +17997,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:46.872189", "expires":
-        "2018-04-09T17:34:46Z", "id": "6ca841e128464d57aafefc002022b01b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:24.404006", "expires":
+        "2018-04-19T18:46:24Z", "id": "0fa15b0c1fa04bad8d48d31783200928", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RlfsSEQhRq6-Ev3W2WvlVA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["knfr_C4NToSx0miQWT0_Hw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18764,7 +18044,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:46 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18782,13 +18062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:46 GMT
+      - Thu, 19 Apr 2018 17:46:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c206f4c4-bb98-48fd-8439-265c01f82853
+      - req-36838812-6830-47d5-a324-e1222c7ce1a3
       Content-Length:
       - '4131'
       Connection:
@@ -18797,10 +18077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:47.141211", "expires":
-        "2018-04-09T17:34:47Z", "id": "202078dd97bc4ad883988cb19a693296", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:24.662695", "expires":
+        "2018-04-19T18:46:24Z", "id": "29a711daa64a46e5b07760a19246ffd4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["A9e0IKAsQMKzlEC7wmWWgg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qX9Nu3c0RzapJwY40Ut4Vw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18844,7 +18124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18862,13 +18142,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:47 GMT
+      - Thu, 19 Apr 2018 17:46:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0b648aaf-5a14-426b-8a98-17e127c06124
+      - req-a304c702-bb6d-4b72-973f-3323bc223680
       Content-Length:
       - '4118'
       Connection:
@@ -18877,10 +18157,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:47.463245", "expires":
-        "2018-04-09T17:34:47Z", "id": "35492700eaf44aad96bf3003ea929d8e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:25.009152", "expires":
+        "2018-04-19T18:46:24Z", "id": "a4f3709e1cb843fa8fb41954f8a72e7e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["W2gS5vqAQCWFJPqKKQGJWw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9Ssszvi3S2OyET4EacovpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18924,7 +18204,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18942,13 +18222,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:47 GMT
+      - Thu, 19 Apr 2018 17:46:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46b4431f-d854-4d33-87e5-769897c585ba
+      - req-e561a48e-a268-48a6-912f-b841ed6a4d4e
       Content-Length:
       - '4117'
       Connection:
@@ -18957,10 +18237,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:47.742600", "expires":
-        "2018-04-09T17:34:47Z", "id": "b27655f0141e4222bd932c3c24acea77", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:25.294602", "expires":
+        "2018-04-19T18:46:25Z", "id": "ef0fbed8c11c4459a00e9881bf76ebef", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["QuhjNs5HRNiKW1ynhVkzkw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["NxqzQYo0SKmnJsMpZUY5fA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -19004,7 +18284,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:47 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -19019,7 +18299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b27655f0141e4222bd932c3c24acea77
+      - ef0fbed8c11c4459a00e9881bf76ebef
   response:
     status:
       code: 200
@@ -19048,15 +18328,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txc2d1af6dc47340e29655d-005acb9627
+      - tx341d6a13039a45158ae70-005ad8d5f1
       Date:
-      - Mon, 09 Apr 2018 16:34:48 GMT
+      - Thu, 19 Apr 2018 17:46:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -19071,7 +18351,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b27655f0141e4222bd932c3c24acea77
+      - ef0fbed8c11c4459a00e9881bf76ebef
   response:
     status:
       code: 200
@@ -19100,14 +18380,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txd4381052aff246e1ba6aa-005acb9628
+      - tx79df6e15df7b4b12bdba3-005ad8d5f1
       Date:
-      - Mon, 09 Apr 2018 16:34:48 GMT
+      - Thu, 19 Apr 2018 17:46:25 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19125,13 +18405,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:48 GMT
+      - Thu, 19 Apr 2018 17:46:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-630f3646-0283-4a99-8cdd-4d2687fecca9
+      - req-9dfdee49-009e-4991-bc92-5d0e2d4e3b7f
       Content-Length:
       - '4131'
       Connection:
@@ -19140,10 +18420,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:48.392204", "expires":
-        "2018-04-09T17:34:48Z", "id": "ec76ed1674e649868a8048cfd70531aa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:25.957856", "expires":
+        "2018-04-19T18:46:25Z", "id": "21c35dc4cd3d477bb631322144873eef", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["a5vJYy_qQSqwhOyvSVq9zQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vbJBmpsrTnOLlZfVF6bcWQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -19187,7 +18467,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -19202,7 +18482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec76ed1674e649868a8048cfd70531aa
+      - 21c35dc4cd3d477bb631322144873eef
   response:
     status:
       code: 200
@@ -19215,22 +18495,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291688.87145'
+      - '1524159986.23610'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291688.87145'
+      - '1524159986.23610'
       X-Trans-Id:
-      - tx9044f3a554304430a0d5a-005acb9628
+      - tx6173ef96c1d844a49334b-005ad8d5f2
       Date:
-      - Mon, 09 Apr 2018 16:34:48 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:48 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -19245,7 +18525,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b38015fcb83a4cd78f55a24fb71211f9
+      - a6fe104082024621922b5bfefed36a7c
   response:
     status:
       code: 200
@@ -19258,22 +18538,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291689.14527'
+      - '1524159986.41689'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291689.14527'
+      - '1524159986.41689'
       X-Trans-Id:
-      - tx206ceff35869488f8c4b7-005acb9628
+      - tx46299ccd57d74133b5e3a-005ad8d5f2
       Date:
-      - Mon, 09 Apr 2018 16:34:49 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19291,13 +18571,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:49 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-12e8f266-bdbc-4945-9085-1961bbf04096
+      - req-c1a32f54-b176-4d46-b2c6-fab4b3cd9f24
       Content-Length:
       - '4118'
       Connection:
@@ -19306,10 +18586,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:49.421738", "expires":
-        "2018-04-09T17:34:49Z", "id": "44c28781d86f4381910b4f2a78f585dd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:46:26.601146", "expires":
+        "2018-04-19T18:46:26Z", "id": "b633e25fc292436fab14a3ee5ee57df5", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["uCyy0YJPR1C1mNAlJYvhLg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ap3hRFSlThus4HE0PeyL0Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -19353,7 +18633,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -19368,7 +18648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44c28781d86f4381910b4f2a78f585dd
+      - b633e25fc292436fab14a3ee5ee57df5
   response:
     status:
       code: 200
@@ -19381,22 +18661,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1523291689.70979'
+      - '1524159986.79177'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1523291689.70979'
+      - '1524159986.79177'
       X-Trans-Id:
-      - txd3365315e83e46bd88a4c-005acb9629
+      - txcd3cbc418d5748569c11c-005ad8d5f2
       Date:
-      - Mon, 09 Apr 2018 16:34:49 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -19411,7 +18691,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b27655f0141e4222bd932c3c24acea77
+      - ef0fbed8c11c4459a00e9881bf76ebef
   response:
     status:
       code: 200
@@ -19432,9 +18712,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txeb727d4a625c4256889a7-005acb9629
+      - tx81583fef1a72481b83174-005ad8d5f2
       Date:
-      - Mon, 09 Apr 2018 16:34:49 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -19444,7 +18724,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -19459,7 +18739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b27655f0141e4222bd932c3c24acea77
+      - ef0fbed8c11c4459a00e9881bf76ebef
   response:
     status:
       code: 200
@@ -19480,14 +18760,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txebcb6cbf233645bab7708-005acb9629
+      - tx42bdf275f9a44accbfa40-005ad8d5f2
       Date:
-      - Mon, 09 Apr 2018 16:34:49 GMT
+      - Thu, 19 Apr 2018 17:46:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:49 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -19502,7 +18782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b27655f0141e4222bd932c3c24acea77
+      - ef0fbed8c11c4459a00e9881bf76ebef
   response:
     status:
       code: 200
@@ -19523,14 +18803,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx509c33714e4b47218500e-005acb962a
+      - tx4e605f4a533e49fdaf4cb-005ad8d5f3
       Date:
-      - Mon, 09 Apr 2018 16:34:50 GMT
+      - Thu, 19 Apr 2018 17:46:27 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -19545,7 +18825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90d4f4497e0f4a94b09b5b619352775b
+      - 3a35fead76f54ec99dc48cbed43842ea
   response:
     status:
       code: 200
@@ -19556,9 +18836,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-39d98edc-8600-4aeb-b644-8f0a76bc781f
+      - req-d3f82091-860e-4d16-aafd-1e4569b7bb65
       Date:
-      - Mon, 09 Apr 2018 16:34:50 GMT
+      - Thu, 19 Apr 2018 17:46:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -19568,7 +18848,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:50 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19583,7 +18863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6245b2cd7a334a5baa723808f90338d6
+      - 7ef0bca7482044f287f560f4a3463aac
   response:
     status:
       code: 200
@@ -19594,157 +18874,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-eab94798-1943-4445-b169-1b4abc0042a2
+      - req-e918e341-f3d3-4345-9044-070917387cc1
       Date:
-      - Mon, 09 Apr 2018 16:34:50 GMT
+      - Thu, 19 Apr 2018 17:46:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6245b2cd7a334a5baa723808f90338d6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-25f8b72e-9ec4-450d-aa25-c18406a11bae
-      Date:
-      - Mon, 09 Apr 2018 16:34:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -19819,20 +18955,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -19847,7 +18995,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6245b2cd7a334a5baa723808f90338d6
+      - 7ef0bca7482044f287f560f4a3463aac
   response:
     status:
       code: 200
@@ -19858,52 +19006,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c01e1938-c433-4a63-9fa8-e665144db045
+      - req-43bb4049-9d03-49b7-ad90-6490cb88d36d
       Date:
-      - Mon, 09 Apr 2018 16:34:51 GMT
+      - Thu, 19 Apr 2018 17:46:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19951,20 +19075,176 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7ef0bca7482044f287f560f4a3463aac
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-239e1668-f7a0-47f8-848f-01378cc277ea
+      Date:
+      - Thu, 19 Apr 2018 17:46:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19979,7 +19259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -19990,157 +19270,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-41459455-554f-449c-aad9-3268386626ff
+      - req-c37de2d8-7147-4486-b6be-dfcb1964e3d7
       Date:
-      - Mon, 09 Apr 2018 16:34:51 GMT
+      - Thu, 19 Apr 2018 17:46:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7125058b-a2a6-4b79-a969-59a71bd3606c
-      Date:
-      - Mon, 09 Apr 2018 16:34:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -20215,20 +19351,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:51 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -20243,7 +19391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -20254,47 +19402,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9c0d48a8-79a8-4787-b263-1d20595fa50c
+      - req-a08b7c53-31e2-41ed-ae42-99f3480d082b
       Date:
-      - Mon, 09 Apr 2018 16:34:51 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -20307,16 +19471,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -20330,37 +19489,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -20375,7 +19523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -20386,25 +19534,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-01224bd4-83af-4ac8-8248-7879c9015f69
+      - req-97b984f5-09cf-4c75-8c15-3f0be2fb83a9
       Date:
-      - Mon, 09 Apr 2018 16:34:52 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -20479,20 +19615,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -20507,7 +19655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -20518,47 +19666,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-578c605f-31e8-4ef3-958c-125fdfca90b9
+      - req-7e4e49e9-3270-49ee-8cb3-616dffbff031
       Date:
-      - Mon, 09 Apr 2018 16:34:52 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -20571,16 +19735,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -20594,37 +19753,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -20639,7 +19787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d375bd3cdf104b0180024f3cfede8c5c
+      - b1c0a7d942944c20b68544894a2ce6b8
   response:
     status:
       code: 200
@@ -20650,9 +19798,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6ed30d94-b352-442e-b47b-2f687fc6c803
+      - req-d3bee426-505b-40be-8474-d32f81908673
       Date:
-      - Mon, 09 Apr 2018 16:34:52 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -20756,7 +19904,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:52 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -20771,7 +19919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90d4f4497e0f4a94b09b5b619352775b
+      - 3a35fead76f54ec99dc48cbed43842ea
   response:
     status:
       code: 200
@@ -20782,52 +19930,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-19920009-e670-4db1-b14c-6f2116b41468
+      - req-f71f85b8-86a3-4ee0-a873-770e96214851
       Date:
-      - Mon, 09 Apr 2018 16:34:52 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -20875,23 +19988,58 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:28 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -20903,7 +20051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90d4f4497e0f4a94b09b5b619352775b
+      - 3a35fead76f54ec99dc48cbed43842ea
   response:
     status:
       code: 200
@@ -20914,16 +20062,69 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6bdd8d2b-15da-4c93-8a67-bd384bb810ac
+      - req-a0e4e046-d4f9-4e24-a9bf-7c8f6cac6f04
       Date:
-      - Mon, 09 Apr 2018 16:34:53 GMT
+      - Thu, 19 Apr 2018 17:46:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -20937,12 +20138,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -20954,73 +20149,26 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -21035,7 +20183,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -21046,157 +20194,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e18f917b-6b49-4d7c-91f9-638aafc7b209
+      - req-968c7b8e-71f6-48e5-b69f-58693660d021
       Date:
-      - Mon, 09 Apr 2018 16:34:53 GMT
+      - Thu, 19 Apr 2018 17:46:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-79c91771-c959-4301-a1de-4153388f7d92
-      Date:
-      - Mon, 09 Apr 2018 16:34:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -21271,20 +20275,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -21299,7 +20315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -21310,47 +20326,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-05672aff-806d-4ada-a7eb-b7bc53c098d0
+      - req-cac84aed-d6b5-498a-8fcd-616453a8c16f
       Date:
-      - Mon, 09 Apr 2018 16:34:53 GMT
+      - Thu, 19 Apr 2018 17:46:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -21363,16 +20395,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -21386,37 +20413,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:53 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -21431,7 +20447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -21442,25 +20458,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3581a0ab-43da-4549-9c27-e8b4224c1cf7
+      - req-d864d3b6-7cef-4511-a826-c395dee297d4
       Date:
-      - Mon, 09 Apr 2018 16:34:54 GMT
+      - Thu, 19 Apr 2018 17:46:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -21535,20 +20539,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -21563,7 +20579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -21574,47 +20590,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5fff9ba9-d716-4752-963e-b92addc51589
+      - req-602481ed-4162-4aa2-a75a-496ca97f3d15
       Date:
-      - Mon, 09 Apr 2018 16:34:54 GMT
+      - Thu, 19 Apr 2018 17:46:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -21627,16 +20659,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -21650,37 +20677,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -21695,7 +20711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b985928aaa4dba9fd52335bafb6685
+      - c07d74089e5842e897015e0ea650b3a8
   response:
     status:
       code: 200
@@ -21706,47 +20722,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f27a387f-e669-4fab-88b5-5ef99fb6534e
+      - req-2dc8d256-3877-44fc-afbe-53bf161d64ac
       Date:
-      - Mon, 09 Apr 2018 16:34:54 GMT
+      - Thu, 19 Apr 2018 17:46:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -21759,16 +20780,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -21782,23 +20798,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -21812,5 +20828,5 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:54 GMT
+  recorded_at: Thu, 19 Apr 2018 17:46:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:55 GMT
+      - Thu, 19 Apr 2018 17:44:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ecc1dcf4-9d45-4c0c-a690-0a514b9138ea
+      - req-b1528dcd-9b23-43ff-8c24-9dd970a8da0d
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:55.403853", "expires":
-        "2018-04-09T17:34:55Z", "id": "8c63ce08700f41738f570cf05f62a284", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:44.477875", "expires":
+        "2018-04-19T18:44:44Z", "id": "dfc462b4e661434bb535faaa93c90499", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["JZDTetHUTnubPDJ0gQ2HiA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wb6Z6Ho5S-OeqxzmwrPmjA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c63ce08700f41738f570cf05f62a284
+      - dfc462b4e661434bb535faaa93c90499
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:34:55 GMT
+      - Thu, 19 Apr 2018 17:44:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:55 GMT
+      - Thu, 19 Apr 2018 17:44:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51755795-5f02-4a97-a0c3-5fe931a584a8
+      - req-172cf14c-47a4-4af4-8bcc-cd9932c583cd
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:55.772644", "expires":
-        "2018-04-09T17:34:55Z", "id": "ec274b104aba4efaae02abbd661f060b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:45.890433", "expires":
+        "2018-04-19T18:44:45Z", "id": "e80b327d1dbd4b97998d793d161757bb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["-3tGbCrGTVSQbdNaiqvy7w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AxwpAd4WQTyca4LoYPjrOg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:55 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:45 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec274b104aba4efaae02abbd661f060b
+      - e80b327d1dbd4b97998d793d161757bb
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:55 GMT
+      - Thu, 19 Apr 2018 17:44:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8813839b-a25f-4901-a75c-6712176e4c75
+      - req-34a5e5f6-8b53-42eb-a64a-0f7f943df450
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:56 GMT
+      - Thu, 19 Apr 2018 17:44:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7ef9efd4-93b5-40f3-8c50-7271a4b3cfa3
+      - req-447fceb0-372f-4837-8199-39b7e03c34bf
       Content-Length:
       - '4117'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:56.351454", "expires":
-        "2018-04-09T17:34:56Z", "id": "e08a1007a30f458ebc4bb2b2a4a529fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:46.368736", "expires":
+        "2018-04-19T18:44:46Z", "id": "4529f756fd804ff492cb01b8321a0bf0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["K8RMuKU9QmyuFygp3D2MuQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["o6VNjcg4R4-UDlOzrMEMMg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -321,7 +321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -336,7 +336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e08a1007a30f458ebc4bb2b2a4a529fe
+      - 4529f756fd804ff492cb01b8321a0bf0
   response:
     status:
       code: 200
@@ -347,9 +347,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-60ba9af9-ac5b-4e0e-8008-727344d7709e
+      - req-9d5d7d94-3571-48f8-a0d9-bd6c95f91a70
       Date:
-      - Mon, 09 Apr 2018 16:34:56 GMT
+      - Thu, 19 Apr 2018 17:44:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -383,7 +383,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:56 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -398,7 +398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e08a1007a30f458ebc4bb2b2a4a529fe
+      - 4529f756fd804ff492cb01b8321a0bf0
   response:
     status:
       code: 200
@@ -409,9 +409,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-124799bd-c305-4c85-a35f-50546a17c435
+      - req-d1113f79-a769-4dc9-8289-6558c4bc2e78
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -467,7 +467,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -482,7 +482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e08a1007a30f458ebc4bb2b2a4a529fe
+      - 4529f756fd804ff492cb01b8321a0bf0
   response:
     status:
       code: 200
@@ -493,9 +493,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-65b98b51-1138-4289-a624-c997ec3ce34a
+      - req-9d8ad7e0-b75f-462e-b2c3-d62eee90e84c
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -507,7 +507,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a468b47-0a2a-40e0-97db-a4060420cc55
+      - req-6eea2003-4fae-4a95-9c5e-f2a9d0cb040f
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:57.552871", "expires":
-        "2018-04-09T17:34:57Z", "id": "74d549867ed7498897745c195d711c1e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:47.345014", "expires":
+        "2018-04-19T18:44:47Z", "id": "377aca084e7a42b8839d8d7b25b39f68", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HyEd5PoMRYSfSESGvqe1sQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NgEcXQeoQJyCyZbyGjVjAA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,7 +588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -603,7 +603,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74d549867ed7498897745c195d711c1e
+      - 377aca084e7a42b8839d8d7b25b39f68
   response:
     status:
       code: 200
@@ -614,13 +614,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -638,13 +638,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c4efb238-4f01-49fe-adfa-c0883dadc4f2
+      - req-9631467d-a622-4ec2-9e40-95b75ac93980
       Content-Length:
       - '370'
       Connection:
@@ -653,13 +653,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:57.871891", "expires":
-        "2018-04-09T17:34:57Z", "id": "eec004ed334943c49b25deac56d94b5d", "audit_ids":
-        ["GYlSkgcLRTecAdzLIDIfVw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:47.585247", "expires":
+        "2018-04-19T18:44:47Z", "id": "6bb98d2108974b3da3ba94534337ee28", "audit_ids":
+        ["xdfq1JwtTD2rywbxR3GIkQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:57 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:47 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -674,20 +674,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eec004ed334943c49b25deac56d94b5d
+      - 6bb98d2108974b3da3ba94534337ee28
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:57 GMT
+      - Thu, 19 Apr 2018 17:44:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f565c899-6450-4a77-a37f-78591b3d0b56
+      - req-11ff9d0c-18bf-4724-8072-8155ad0c0c14
       Content-Length:
       - '500'
       Connection:
@@ -704,13 +704,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"eec004ed334943c49b25deac56d94b5d"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"6bb98d2108974b3da3ba94534337ee28"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -722,13 +722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:58 GMT
+      - Thu, 19 Apr 2018 17:44:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5bec4a28-0665-401a-a5ca-ec6572157b39
+      - req-fc936b81-aa8e-460c-91ad-34e68779638e
       Content-Length:
       - '4143'
       Connection:
@@ -737,11 +737,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:58.361788", "expires":
-        "2018-04-09T17:34:57Z", "id": "74a7b55d2db7451ea85165977e3557b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:48.509401", "expires":
+        "2018-04-19T18:44:47Z", "id": "1c06f5bb6b3646958ed8bf4764f18356", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["981iKUlvTqGul_Id01IYIw",
-        "GYlSkgcLRTecAdzLIDIfVw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TgQskCBjSae36vUzGztT4w",
+        "xdfq1JwtTD2rywbxR3GIkQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -785,7 +785,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -800,20 +800,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eec004ed334943c49b25deac56d94b5d
+      - 6bb98d2108974b3da3ba94534337ee28
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:58 GMT
+      - Thu, 19 Apr 2018 17:44:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e6fa8214-0609-48a0-a10f-bef873d6b3b8
+      - req-19310c0c-72f3-4eeb-b39c-7968e3388c12
       Content-Length:
       - '500'
       Connection:
@@ -830,7 +830,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:58 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -848,13 +848,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:58 GMT
+      - Thu, 19 Apr 2018 17:44:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7319d6c2-a44c-4eca-aecb-1f07d4fd9b61
+      - req-5c5e5123-b07f-409f-b99c-839674292126
       Content-Length:
       - '4117'
       Connection:
@@ -863,10 +863,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:58.970625", "expires":
-        "2018-04-09T17:34:58Z", "id": "44c75facdf4144d3aba301d08138ebb0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:48.837411", "expires":
+        "2018-04-19T18:44:48Z", "id": "a2c5c4d45c5e4898a5850a3ad09df19a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yNJemjVfSwiYrJYthdnsuA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VHO5yqBCQSGCuPa9PPjq3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -910,7 +910,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -925,7 +925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44c75facdf4144d3aba301d08138ebb0
+      - a2c5c4d45c5e4898a5850a3ad09df19a
   response:
     status:
       code: 200
@@ -936,7 +936,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:34:59 GMT
+      - Thu, 19 Apr 2018 17:44:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -945,7 +945,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -963,13 +963,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:59 GMT
+      - Thu, 19 Apr 2018 17:44:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28761adf-4f36-4957-b86a-26f73a46107b
+      - req-ddab0219-8c56-4249-86fe-504025941c53
       Content-Length:
       - '4131'
       Connection:
@@ -978,10 +978,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:59.364300", "expires":
-        "2018-04-09T17:34:59Z", "id": "1965d9cf822a4b5f9dbc315988f9676d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:49.085405", "expires":
+        "2018-04-19T18:44:49Z", "id": "e7ad56a8e97e4789b4687c0383004421", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4eqxjHWhSlKZerd8rGnvGA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9dG04Md9Teyw1zJsjRCPEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1025,7 +1025,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1040,7 +1040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1965d9cf822a4b5f9dbc315988f9676d
+      - e7ad56a8e97e4789b4687c0383004421
   response:
     status:
       code: 200
@@ -1051,7 +1051,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:34:59 GMT
+      - Thu, 19 Apr 2018 17:44:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1060,7 +1060,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1078,13 +1078,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:34:59 GMT
+      - Thu, 19 Apr 2018 17:44:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-581f69de-b415-4930-be1e-f18db227ce6a
+      - req-0502434f-21d0-4881-90e2-18cab48470c5
       Content-Length:
       - '4118'
       Connection:
@@ -1093,10 +1093,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:34:59.806529", "expires":
-        "2018-04-09T17:34:59Z", "id": "235d9613261943babeb033ed2c672b01", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:49.707024", "expires":
+        "2018-04-19T18:44:49Z", "id": "0bf0f96eedde4cb19b453cd4dfbf3884", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Y4dzBfZQT_ydP77NKl9HJg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rZCjXVDNSSOzlUkI1kXk9A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1140,7 +1140,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1155,7 +1155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 235d9613261943babeb033ed2c672b01
+      - 0bf0f96eedde4cb19b453cd4dfbf3884
   response:
     status:
       code: 200
@@ -1166,7 +1166,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:34:59 GMT
+      - Thu, 19 Apr 2018 17:44:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1175,7 +1175,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:34:59 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1193,13 +1193,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:00 GMT
+      - Thu, 19 Apr 2018 17:44:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ae38ac2f-55c4-4647-89ff-020ffa253ba1
+      - req-4afe5a3e-9b23-4729-86b5-1437cc4eb8f5
       Content-Length:
       - '4117'
       Connection:
@@ -1208,10 +1208,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:00.145495", "expires":
-        "2018-04-09T17:35:00Z", "id": "5e0c6193b9ae4406b51826b9950669b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:50.087068", "expires":
+        "2018-04-19T18:44:50Z", "id": "6e788c7f0cce4801bd9bf2384aff69d6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZBlMMMqAR5ykjX3_2nejQw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0_6VS6qMTdKFFZzmbUfYJw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1255,7 +1255,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1270,7 +1270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e0c6193b9ae4406b51826b9950669b5
+      - 6e788c7f0cce4801bd9bf2384aff69d6
   response:
     status:
       code: 200
@@ -1281,52 +1281,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-461a9b7c-49cd-4a0a-8618-d079c7f43176
+      - req-3e812b70-038b-4c9e-97c2-a6b362084027
       Date:
-      - Mon, 09 Apr 2018 16:35:00 GMT
+      - Thu, 19 Apr 2018 17:44:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1374,108 +1350,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5e0c6193b9ae4406b51826b9950669b5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a3028a2c-6992-433f-8b6e-716b22c1498f
-      Date:
-      - Mon, 09 Apr 2018 16:35:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -1489,37 +1368,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:00 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1534,7 +1402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e0c6193b9ae4406b51826b9950669b5
+      - 6e788c7f0cce4801bd9bf2384aff69d6
   response:
     status:
       code: 200
@@ -1545,9 +1413,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-32b8f100-4e34-4939-bea1-b4490a88914d
+      - req-625673d3-60e7-47c4-9ae8-e97b5002cb29
       Date:
-      - Mon, 09 Apr 2018 16:35:01 GMT
+      - Thu, 19 Apr 2018 17:44:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -1651,7 +1519,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1669,13 +1537,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:01 GMT
+      - Thu, 19 Apr 2018 17:44:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb856614-6e61-457c-a905-7727dda99e46
+      - req-dbfdf506-0585-4e59-962f-69bdba0808e1
       Content-Length:
       - '4131'
       Connection:
@@ -1684,10 +1552,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:01.417280", "expires":
-        "2018-04-09T17:35:01Z", "id": "b4d70169a5db43c594e9a7bfd5b0d2c0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:51.127004", "expires":
+        "2018-04-19T18:44:51Z", "id": "0c30519075734f5aa155916252b99161", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vXktNFdzTs2LGZe4xb8Tyg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3dMhnU7fS9a9VlKSV_MzAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1731,7 +1599,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:01 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1746,7 +1614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4d70169a5db43c594e9a7bfd5b0d2c0
+      - 0c30519075734f5aa155916252b99161
   response:
     status:
       code: 200
@@ -1757,52 +1625,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-01049d51-9800-444b-9c0c-15846db5f0c0
+      - req-6ae84903-ed05-481f-8240-8c2e2039d5c3
       Date:
-      - Mon, 09 Apr 2018 16:35:01 GMT
+      - Thu, 19 Apr 2018 17:44:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1850,51 +1683,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b4d70169a5db43c594e9a7bfd5b0d2c0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6c9db404-dcca-4831-9509-9bfb92945847
-      Date:
-      - Mon, 09 Apr 2018 16:35:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1918,12 +1707,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1935,185 +1718,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 74d549867ed7498897745c195d711c1e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5604db99-885d-4ccc-a424-054aa1ccd756
-      Date:
-      - Mon, 09 Apr 2018 16:35:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2127,7 +1731,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2142,7 +1746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74d549867ed7498897745c195d711c1e
+      - 0c30519075734f5aa155916252b99161
   response:
     status:
       code: 200
@@ -2153,9 +1757,273 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-05f3c5b9-645c-4c6c-abfd-696ab1df0018
+      - req-ca1da71d-7437-4644-acae-461b08d98cd7
       Date:
-      - Mon, 09 Apr 2018 16:35:02 GMT
+      - Thu, 19 Apr 2018 17:44:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:51 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0c30519075734f5aa155916252b99161
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-30a13c57-e95d-4c48-ab1f-331ec2a2dee6
+      Date:
+      - Thu, 19 Apr 2018 17:44:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:51 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0c30519075734f5aa155916252b99161
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f2366767-26c8-4ed4-98ea-405cd892f0d6
+      Date:
+      - Thu, 19 Apr 2018 17:44:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -2259,7 +2127,271 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:02 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:51 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 377aca084e7a42b8839d8d7b25b39f68
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b1993561-84fe-42bd-9fb9-d6963bd76c7c
+      Date:
+      - Thu, 19 Apr 2018 17:44:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 377aca084e7a42b8839d8d7b25b39f68
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-90811842-e12f-464e-8d7c-03e1e4fe987e
+      Date:
+      - Thu, 19 Apr 2018 17:44:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2277,13 +2409,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:03 GMT
+      - Thu, 19 Apr 2018 17:44:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fec9d60a-5f9d-4f13-a2ba-5369414f4d6b
+      - req-9f891673-c624-479a-880c-ecda004b7ea1
       Content-Length:
       - '4118'
       Connection:
@@ -2292,10 +2424,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:03.230449", "expires":
-        "2018-04-09T17:35:03Z", "id": "fad22125c7e6454e9b32e8cc66db1fe1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:52.784245", "expires":
+        "2018-04-19T18:44:52Z", "id": "da131aa5f8f54eb79a364b02c357d3ed", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Hpd8zBpZQ82M67l0Ozyy2w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["CNnFyk_DSxi1w03ra5KGLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2339,7 +2471,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2354,7 +2486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fad22125c7e6454e9b32e8cc66db1fe1
+      - da131aa5f8f54eb79a364b02c357d3ed
   response:
     status:
       code: 200
@@ -2365,25 +2497,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cae9d997-9e6c-4ce8-8b63-d04725f2bf86
+      - req-3a650be4-89d3-4f06-9d78-60325d7b1326
       Date:
-      - Mon, 09 Apr 2018 16:35:03 GMT
+      - Thu, 19 Apr 2018 17:44:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2458,20 +2578,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2486,7 +2618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fad22125c7e6454e9b32e8cc66db1fe1
+      - da131aa5f8f54eb79a364b02c357d3ed
   response:
     status:
       code: 200
@@ -2497,47 +2629,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f9fcc716-3a8f-497c-aaf8-c2617399fa33
+      - req-08be9efb-1e9d-4ad9-94d1-74631ab2c432
       Date:
-      - Mon, 09 Apr 2018 16:35:03 GMT
+      - Thu, 19 Apr 2018 17:44:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -2550,16 +2698,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -2573,37 +2716,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:03 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2618,7 +2750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fad22125c7e6454e9b32e8cc66db1fe1
+      - da131aa5f8f54eb79a364b02c357d3ed
   response:
     status:
       code: 200
@@ -2629,52 +2761,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5378fba3-d3e1-4965-a607-bf3550b6f21d
+      - req-80f83f6a-fe66-48a5-bcc8-d5f61142b200
       Date:
-      - Mon, 09 Apr 2018 16:35:03 GMT
+      - Thu, 19 Apr 2018 17:44:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2722,51 +2819,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fad22125c7e6454e9b32e8cc66db1fe1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-eb448a49-f5c8-4a74-b31e-ae212ea42570
-      Date:
-      - Mon, 09 Apr 2018 16:35:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2790,12 +2843,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -2807,65 +2854,18 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:04 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:14 GMT
+      - Thu, 19 Apr 2018 17:45:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fec7cd8f-42ec-41ef-8839-c7e3f0a8e02b
+      - req-8a90ae17-51e6-4921-b8bd-1d3ad0dbbe85
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:14.819719", "expires":
-        "2018-04-09T17:33:14Z", "id": "6a47a311e55742afad38d95e4beeae84", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:10.196710", "expires":
+        "2018-04-19T18:45:10Z", "id": "fdbee3e8711b4619a7a16ff23ca6a784", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jMXc2_JnRr-70NMJKyw-pQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["7zKq-Zg7RvyuoIk7NOPMgQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a47a311e55742afad38d95e4beeae84
+      - fdbee3e8711b4619a7a16ff23ca6a784
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:14 GMT
+      - Thu, 19 Apr 2018 17:45:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:15 GMT
+      - Thu, 19 Apr 2018 17:45:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ed35a761-56d4-4b38-ba05-baa2d8c07533
+      - req-ea20784b-fc9a-46cd-9f8c-21a3ad62b4a3
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:15.152668", "expires":
-        "2018-04-09T17:33:15Z", "id": "6b7f3eea386d418182ee1f89d088debb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:10.513661", "expires":
+        "2018-04-19T18:45:10Z", "id": "7eb416bed7e14138a260352b6643b66e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6aUw-i_GSACoRvxezsxaAQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PQ7orbj9QmegsV2djog6kQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b7f3eea386d418182ee1f89d088debb
+      - 7eb416bed7e14138a260352b6643b66e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:15 GMT
+      - Thu, 19 Apr 2018 17:45:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-01e5bef2-1ecc-4abe-b5c3-11c7e005fa25
+      - req-3a991568-d7f8-49c0-aa04-276b3c2abc33
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:15 GMT
+      - Thu, 19 Apr 2018 17:45:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-65fec79d-fb26-40a7-ae77-bf81bc90858d
+      - req-022281b5-c351-494d-9fb9-87847d9b0b41
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:15.781186", "expires":
-        "2018-04-09T17:33:15Z", "id": "d4fb7c6dcc4741eda54d2447c0de4eed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:10.875117", "expires":
+        "2018-04-19T18:45:10Z", "id": "de881c0b17184c9e92f213dc5159ced9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Dv9DCL_wScyv18SZ_GukuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mwEIgyxCSvyxkSlNdJN_iw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -337,7 +337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4fb7c6dcc4741eda54d2447c0de4eed
+      - de881c0b17184c9e92f213dc5159ced9
   response:
     status:
       code: 200
@@ -348,13 +348,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:33:15 GMT
+      - Thu, 19 Apr 2018 17:45:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -372,13 +372,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:15 GMT
+      - Thu, 19 Apr 2018 17:45:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb4d8144-b975-4ad3-abce-fdfbc2b3598a
+      - req-6f5f992e-500e-491d-a8b2-b43e6b2723fc
       Content-Length:
       - '370'
       Connection:
@@ -387,13 +387,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:16.045356", "expires":
-        "2018-04-09T17:33:16Z", "id": "7e817d2bfaa648f3a6ca0569c1ce419a", "audit_ids":
-        ["i4KhD4cOQYeHZkxjSkjM3w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:11.078137", "expires":
+        "2018-04-19T18:45:11Z", "id": "26d1625d14aa463782d84c8e61867262", "audit_ids":
+        ["4RBrtFQoRL6kai_ftXFgWA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e817d2bfaa648f3a6ca0569c1ce419a
+      - 26d1625d14aa463782d84c8e61867262
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:16 GMT
+      - Thu, 19 Apr 2018 17:45:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29ecaeac-b870-402a-8af7-429961750cb3
+      - req-d68a0929-9315-40b3-913a-d85a6404edff
       Content-Length:
       - '500'
       Connection:
@@ -438,13 +438,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7e817d2bfaa648f3a6ca0569c1ce419a"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"26d1625d14aa463782d84c8e61867262"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:16 GMT
+      - Thu, 19 Apr 2018 17:45:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5151530-aa2c-414d-8147-846200570a75
+      - req-ea5d29d5-c2b4-4a04-87d9-714a17c32908
       Content-Length:
       - '4143'
       Connection:
@@ -471,11 +471,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:16.430257", "expires":
-        "2018-04-09T17:33:16Z", "id": "266cc1e97c1745d0bf521be53f96dd0a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:11.360546", "expires":
+        "2018-04-19T18:45:11Z", "id": "d32a06500f774a65b8fd40c58a169ec3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2H0Hkud2TDaADZ9WOVb8OQ",
-        "i4KhD4cOQYeHZkxjSkjM3w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BvjQxBj-Q7OlmCJi-1DDDw",
+        "4RBrtFQoRL6kai_ftXFgWA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -519,7 +519,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -534,20 +534,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e817d2bfaa648f3a6ca0569c1ce419a
+      - 26d1625d14aa463782d84c8e61867262
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:16 GMT
+      - Thu, 19 Apr 2018 17:45:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3fefdb32-deaa-4d1d-b309-6a8b21ff666c
+      - req-2e9811fa-c013-4937-b172-d818540aa33d
       Content-Length:
       - '500'
       Connection:
@@ -564,7 +564,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -582,13 +582,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:16 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7de1894f-452c-4011-b6db-282f72c63492
+      - req-8b52e50c-ec15-4627-978a-b4f1139dff5e
       Content-Length:
       - '4117'
       Connection:
@@ -597,10 +597,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:17.101194", "expires":
-        "2018-04-09T17:33:17Z", "id": "6ce083c977f84ef6aac2550eebd74b9c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:12.313533", "expires":
+        "2018-04-19T18:45:12Z", "id": "dbeb80c5a8d74240813754c231c8b842", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v_2242fuTJu74twuLHPtQA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CHi4dKAeRLmxONVp3xeu4g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -644,7 +644,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -659,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6ce083c977f84ef6aac2550eebd74b9c
+      - dbeb80c5a8d74240813754c231c8b842
   response:
     status:
       code: 200
@@ -670,7 +670,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:17 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -679,7 +679,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -697,13 +697,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:17 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5172b4c3-ec17-4db3-80d5-38a44c8f9abd
+      - req-a9f69d23-0033-4e50-b065-41804e1be94e
       Content-Length:
       - '4131'
       Connection:
@@ -712,10 +712,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:17.452380", "expires":
-        "2018-04-09T17:33:17Z", "id": "244c719f7a7947338da7b2d1abe752ae", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:12.589632", "expires":
+        "2018-04-19T18:45:12Z", "id": "1a447cd717164aeaa7503a49e05b0181", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Pr1sW025SA6T8CFL9sY3sA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pr9PvrlQQBWgCSgPCxxsRw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -759,7 +759,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -774,7 +774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 244c719f7a7947338da7b2d1abe752ae
+      - 1a447cd717164aeaa7503a49e05b0181
   response:
     status:
       code: 200
@@ -785,7 +785,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:17 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -794,7 +794,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -812,13 +812,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:17 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0ab9227a-4238-4263-9026-ba96499bfc5b
+      - req-20529438-75eb-4b31-9a2a-212f68375755
       Content-Length:
       - '4118'
       Connection:
@@ -827,10 +827,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:17.810926", "expires":
-        "2018-04-09T17:33:17Z", "id": "142bbe3f8f4e4ee695ee8d3167276776", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:12.879513", "expires":
+        "2018-04-19T18:45:12Z", "id": "5905a3aff63c40fe93eca3b4e99ca3aa", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["p0ZlK9IVT4awhTdsc_sj5Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qUmpolxVSBq0v7oSlfpF-A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -874,7 +874,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -889,7 +889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 142bbe3f8f4e4ee695ee8d3167276776
+      - 5905a3aff63c40fe93eca3b4e99ca3aa
   response:
     status:
       code: 200
@@ -900,7 +900,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:33:17 GMT
+      - Thu, 19 Apr 2018 17:45:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -909,7 +909,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -927,13 +927,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:18 GMT
+      - Thu, 19 Apr 2018 17:45:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-243fa030-384a-419a-b155-6c9d40a84e42
+      - req-cc70868b-75c3-4fc0-a4f0-e21136355522
       Content-Length:
       - '4117'
       Connection:
@@ -942,10 +942,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:18.184625", "expires":
-        "2018-04-09T17:33:18Z", "id": "c55286b0390142b19f35e22eddce5fdf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:13.139503", "expires":
+        "2018-04-19T18:45:13Z", "id": "b39859225742423b9bf27aede938db65", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zjHLMvZiRkGTXenOkd4Y7g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["coxNFzJJTgGegvoehIZQ6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -989,7 +989,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
+      - b39859225742423b9bf27aede938db65
   response:
     status:
       code: 200
@@ -1015,52 +1015,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b3c81cd7-4ca5-416b-80d2-6a5d0d273a9c
+      - req-957e093d-c70f-4fd3-b309-6f3681573f9a
       Date:
-      - Mon, 09 Apr 2018 16:33:18 GMT
+      - Thu, 19 Apr 2018 17:45:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1108,183 +1073,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f6e4950c-d71f-4c8f-83fa-902ed271f9b4
-      Date:
-      - Mon, 09 Apr 2018 16:33:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2e0d223f-4dc7-4264-afa8-0409bcd65ef5
-      Date:
-      - Mon, 09 Apr 2018 16:33:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1308,12 +1097,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1325,185 +1108,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f49fbdfc-7f6f-4f82-ab86-01972b50ed5d
-      Date:
-      - Mon, 09 Apr 2018 16:33:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1517,7 +1121,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1532,7 +1136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
+      - b39859225742423b9bf27aede938db65
   response:
     status:
       code: 200
@@ -1543,141 +1147,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0f56d299-47fb-4b67-aa62-a4cc1d0fe170
+      - req-c144e9bb-a727-4f97-938c-325ab822e5f7
       Date:
-      - Mon, 09 Apr 2018 16:33:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d1c6e8fa-6c2f-4940-be9d-f3cd4ca3bc9f
-      Date:
-      - Mon, 09 Apr 2018 16:33:19 GMT
+      - Thu, 19 Apr 2018 17:45:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -1781,403 +1253,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d7bf030e-f056-4ab8-af6f-4fb4aa43747a
-      Date:
-      - Mon, 09 Apr 2018 16:33:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8fb8f35e-5e12-4a22-8b70-8ba5b38cf0da
-      Date:
-      - Mon, 09 Apr 2018 16:33:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c55286b0390142b19f35e22eddce5fdf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cd333861-ba42-40cd-b720-0fee05482b56
-      Date:
-      - Mon, 09 Apr 2018 16:33:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2195,13 +1271,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:20 GMT
+      - Thu, 19 Apr 2018 17:45:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e4814319-3dab-4a31-ac76-245f949ab09e
+      - req-9dd90721-9caa-4007-bf29-8a194663094e
       Content-Length:
       - '4131'
       Connection:
@@ -2210,10 +1286,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:20.699422", "expires":
-        "2018-04-09T17:33:20Z", "id": "e7f11a42bfb148b79502f4b3ff051e70", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:13.878436", "expires":
+        "2018-04-19T18:45:13Z", "id": "7f3f2820bddb4718a31d813f5d8627aa", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4gJUIAkGQbayI3L4_JedUg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MpBm-71pS0iDkKOJ1i5obg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2257,7 +1333,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2272,7 +1348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7f11a42bfb148b79502f4b3ff051e70
+      - 7f3f2820bddb4718a31d813f5d8627aa
   response:
     status:
       code: 200
@@ -2283,52 +1359,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-34cbea5c-4dfd-4866-bed3-706365ed1386
+      - req-1b617fdf-2a4f-4bd2-b02b-6ec4a28d6119
       Date:
-      - Mon, 09 Apr 2018 16:33:21 GMT
+      - Thu, 19 Apr 2018 17:45:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2376,51 +1417,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e7f11a42bfb148b79502f4b3ff051e70
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9ce063c7-bd48-4fb9-af0d-181473908d59
-      Date:
-      - Mon, 09 Apr 2018 16:33:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2444,12 +1441,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -2461,185 +1452,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d4fb7c6dcc4741eda54d2447c0de4eed
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cd60bd24-374c-4bd1-a7a5-b69b7a5bdb31
-      Date:
-      - Mon, 09 Apr 2018 16:33:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2653,7 +1465,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2668,7 +1480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4fb7c6dcc4741eda54d2447c0de4eed
+      - 7f3f2820bddb4718a31d813f5d8627aa
   response:
     status:
       code: 200
@@ -2679,9 +1491,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5551c979-bab4-4f88-9027-f5cf4005185e
+      - req-755bc703-fffb-46fd-991f-18612926ebb2
       Date:
-      - Mon, 09 Apr 2018 16:33:22 GMT
+      - Thu, 19 Apr 2018 17:45:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - de881c0b17184c9e92f213dc5159ced9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ce5f284d-b243-4588-8e38-4365f4cddc76
+      Date:
+      - Thu, 19 Apr 2018 17:45:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -2785,7 +1729,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - de881c0b17184c9e92f213dc5159ced9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0164c848-1801-42eb-adb7-9d90ead37ac6
+      Date:
+      - Thu, 19 Apr 2018 17:45:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2803,13 +1879,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:33:22 GMT
+      - Thu, 19 Apr 2018 17:45:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4149def3-2ea2-4649-83c4-c1d11658a0e0
+      - req-6cbcc860-2671-4061-bd73-d5153f9de3a3
       Content-Length:
       - '4118'
       Connection:
@@ -2818,10 +1894,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:33:22.408041", "expires":
-        "2018-04-09T17:33:22Z", "id": "eb9cf51e6d87477cb3d3d8183e41d33d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:15.143373", "expires":
+        "2018-04-19T18:45:15Z", "id": "08d6e998cb4f4eb78f8bbf294d8b14ce", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7tuhHqPMQPG0SormaeLTtQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UpUDXoHNRIGxpfv_aD184A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2865,7 +1941,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2880,7 +1956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
+      - '08d6e998cb4f4eb78f8bbf294d8b14ce'
   response:
     status:
       code: 200
@@ -2891,141 +1967,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0bcdf597-85ee-4570-b454-fc8b34748040
+      - req-5c0ba8a1-bf70-40d1-ac3d-702208261438
       Date:
-      - Mon, 09 Apr 2018 16:33:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8c5b3830-0e87-4007-931b-2e871af55990
-      Date:
-      - Mon, 09 Apr 2018 16:33:23 GMT
+      - Thu, 19 Apr 2018 17:45:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -3129,7 +2073,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -3144,7 +2088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
+      - '08d6e998cb4f4eb78f8bbf294d8b14ce'
   response:
     status:
       code: 200
@@ -3155,25 +2099,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bb746558-b25c-4f70-a575-45f5fadb021c
+      - req-5092c147-3d65-4eb4-80eb-19c7c0c4bc27
       Date:
-      - Mon, 09 Apr 2018 16:33:23 GMT
+      - Thu, 19 Apr 2018 17:45:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -3248,20 +2180,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:23 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3276,7 +2220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
+      - '08d6e998cb4f4eb78f8bbf294d8b14ce'
   response:
     status:
       code: 200
@@ -3287,9 +2231,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b212a3b3-03d0-4755-a147-8bc929ceeb9d
+      - req-bbdb40cb-99c3-47e7-94f4-1814ce8c7171
       Date:
-      - Mon, 09 Apr 2018 16:33:23 GMT
+      - Thu, 19 Apr 2018 17:45:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:15 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '08d6e998cb4f4eb78f8bbf294d8b14ce'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-70d1d73f-7414-451c-8f5f-ff88c81d49fa
+      Date:
+      - Thu, 19 Apr 2018 17:45:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -3393,797 +2469,5 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8f3b4a75-a3fd-417a-afbf-cd79d1aa6a7e
-      Date:
-      - Mon, 09 Apr 2018 16:33:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5bd38378-8a5a-43e6-a3cf-db026577d6bc
-      Date:
-      - Mon, 09 Apr 2018 16:33:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f739d99b-4c32-4896-a13d-6384459eaaa3
-      Date:
-      - Mon, 09 Apr 2018 16:33:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-03c7673c-8a1c-4ab0-983a-18dbbd02c77e
-      Date:
-      - Mon, 09 Apr 2018 16:33:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5a07982c-7f98-4bb2-92c2-3d2f18809060
-      Date:
-      - Mon, 09 Apr 2018 16:33:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb9cf51e6d87477cb3d3d8183e41d33d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b72160a5-0456-4ae4-8775-a4732cf319eb
-      Date:
-      - Mon, 09 Apr 2018 16:33:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:33:25 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:05 GMT
+      - Thu, 19 Apr 2018 17:44:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7bea44ec-ba4e-4335-9384-e6904e55fc18
+      - req-ec26014d-e7f9-4904-acde-84db94dc5003
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:05.341880", "expires":
-        "2018-04-09T17:35:05Z", "id": "9c9a4573a96043189b6e7733a7045a67", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:54.728878", "expires":
+        "2018-04-19T18:44:54Z", "id": "95890397e3ad47659ed12c5c81e93aad", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Pq2QFeABTrCH8Vvegmt24A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["32yj3tZdTCOBy0WxH9GnYg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:05 GMT
+      - Thu, 19 Apr 2018 17:44:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:05 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,9 +143,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-f9e4384d-4737-4915-ac6e-82f7efc4cace
+      - req-c21838f5-6df2-4bb0-baf6-a55a5378cda1
       Date:
-      - Mon, 09 Apr 2018 16:35:06 GMT
+      - Thu, 19 Apr 2018 17:44:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-01-17T19:26:19Z",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-2001200c-8834-4b53-b020-5cc29a1db6dd
+      - req-900f9c30-3e3c-427c-adb9-58bb005ca860
       Date:
-      - Mon, 09 Apr 2018 16:35:06 GMT
+      - Thu, 19 Apr 2018 17:44:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:06 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-c5aeaf52-b41b-4f94-a67d-5692d8c4c79e
+      - req-42740705-6938-4ed8-ac05-1ca4c23b0620
       Date:
-      - Mon, 09 Apr 2018 16:35:07 GMT
+      - Thu, 19 Apr 2018 17:44:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f3aad05e-d198-4fb8-bc7e-b30cdc453bbb
+      - req-20d14749-1a00-44d5-9c8c-62dc8838f391
       Date:
-      - Mon, 09 Apr 2018 16:35:07 GMT
+      - Thu, 19 Apr 2018 17:44:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:07 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:08 GMT
+      - Thu, 19 Apr 2018 17:44:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e87588b-0180-496d-af81-68ce46a1d76d
+      - req-7bbba8cc-1e1c-4a52-bde4-0d0ddcbd0426
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:08.157979", "expires":
-        "2018-04-09T17:35:08Z", "id": "019b80ae390b430f8b28146e6b7a19ee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:57.094065", "expires":
+        "2018-04-19T18:44:56Z", "id": "bd6a63589e4848c083dcec910dc73cea", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4A7tpH-mQJW9LxIDrJ1UzA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["LUDcKzRqRs6xwbzlAwPa9g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -434,13 +434,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 09 Apr 2018 16:35:08 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -466,9 +466,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-249323be-6aa3-4a3e-ba78-d529f4138698
+      - req-e0a4bad1-ce4b-43d7-b219-dc5022b30bf9
       Date:
-      - Mon, 09 Apr 2018 16:35:08 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -477,7 +477,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -495,13 +495,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:08 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45121e08-8992-400c-9474-f6959b68cb79
+      - req-41add31d-43b6-4678-b0de-07d3d4a54002
       Content-Length:
       - '4170'
       Connection:
@@ -510,10 +510,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:08.893175", "expires":
-        "2018-04-09T17:35:08Z", "id": "d9b192a016034fac9966dfd054d740f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:57.494358", "expires":
+        "2018-04-19T18:44:57Z", "id": "c47daaa4d95945daaa02007ffa0dbee9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["EoWcEuC4T3WjB-od6Dfo9g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sXbbH7oUQVSvkShDXKIScw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:08 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -573,20 +573,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9b192a016034fac9966dfd054d740f9
+      - c47daaa4d95945daaa02007ffa0dbee9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:09 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-735f95d3-7d1d-49c5-8225-0c1f4f470281
+      - req-9a846e95-5e2b-4486-9421-b67b53fef809
       Content-Length:
       - '500'
       Connection:
@@ -603,7 +603,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -618,7 +618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -631,9 +631,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-9d0116d5-f84e-4dcd-8af3-9e37316e726c
+      - req-cece9f82-8297-4170-adb6-3089b787f3a2
       Date:
-      - Mon, 09 Apr 2018 16:35:09 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -642,7 +642,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -660,13 +660,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:09 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10d14b0c-a38f-4061-a8e2-6586f6c82a99
+      - req-ae708f34-ba18-4512-a170-67934d769fe4
       Content-Length:
       - '4170'
       Connection:
@@ -675,10 +675,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:09.465959", "expires":
-        "2018-04-09T17:35:09Z", "id": "e7ebb83d35e543b49077fdc377f14075", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:57.909691", "expires":
+        "2018-04-19T18:44:57Z", "id": "4f171a78a29e45c3a9f4a303d591924d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["wyaA51pZQtyCdXBaezAb2Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ypCMy-7tR9yNUz-a6vgn2w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -723,7 +723,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -738,7 +738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7ebb83d35e543b49077fdc377f14075
+      - 4f171a78a29e45c3a9f4a303d591924d
   response:
     status:
       code: 300
@@ -749,7 +749,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 09 Apr 2018 16:35:09 GMT
+      - Thu, 19 Apr 2018 17:44:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -762,7 +762,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -777,7 +777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7ebb83d35e543b49077fdc377f14075
+      - 4f171a78a29e45c3a9f4a303d591924d
   response:
     status:
       code: 200
@@ -788,9 +788,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-65b6a408-2e35-423d-9ea0-c53a7969ebd8
+      - req-3f2b72d4-f7db-4b5e-a313-72531f1b0354
       Date:
-      - Mon, 09 Apr 2018 16:35:09 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -801,7 +801,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:09 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs
@@ -816,7 +816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -829,9 +829,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-0915c946-1daf-486b-b162-056912342d5a
+      - req-31a6170e-dd80-4dd6-ae63-85e157b6ffff
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -841,7 +841,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -856,7 +856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a4573a96043189b6e7733a7045a67
+      - 95890397e3ad47659ed12c5c81e93aad
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -869,9 +869,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-60e2ca4e-64c6-4500-a0b9-77a064d088c1
+      - req-7a6e73f2-d185-40b2-a1ab-eafd61b96682
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -880,7 +880,43 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 95890397e3ad47659ed12c5c81e93aad
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-a433a365-6408-45d7-8752-c6a8c004324c
+      Date:
+      - Thu, 19 Apr 2018 17:44:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -895,7 +931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -906,9 +942,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-17d5b2f9-ea7e-4c85-b82b-ae1af5d23761
+      - req-97f96f87-5c28-48dd-9da8-b895af49842a
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
@@ -918,7 +954,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -933,7 +969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -944,9 +980,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-0b0d5afc-b82e-40ea-8ab9-4eb9d1a4b937
+      - req-8ee46ca7-5cfe-44e3-a7fc-3e539feb0d67
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -956,7 +992,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -974,13 +1010,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91671449-6640-4a53-83b8-9c46691c864e
+      - req-5df10dfd-e1e5-4d12-9dad-8c50b06a7bc3
       Content-Length:
       - '370'
       Connection:
@@ -989,13 +1025,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:10.559227", "expires":
-        "2018-04-09T17:35:10Z", "id": "9188b232f6de49dab2d68bb2d4641788", "audit_ids":
-        ["CN1bI_h9QXWE2zyaLm63iA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:58.901260", "expires":
+        "2018-04-19T18:44:58Z", "id": "76432123bf1749439516ec363920af1a", "audit_ids":
+        ["4P6JnVqCTKSKi-Dd4qJn1w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:58 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1010,20 +1046,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9188b232f6de49dab2d68bb2d4641788
+      - 76432123bf1749439516ec363920af1a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aa3072fe-65e7-4707-8d4e-b6843fe365a0
+      - req-6c50b38d-36c3-4dec-b118-e8028ed2be59
       Content-Length:
       - '500'
       Connection:
@@ -1040,13 +1076,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:10 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9188b232f6de49dab2d68bb2d4641788"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"76432123bf1749439516ec363920af1a"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1058,13 +1094,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:10 GMT
+      - Thu, 19 Apr 2018 17:44:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-225892bc-7729-45e7-b66a-6da74d2b1ded
+      - req-9eb67aba-683f-415e-85cb-9ac76525c918
       Content-Length:
       - '4143'
       Connection:
@@ -1073,11 +1109,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:11.035643", "expires":
-        "2018-04-09T17:35:10Z", "id": "8ac814cf74ce4753bc3561d913505522", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:59.262714", "expires":
+        "2018-04-19T18:44:58Z", "id": "3a192c84e7d243228b7e4cf178101f0e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hnbNiZuoQN-O1Wb6zBdB1Q",
-        "CN1bI_h9QXWE2zyaLm63iA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kikGHmB7Re-GlL0akefPbg",
+        "4P6JnVqCTKSKi-Dd4qJn1w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1121,7 +1157,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1136,20 +1172,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9188b232f6de49dab2d68bb2d4641788
+      - 76432123bf1749439516ec363920af1a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:11 GMT
+      - Thu, 19 Apr 2018 17:44:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d40b273c-22ad-4987-8bcd-941b46c83e1a
+      - req-d4db9f4e-3750-4ca4-b58a-5f362ed39ebb
       Content-Length:
       - '500'
       Connection:
@@ -1166,7 +1202,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1184,13 +1220,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:11 GMT
+      - Thu, 19 Apr 2018 17:44:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0338ae1b-ca55-4d14-b5b0-8a53de14c15f
+      - req-60d7b259-7a7d-46c9-bb94-7eb34e25e890
       Content-Length:
       - '4117'
       Connection:
@@ -1199,10 +1235,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:11.460699", "expires":
-        "2018-04-09T17:35:11Z", "id": "8ac840715f9d4ebdad9ac1585f630572", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:44:59.660510", "expires":
+        "2018-04-19T18:44:59Z", "id": "91951d0d90c44ddc988cae00f0a2d71f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MG3tPEAlS-SA5mGHtrXiqw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8OWEnnQhQ4mnvfURb14eyg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1246,7 +1282,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1261,7 +1297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ac840715f9d4ebdad9ac1585f630572
+      - 91951d0d90c44ddc988cae00f0a2d71f
   response:
     status:
       code: 200
@@ -1272,7 +1308,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:11 GMT
+      - Thu, 19 Apr 2018 17:44:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1281,7 +1317,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:44:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1299,13 +1335,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:11 GMT
+      - Thu, 19 Apr 2018 17:44:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7dba3ce1-f674-47ca-a95b-872c30f60e66
+      - req-2b7868c1-40bf-4723-a8ab-6871c144982b
       Content-Length:
       - '4131'
       Connection:
@@ -1314,10 +1350,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:11.799485", "expires":
-        "2018-04-09T17:35:11Z", "id": "7fd3e39eb4d942adae25ebc9186087c2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:00.067834", "expires":
+        "2018-04-19T18:44:59Z", "id": "b5f800828c35486db010899850ba3be3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["T-21IV_5To2iS93wdDIIfQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xCogzFNTSUq9rUuckGKDEA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1361,7 +1397,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1376,7 +1412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fd3e39eb4d942adae25ebc9186087c2
+      - b5f800828c35486db010899850ba3be3
   response:
     status:
       code: 200
@@ -1387,7 +1423,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:11 GMT
+      - Thu, 19 Apr 2018 17:45:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1396,7 +1432,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:11 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1414,13 +1450,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:12 GMT
+      - Thu, 19 Apr 2018 17:45:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ec66b04-1d48-4d1a-afa4-1b034578ece9
+      - req-a3dbddbd-78e3-40fc-85ac-66b33ec1a6f7
       Content-Length:
       - '4118'
       Connection:
@@ -1429,10 +1465,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:12.156911", "expires":
-        "2018-04-09T17:35:12Z", "id": "0733073710c54678b6d59cba75b2aecd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:00.479277", "expires":
+        "2018-04-19T18:45:00Z", "id": "b2823a4a257d47d09afc88390eb4d4a0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["57C6smpzR1uXQYoQ2x1Uuw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8sheiNNdTlaiUgstDKV1Nw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1476,7 +1512,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1491,7 +1527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0733073710c54678b6d59cba75b2aecd
+      - b2823a4a257d47d09afc88390eb4d4a0
   response:
     status:
       code: 200
@@ -1502,7 +1538,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 09 Apr 2018 16:35:12 GMT
+      - Thu, 19 Apr 2018 17:45:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1511,7 +1547,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1529,13 +1565,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:12 GMT
+      - Thu, 19 Apr 2018 17:45:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-90dcc2e8-780c-4241-9841-38d11b886ee2
+      - req-c4eb7700-2909-42aa-ac6c-f4eb3b7bbbf4
       Content-Length:
       - '4117'
       Connection:
@@ -1544,10 +1580,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:12.488728", "expires":
-        "2018-04-09T17:35:12Z", "id": "6575137c6c8b41d090530720eda37e88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:00.852221", "expires":
+        "2018-04-19T18:45:00Z", "id": "6be5bc76d56a4162bd62739cb1d95477", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RuKi4y7zTRe0rPc3Oj3N5Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HKqf8TwAQu6vTBO00mYeVA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1591,7 +1627,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1606,7 +1642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6575137c6c8b41d090530720eda37e88
+      - 6be5bc76d56a4162bd62739cb1d95477
   response:
     status:
       code: 200
@@ -1617,9 +1653,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c9a892f8-cafd-4dee-adc8-b546b3d4ea1d
+      - req-0e5efa91-a6c1-41a5-b34b-71f1f367e5ad
       Date:
-      - Mon, 09 Apr 2018 16:35:12 GMT
+      - Thu, 19 Apr 2018 17:45:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -1723,7 +1759,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:12 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1738,7 +1774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6575137c6c8b41d090530720eda37e88
+      - 6be5bc76d56a4162bd62739cb1d95477
   response:
     status:
       code: 200
@@ -1749,47 +1785,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-da38fb86-146a-498f-8d17-634142c757bd
+      - req-467ff57e-1032-4484-bc7b-9991595aa020
       Date:
-      - Mon, 09 Apr 2018 16:35:13 GMT
+      - Thu, 19 Apr 2018 17:45:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -1802,16 +1843,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -1825,23 +1861,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1855,7 +1891,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1873,13 +1909,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:13 GMT
+      - Thu, 19 Apr 2018 17:45:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-468e511e-fdc5-45fa-a3db-57dede57af84
+      - req-9b545b25-153c-47bf-aec9-9f0dbbf14a65
       Content-Length:
       - '4131'
       Connection:
@@ -1888,10 +1924,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:13.527474", "expires":
-        "2018-04-09T17:35:13Z", "id": "c38957c08adc45a89c7a75ca8d63f82d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:01.628295", "expires":
+        "2018-04-19T18:45:01Z", "id": "9211a1bbd9234502b855a34e23440c4e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pBvtbtkeT7CRZ_G248qhBw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DHFFd9mgRuiy03FOdmhM2A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1935,7 +1971,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1950,7 +1986,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
+      - 9211a1bbd9234502b855a34e23440c4e
   response:
     status:
       code: 200
@@ -1961,25 +1997,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5e1e35ee-376a-4120-a5e7-fad8644e1fa1
+      - req-c4b20a77-56eb-4203-b911-28a48fa90e4c
       Date:
-      - Mon, 09 Apr 2018 16:35:13 GMT
+      - Thu, 19 Apr 2018 17:45:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2054,20 +2078,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:13 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2082,7 +2118,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
+      - 9211a1bbd9234502b855a34e23440c4e
   response:
     status:
       code: 200
@@ -2093,9 +2129,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9585f3d1-4779-4df3-aff8-ddbb84c7d0b9
+      - req-8333fce5-c358-414b-abc0-00c56ae89e55
       Date:
-      - Mon, 09 Apr 2018 16:35:14 GMT
+      - Thu, 19 Apr 2018 17:45:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -2199,7 +2235,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:14 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2214,7 +2250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
+      - 9211a1bbd9234502b855a34e23440c4e
   response:
     status:
       code: 200
@@ -2225,52 +2261,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d09c0034-c960-4695-bc43-9226fef8cceb
+      - req-8d051f0d-cd27-42bf-84a9-c4fe1d417c79
       Date:
-      - Mon, 09 Apr 2018 16:35:14 GMT
+      - Thu, 19 Apr 2018 17:45:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2318,108 +2330,11 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e75f5df9-520f-4ac6-98ce-d6c1685b6c7e
-      Date:
-      - Mon, 09 Apr 2018 16:35:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -2433,301 +2348,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-803608c6-2f66-4555-8d86-d8da57b530ee
-      Date:
-      - Mon, 09 Apr 2018 16:35:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6ebf42b1-f741-4c96-9114-1e883379278c
-      Date:
-      - Mon, 09 Apr 2018 16:35:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2742,7 +2382,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -2753,157 +2393,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-00815174-42e1-47e0-ac6e-13eb46d7c313
+      - req-5aae3128-6727-429b-9dc0-105213054a92
       Date:
-      - Mon, 09 Apr 2018 16:35:15 GMT
+      - Thu, 19 Apr 2018 17:45:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-082d7165-22df-4df0-aece-5550221bee1d
-      Date:
-      - Mon, 09 Apr 2018 16:35:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2978,20 +2474,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:15 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3006,7 +2514,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -3017,184 +2525,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8272375e-6efb-4982-a311-5ca8a2af3ec5
+      - req-ba63e5c4-fcc2-4b2b-abe5-6c97381dac32
       Date:
-      - Mon, 09 Apr 2018 16:35:15 GMT
+      - Thu, 19 Apr 2018 17:45:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8b99daec-411a-482a-a619-295ae40b769f
-      Date:
-      - Mon, 09 Apr 2018 16:35:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3242,183 +2583,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-95b83f3b-f1cb-4c75-94dd-4f8837d0537e
-      Date:
-      - Mon, 09 Apr 2018 16:35:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:16 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-679fec2b-63fe-4f70-9561-1af1daa009a2
-      Date:
-      - Mon, 09 Apr 2018 16:35:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -3442,12 +2607,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -3459,185 +2618,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:16 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-47be9706-ef31-4b77-aedd-54400aea0f13
-      Date:
-      - Mon, 09 Apr 2018 16:35:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -3651,7 +2631,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:16 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -3666,7 +2646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -3677,141 +2657,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2783ec5f-985c-4ef2-960f-d16307b2b1e6
+      - req-56d2e494-b296-464a-bc25-492e68e074e8
       Date:
-      - Mon, 09 Apr 2018 16:35:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:16 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4d8375be-c27f-4dd5-b538-e8dff28dae32
-      Date:
-      - Mon, 09 Apr 2018 16:35:17 GMT
+      - Thu, 19 Apr 2018 17:45:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -3915,403 +2763,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1363ba5c-a2c6-41a4-b555-c1f4931cc56b
-      Date:
-      - Mon, 09 Apr 2018 16:35:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-31239813-b01d-4e85-8637-cbdbfa5b8ec0
-      Date:
-      - Mon, 09 Apr 2018 16:35:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e76ef0da-0a5d-4d5b-9766-18fa676d0ce4
-      Date:
-      - Mon, 09 Apr 2018 16:35:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4329,13 +2781,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:17 GMT
+      - Thu, 19 Apr 2018 17:45:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b58e65b-3126-4dd6-abda-cd49112aaa7d
+      - req-40d0607f-7a7b-4329-b0a7-f9101d1c8e7e
       Content-Length:
       - '4118'
       Connection:
@@ -4344,10 +2796,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:17.887201", "expires":
-        "2018-04-09T17:35:17Z", "id": "5bc65d544bde4c6a85303f10ef64a0dd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:03.666244", "expires":
+        "2018-04-19T18:45:03Z", "id": "c6070b31a1b54387a5139003171ca350", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["2ttNAMe0T8mnSKzGDqGJKw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mAoCWVOUTeKLXlA6oc0LeA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4391,7 +2843,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:17 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -4406,7 +2858,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
+      - c6070b31a1b54387a5139003171ca350
   response:
     status:
       code: 200
@@ -4417,12 +2869,76 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f263cffc-7e39-414f-9b27-3b7a54ef4183
+      - req-f5eba42b-14d7-44e3-b2cd-111d515fc67f
       Date:
-      - Mon, 09 Apr 2018 16:35:18 GMT
+      - Thu, 19 Apr 2018 17:45:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -4436,6 +2952,62 @@ http_interactions:
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
         "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c6070b31a1b54387a5139003171ca350
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-65b524e9-47c6-4c06-857a-550558ebfda7
+      Date:
+      - Thu, 19 Apr 2018 17:45:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -4510,20 +3082,32 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:18 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -4538,7 +3122,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
+      - c6070b31a1b54387a5139003171ca350
   response:
     status:
       code: 200
@@ -4549,9 +3133,405 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a474ff09-1f74-49ce-9da2-0b789d85ce22
+      - req-38d4179e-cb6a-4171-9e41-cc15e38c3870
       Date:
-      - Mon, 09 Apr 2018 16:35:18 GMT
+      - Thu, 19 Apr 2018 17:45:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c6070b31a1b54387a5139003171ca350
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f07ba3ac-0f78-4d82-8d8a-1dd8aa5dd4dd
+      Date:
+      - Thu, 19 Apr 2018 17:45:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
+        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c6070b31a1b54387a5139003171ca350
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b0fe0985-f30b-4d73-b9bf-c2ab7e0aaf02
+      Date:
+      - Thu, 19 Apr 2018 17:45:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 19 Apr 2018 17:45:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c6070b31a1b54387a5139003171ca350
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c8163da6-7a40-4b5e-a2ec-b03c17f0d6c7
+      Date:
+      - Thu, 19 Apr 2018 17:45:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -4655,271 +3635,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fad49234-f0b6-4ea0-976d-97b72631fd34
-      Date:
-      - Mon, 09 Apr 2018 16:35:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6a72546c-d25a-4b6d-af43-4dcaa24fe90c
-      Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -4934,7 +3650,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -4945,9 +3661,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-c837b001-8294-4789-a0c5-62bcf5b4201e
+      - req-4427cea4-b01d-4671-91a0-5dcc893e1eaa
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4962,7 +3678,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4977,7 +3693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6575137c6c8b41d090530720eda37e88
+      - 6be5bc76d56a4162bd62739cb1d95477
   response:
     status:
       code: 200
@@ -4988,9 +3704,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-68fc78d0-43da-4f5b-bd55-0c700bce3761
+      - req-92c43f33-f2c5-40b7-8e1a-08c231291d02
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5026,7 +3742,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -5041,7 +3757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6575137c6c8b41d090530720eda37e88
+      - 6be5bc76d56a4162bd62739cb1d95477
   response:
     status:
       code: 200
@@ -5052,9 +3768,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-ee480c2f-2cd3-4fe0-82ae-9b9f12fd6830
+      - req-20ee7ad3-c0ea-48d6-9f14-798ecda81e79
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5090,7 +3806,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -5105,7 +3821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
+      - 9211a1bbd9234502b855a34e23440c4e
   response:
     status:
       code: 200
@@ -5116,9 +3832,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-ecf1978b-78a5-43bb-b80a-848031abbbec
+      - req-edaaf968-44b0-4429-bf1d-5ca394fc7e9d
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5154,7 +3870,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -5169,7 +3885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c38957c08adc45a89c7a75ca8d63f82d
+      - 9211a1bbd9234502b855a34e23440c4e
   response:
     status:
       code: 200
@@ -5180,9 +3896,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a18703b9-b4f2-40cb-ad05-fdb0cd166997
+      - req-71707f24-8bfb-4c34-b8b7-057dfa31833d
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5218,7 +3934,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -5233,7 +3949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -5244,9 +3960,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-dc31d34e-bfa7-4d2c-a8a9-1f88fa8b4f91
+      - req-a30e3f08-1a54-4b84-9206-3529345f5b6f
       Date:
-      - Mon, 09 Apr 2018 16:35:19 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5282,7 +3998,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:19 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -5297,7 +4013,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -5308,9 +4024,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-0c2ceff1-fe9f-4e1d-8bc6-98e902f018f8
+      - req-a87134b7-18e2-4051-939a-c9ff07c2e836
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5346,7 +4062,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -5361,7 +4077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
+      - c6070b31a1b54387a5139003171ca350
   response:
     status:
       code: 200
@@ -5372,9 +4088,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-dc821b8b-46ae-4fd9-810d-b1e5b3a2587a
+      - req-7e4490c5-f208-4f5c-b32e-4716008e61cc
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5410,7 +4126,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -5425,7 +4141,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc65d544bde4c6a85303f10ef64a0dd
+      - c6070b31a1b54387a5139003171ca350
   response:
     status:
       code: 200
@@ -5436,9 +4152,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-56877c43-e2d0-4b86-9d3e-43d3e5f59d65
+      - req-77ce9969-5028-48e2-bbb7-f79895a6271f
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5474,7 +4190,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -5489,7 +4205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -5500,9 +4216,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-2068b264-3e6c-4c7c-a405-9e09bf4c7676
+      - req-a17a3f90-bb23-42c7-b9ac-9345b3a3e3df
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5511,7 +4227,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -5526,7 +4242,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -5537,9 +4253,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-282a4547-51a1-4f12-aa81-906c2ac3ad27
+      - req-ded1e2ac-c6dc-4267-97d6-8e8a270afd6e
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5625,7 +4341,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5640,7 +4356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '019b80ae390b430f8b28146e6b7a19ee'
+      - bd6a63589e4848c083dcec910dc73cea
   response:
     status:
       code: 200
@@ -5651,9 +4367,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-2606cb2f-174a-4a42-9295-c744116c6716
+      - req-a1d26158-32ed-446a-91a3-315aa38509e3
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5667,7 +4383,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:20 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5685,13 +4401,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 16:35:20 GMT
+      - Thu, 19 Apr 2018 17:45:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a55909bb-d7f3-41cb-b441-0bae3eaac8d5
+      - req-088c4e9d-f3a3-4c84-ae77-a5649a0b65f9
       Content-Length:
       - '4117'
       Connection:
@@ -5700,10 +4416,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-04-09T16:35:21.016035", "expires":
-        "2018-04-09T17:35:20Z", "id": "04b6534a7cfc4090945fb8e5b20cdb91", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-04-19T17:45:07.377862", "expires":
+        "2018-04-19T18:45:07Z", "id": "464a6bdbec0e4391ac15846600049981", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["i9HoslINSou5mnac_Azddw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Ateq1dM0QNSRAn9IAKMLVg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5747,7 +4463,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5762,22 +4478,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04b6534a7cfc4090945fb8e5b20cdb91
+      - 464a6bdbec0e4391ac15846600049981
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d685643-c2d6-4919-9112-df3fddbfef06
+      - req-faf8b5e3-6a37-45ff-9ee0-492db5a20f12
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-9d685643-c2d6-4919-9112-df3fddbfef06
+      - req-faf8b5e3-6a37-45ff-9ee0-492db5a20f12
       Date:
-      - Mon, 09 Apr 2018 16:35:21 GMT
+      - Thu, 19 Apr 2018 17:45:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5798,7 +4514,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:21 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5813,22 +4529,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04b6534a7cfc4090945fb8e5b20cdb91
+      - 464a6bdbec0e4391ac15846600049981
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-77c5569c-00c3-4eea-9d23-2057be9f8a62
+      - req-b6ec365d-e813-4b25-821a-e1bc1863421e
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-77c5569c-00c3-4eea-9d23-2057be9f8a62
+      - req-b6ec365d-e813-4b25-821a-e1bc1863421e
       Date:
-      - Mon, 09 Apr 2018 16:35:22 GMT
+      - Thu, 19 Apr 2018 17:45:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5849,5 +4565,5 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 16:35:22 GMT
+  recorded_at: Thu, 19 Apr 2018 17:45:08 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
When the CloudManager refreshes, it removes from the inventory any Disks that were only added by the CinderManager as part of attaching Volumes to VMs since the CloudManager doesn't find them while collecting inventory. As a result, Volumes will have correct statuses but incorrect numbers of attachments, leading to confusing user experience and various UI actions failing.
This patch causes the CloudManager to be aware of VM volume attachments so that the associations are not broken between Cloud and Cinder refreshes.

This is a solution for https://bugzilla.redhat.com/show_bug.cgi?id=1544344

Depends on https://github.com/ManageIQ/manageiq-providers-openstack/pull/242
