### PR TITLE
Use the correct id when collecting quotas from Neutron

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
@@ -30,7 +30,7 @@ module OpenstackHandle
     end
 
     def quotas_for_accessible_tenants
-      @os_handle.accessor_for_accessible_tenants(SERVICE_NAME, :quotas_for_current_tenant, 'id', false)
+      @os_handle.accessor_for_accessible_tenants(SERVICE_NAME, :quotas_for_current_tenant, 'tenant_id', false)
     end
   end
 end


### PR DESCRIPTION
Quotas from Neutron don't seem to contain an 'id' field like from Nova, so the current collection fails to gather the networking quotas correctly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1390456