### PR TITLE
Make Gnocchi default granularity configurable in Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -177,6 +177,7 @@
         :ems_metrics_collector_worker_openstack_infra: {}
         :ems_metrics_collector_worker_openstack_network: {}
         :ems_metrics_openstack_default_service: "auto"
+        :ems_metrics_gnocchi_granularity: 300
       :ems_refresh_worker:
         :ems_refresh_worker_openstack: {}
         :ems_refresh_worker_openstack_infra: {}

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
@@ -34,11 +34,12 @@ module OpenstackHandle
       resource_id = options['q'].find { |q| q['field'] == 'resource_id' }['value']
       start = options['q'].find { |q| q['field'] == 'timestamp' && q['op'] == 'gt' }['value']
       stop = options['q'].find { |q| q['field'] == 'timestamp' && q['op'] == 'lt' }['value']
-      granularity = 300 # Gnocchi default minimal granularity
+      granularity = ::Settings.workers.worker_base.queue_worker_base.ems_metrics_collector_worker
+                              .ems_metrics_gnocchi_granularity || 300
       measures = get_resource_metric_measures(resource_id, counter_name, :start => start, :stop => stop, :granularity => granularity).body
       stats = measures.map do |measure|
         {
-          'period_end'   => measure[0], # TODO(maufart): Is count with granularity needed here?
+          'period_end'   => measure[0],
           'duration_end' => measure[0],
           'avg'          => measure[2],
         }


### PR DESCRIPTION
ManageIQ counts with default "minimal" granularity for collecting Metrics via
OpenStack Gnocchi service. This PR makes the default granularity an option in
Settings which allows configure it on customer side.

Adjusting this should resolve Metric NotFound errors caused by not matching
granularity.

Solves https://bugzilla.redhat.com/show_bug.cgi?id=1529449