### PR TITLE
Default Event payload to empty Hash

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Openstack::CloudManager::EventParser
   def self.event_to_hash(event, ems_id)
     content = message_content(event, ems_id)
     event_type = content["event_type"]
-    payload = content["payload"]
+    payload = content["payload"] || {}
 
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
     _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?

--- a/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Openstack::InfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     content = message_content(event, ems_id)
     event_type = content["event_type"]
-    payload = content["payload"]
+    payload = content["payload"] || {}
 
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
     _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?

--- a/app/models/manageiq/providers/openstack/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_parser.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Openstack::NetworkManager::EventParser
   def self.event_to_hash(event, ems_id)
     content = message_content(event, ems_id)
     event_type = content["event_type"]
-    payload = content["payload"]
+    payload = content["payload"] || {}
 
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
     _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?


### PR DESCRIPTION
Event payload received from OpenStack could have nil content which
resulted in failures in code assigning Event to inventory.

Defaulting empty hash for payload to avoid it.

Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1519887