### PR TITLE
Combine InfraManager and child manager refresh queues

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
@@ -5,6 +5,27 @@ class ManageIQ::Providers::Openstack::InfraManager::RefreshWorker < ::MiqEmsRefr
     ManageIQ::Providers::Openstack::InfraManager
   end
 
+  # overriding queue_name_for_ems so PerEmsWorkerMixin picks up *all* of the
+  # Openstack-manager types from here.
+  # This way, the refresher for Openstack's InfraManager will refresh *all*
+  # of the Openstack inventory across all managers.
+  class << self
+    def queue_name_for_ems(ems)
+      return ems unless ems.kind_of?(ExtManagementSystem)
+      combined_managers(ems).collect(&:queue_name).sort
+    end
+
+    private
+
+    def combined_managers(ems)
+      [ems].concat(ems.child_managers)
+    end
+  end
+
+  # MiQ complains if this isn't defined
+  def queue_name_for_ems(ems)
+  end
+
   def self.settings_name
     :ems_refresh_worker_openstack_infra
   end

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresh_worker_spec.rb
@@ -1,0 +1,28 @@
+describe ManageIQ::Providers::Openstack::InfraManager::RefreshWorker do
+  context "EMS with children" do
+    let!(:network_manager) { FactoryGirl.create(:ems_network) }
+    let!(:storage_manager) { FactoryGirl.create(:ems_storage) }
+    let(:ems) do
+      FactoryGirl.create(:ems_infra).tap do |ems|
+        network_manager.update_attributes(:parent_ems_id => ems.id)
+        storage_manager.update_attributes(:parent_ems_id => ems.id)
+      end
+    end
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(3)
+      expect(queue_name.sort).to  eq(queue_name)
+    end
+  end
+
+  context "EMS with no children" do
+    let(:ems) { FactoryGirl.create(:ems_infra) }
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(1)
+      expect(queue_name.first).to eq(ems.queue_name)
+    end
+  end
+end


### PR DESCRIPTION
When the CloudManager's refresh queues were consolidated,
the individual NetworkManager refresh worker was removed.
However, the InfraManager's queues were not combined at
the same time, resulting in Infra network refresh events
not being picked up. This commit ensures that the Infra
Manager's refresh worker picks up queued refreshes for
its child managers as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572760