### PR TITLE
Add template decorator

### DIFF
--- a/app/decorators/manageiq/providers/openstack/cloud_manager/template_decorator.rb
+++ b/app/decorators/manageiq/providers/openstack/cloud_manager/template_decorator.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Openstack::CloudManager::TemplateDecorator < MiqTemplateDecorator
+  def provisioning_volume_size_tooltip
+    _("Default value is 1")
+  end
+end


### PR DESCRIPTION
Add a UI decorator for template. Method ```provisioning_volume_size_tooltip ``` returns message that will be displayed in instance provisioning.
