### PR TITLE
Improve provisioning failure error messages

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::Provision < ::MiqProvisionCloud
+  include ManageIQ::Providers::Openstack::HelperMethods
   include_concern 'Cloning'
   include_concern 'Configuration'
   include_concern 'VolumeAttachment'

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
@@ -19,7 +19,8 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
       status   = instance.state.downcase.to_sym if instance.present?
 
       if status == :error
-        raise MiqException::MiqProvisionError, "An error occurred while provisioning Instance #{instance.name}"
+        error_message = instance.fault["message"]
+        raise MiqException::MiqProvisionError, "An error occurred while provisioning Instance #{instance.name}: #{error_message}"
       end
       return true if status == :active
       return false, status
@@ -79,5 +80,8 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
       instance = openstack.servers.create(clone_options)
       return instance.id
     end
+  rescue => e
+    error_message = parse_error_message_from_fog_response(e)
+    raise MiqException::MiqProvisionError, "An error occurred while provisioning Instance #{clone_options[:name]}: #{error_message}", e.backtrace
   end
 end


### PR DESCRIPTION
Parse messages from fog responses and pull fault messages
from incomplete instances.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549846