### PR TITLE
Correct network event target associations

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_target_parser.rb
@@ -27,13 +27,13 @@ class ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser
     target_type = if ems_event.event_type.start_with?("floatingip.")
                     :floating_ips
                   elsif ems_event.event_type.start_with?("router.")
-                    :routers
+                    :network_routers
                   elsif ems_event.event_type.start_with?("port.")
-                    :ports
+                    :network_ports
                   elsif ems_event.event_type.start_with?("network.")
-                    :networks
+                    :cloud_networks
                   elsif ems_event.event_type.start_with?("subnet.")
-                    :subnets
+                    :cloud_subnets
                   elsif ems_event.event_type.start_with?("security_group.")
                     :security_groups
                   end

--- a/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
@@ -15,7 +15,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:networks, {:ems_ref => "network_id_test"}]
+            [:cloud_networks, {:ems_ref => "network_id_test"}]
           ]
         )
       )
@@ -28,7 +28,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:subnets, {:ems_ref => "subnet_id_test"}]
+            [:cloud_subnets, {:ems_ref => "subnet_id_test"}]
           ]
         )
       )
@@ -41,7 +41,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:routers, {:ems_ref => "router_id_test"}]
+            [:network_routers, {:ems_ref => "router_id_test"}]
           ]
         )
       )
@@ -54,7 +54,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:ports, {:ems_ref => "port_id_test"}]
+            [:network_ports, {:ems_ref => "port_id_test"}]
           ]
         )
       )


### PR DESCRIPTION
The network event target parser was using the wrong association names for some objects, causing targeted refresh for those objects to be skipped.
https://bugzilla.redhat.com/show_bug.cgi?id=1519460