### PR TITLE
bz1573893: duplicate opts hash before modifying in raw_connect_try_ssl

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -46,8 +46,9 @@ module OpenstackHandle
       end
     end
 
-    def self.raw_connect_try_ssl(username, password, address, port, service = "Compute", opts = nil, api_version = nil,
+    def self.raw_connect_try_ssl(username, password, address, port, service = "Compute", options = nil, api_version = nil,
                                  security_protocol = nil)
+      opts = options.dup
       ssl_options = opts.delete(:ssl_options) || {}
       try_connection(security_protocol, ssl_options) do |scheme, connection_options|
         auth_url = auth_url(address, port, scheme, api_version)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1573893

raw_connect_try_ssl modifies the opts hash (pulling out :ssl_options and then
using it. This means that if raw_connect_try_ssl is called twice with the
same opts hash, the second time fails because of the side effect of the first
call. With this change, the method works on a copy of the hash rather than
the original