### PR TITLE
Bug 1518304: Don't show events tab for openstack network provider edit

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -47,6 +47,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :cinder_service
   supports :swift_service
   supports :create_host_aggregate
+  supports :configure_events
 
   before_create :ensure_managers,
                 :ensure_cinder_managers,

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -17,6 +17,8 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   include HasManyOrchestrationStackMixin
   include HasNetworkManagerMixin
 
+  supports :configure_events
+
   before_save :ensure_parent_provider
   before_destroy :destroy_parent_provider
   before_create :ensure_managers


### PR DESCRIPTION
Add supports entry for events configuration for both infra and cloud providers.

After https://github.com/ManageIQ/manageiq-ui-classic/pull/3832 this is needed to show the event tab for the cloud and infra provider edit page.