### PR TITLE
Fixes unfriendly message when adding network for unavailable provider

### DIFF
--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -21,6 +21,8 @@ module ManageIQ::Providers::Openstack::HelperMethods
     end
 
     def parse_error_message_from_neutron_response(exception)
+      return exception.to_s unless exception.respond_to?(:response)
+
       response_body = JSON.parse(exception.response.body)
       if response_body.key?("NeutronError")
         response_body["NeutronError"]["message"]


### PR DESCRIPTION
Create/Update/Delete Cloud Network caused unfriendly message when provider unavailable (fix)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1510769
@miq-bot add_label bug
Cc @Ladas 

## Steps to reproduce:
In **Networks** -> **Networks**:

1. Click **Configure** / **Add a new Cloud Network**
2. Choose Network manager of unavailable provider (_OpenStack / Ovirt only _)
3. Fill required fields and click **Add**

Actual results:
Unfriendly error message. ("undefined method `response' for <...> Did you mean? respond_to?")

Expected results:
Message should be friendly.
