### PR TITLE
Move CinderManager inventory classes

### DIFF
--- a/app/models/manageiq/providers/openstack/builder.rb
+++ b/app/models/manageiq/providers/openstack/builder.rb
@@ -8,9 +8,9 @@ class ManageIQ::Providers::Openstack::Builder
         inventory(
           ems,
           target,
-          ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager::CinderManager,
-          ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::CinderManager,
-          [ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderManager]
+          ManageIQ::Providers::Openstack::Inventory::Collector::CinderManager,
+          ManageIQ::Providers::Openstack::Inventory::Persister::CinderManager,
+          [ManageIQ::Providers::Openstack::Inventory::Parser::CinderManager]
         )
       when ManageIQ::Providers::Openstack::NetworkManager
         inventory(
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Openstack::Builder
           ManageIQ::Providers::Openstack::Inventory::Persister::TargetCollection,
           [ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager,
            ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager,
-           ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderManager]
+           ManageIQ::Providers::Openstack::Inventory::Parser::CinderManager]
         )
       else
         # Fallback to ems refresh

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManagerRefresh::Inv
 
   require_nested :CloudManager
   require_nested :NetworkManager
+  require_nested :CinderManager
   require_nested :TargetCollection
 
   attr_reader :availability_zones

--- a/app/models/manageiq/providers/openstack/inventory/collector/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cinder_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Collector
+class ManageIQ::Providers::Openstack::Inventory::Collector::CinderManager < ManageIQ::Providers::Openstack::Inventory::Collector
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
 
   def cloud_volumes

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManagerRefresh::Inventory::Parser
   require_nested :CloudManager
   require_nested :NetworkManager
+  require_nested :CinderManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cinder_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Parser
+class ManageIQ::Providers::Openstack::Inventory::Parser::CinderManager < ManageIQ::Providers::Openstack::Inventory::Parser
   def parse
     cloud_volumes
     cloud_volume_snapshots

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :CloudManager
   require_nested :NetworkManager
+  require_nested :CinderManager
   require_nested :TargetCollection
 
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below

--- a/app/models/manageiq/providers/openstack/inventory/persister/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/cinder_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Persister
+class ManageIQ::Providers::Openstack::Inventory::Persister::CinderManager < ManageIQ::Providers::Openstack::Inventory::Persister
   def initialize_inventory_collections
     add_inventory_collections(storage,
                               %i(


### PR DESCRIPTION
Moves the CinderManager inventory classes out from being nested under StorageManager so that `ManagerRefresh::Inventory.persister_class_for` and `ManagerRefresh::Inventory.parser_class_for` can find them.