### PR TITLE
Instances workflow: Allow flavors with disk size of 0

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -14,7 +14,8 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
       minimum_memory_required = source.hardware.memory_mb_minimum.to_i * 1.megabyte
     end
     flavors.each_with_object({}) do |flavor, h|
-      next if flavor.root_disk_size < minimum_disk_required
+      # Allow flavors with 0 disk size: The instance will grow disk based upon image build definition
+      next if flavor.root_disk_size.positive? && flavor.root_disk_size < minimum_disk_required
       next if flavor.memory         < minimum_memory_required
       h[flavor.id] = display_name_for_name_description(flavor)
     end


### PR DESCRIPTION
Align with OpenStack behaviour when building a new instance and be able to choose a flavor with disk size of 0. The disk size is then determined by the base image build definition.

https://bugzilla.redhat.com/show_bug.cgi?id=1540588