### PR TITLE
Bug 1506987: per_volume_gigabytes_used definition is missing

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
@@ -89,6 +89,12 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota < ::Cloud
                .sum(:size) / 1_073_741_824
   end
 
+  def per_volume_gigabytes_quota_used
+    max_used = CloudVolume.where(:cloud_tenant_id => cloud_tenant_id)
+                          .maximum(:size)
+    max_used.nil? ? 0 : max_used / 1_073_741_824
+  end
+
   def backups_quota_used
     CloudVolumeBackup.joins(:cloud_volume)
                      .where("cloud_volumes.cloud_tenant_id" => cloud_tenant_id).count


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1506987

For cloud resource quota reporting, per_volume_gigabytes_used is
missing, causing -1 to be shown instead of a real value.

The per_volume_gigabytes quota parameter is not a true quota limit,
since it's not an aggregate across volumes but a per-volume limit.
However, since OpenStack defines it as a quota param along with the
aggregate values, MIQ treats it in the same way as the other
parameters.

In this case, we're reporting the size of the largest volume, since
the limit is a per-volume limit rather than an aggregate one.