### PR TITLE
Bump fog-openstack to version 0.1.27

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
   s.add_runtime_dependency "bunny",                "~>2.1.0"
   s.add_runtime_dependency "excon",                "~>0.40"
-  s.add_runtime_dependency "fog-openstack",        "=0.1.25"
+  s.add_runtime_dependency "fog-openstack",        "=0.1.27"
   s.add_runtime_dependency "more_core_extensions", "~>3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -79,7 +79,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:33 GMT
 - request:
     method: get
@@ -114,7 +114,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:33 GMT
 - request:
     method: get
@@ -150,7 +150,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:34 GMT
 - request:
     method: post
@@ -231,7 +231,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:34 GMT
 - request:
     method: get
@@ -267,7 +267,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:34 GMT
 - request:
     method: post
@@ -306,7 +306,7 @@ http_interactions:
         ["qhjmX6BZT-ybtVczWKsDSA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:35 GMT
 - request:
     method: get
@@ -351,7 +351,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:35 GMT
 - request:
     method: post
@@ -432,7 +432,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:35 GMT
 - request:
     method: get
@@ -477,7 +477,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:35 GMT
 - request:
     method: post
@@ -557,7 +557,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: get
@@ -592,7 +592,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: post
@@ -672,7 +672,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: get
@@ -707,7 +707,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: post
@@ -787,7 +787,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: get
@@ -822,7 +822,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:36 GMT
 - request:
     method: get
@@ -869,7 +869,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:37 GMT
 - request:
     method: get
@@ -916,7 +916,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:37 GMT
 - request:
     method: get
@@ -963,7 +963,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:37 GMT
 - request:
     method: get
@@ -1010,7 +1010,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:37 GMT
 - request:
     method: get
@@ -1057,7 +1057,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:38 GMT
 - request:
     method: get
@@ -1104,7 +1104,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:38 GMT
 - request:
     method: get
@@ -1151,7 +1151,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:39 GMT
 - request:
     method: get
@@ -1198,7 +1198,7 @@ http_interactions:
         "2018-06-27T13:12:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:12:33.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:39 GMT
 - request:
     method: get
@@ -1242,7 +1242,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:39 GMT
 - request:
     method: get
@@ -1286,7 +1286,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:39 GMT
 - request:
     method: get
@@ -1331,7 +1331,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:40 GMT
 - request:
     method: get
@@ -1371,7 +1371,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 16384, "OS-FLV-DISABLED:disabled": false, "vcpus":
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:40 GMT
 - request:
     method: get
@@ -1415,7 +1415,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1459,7 +1459,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1504,7 +1504,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1539,7 +1539,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1583,7 +1583,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1627,7 +1627,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:41 GMT
 - request:
     method: get
@@ -1672,7 +1672,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:42 GMT
 - request:
     method: get
@@ -1707,7 +1707,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:42 GMT
 - request:
     method: get
@@ -1751,7 +1751,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:42 GMT
 - request:
     method: get
@@ -1795,7 +1795,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: get
@@ -1840,7 +1840,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: get
@@ -1875,7 +1875,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: get
@@ -1911,7 +1911,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: post
@@ -1992,7 +1992,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: get
@@ -2031,7 +2031,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:43 GMT
 - request:
     method: post
@@ -2111,7 +2111,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:44 GMT
 - request:
     method: get
@@ -2181,7 +2181,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:44 GMT
 - request:
     method: get
@@ -2214,7 +2214,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:44 GMT
 - request:
     method: post
@@ -2294,7 +2294,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:45 GMT
 - request:
     method: get
@@ -2364,7 +2364,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:45 GMT
 - request:
     method: get
@@ -2397,7 +2397,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:45 GMT
 - request:
     method: get
@@ -2467,7 +2467,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:46 GMT
 - request:
     method: get
@@ -2500,7 +2500,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:46 GMT
 - request:
     method: post
@@ -2580,7 +2580,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:46 GMT
 - request:
     method: get
@@ -2650,7 +2650,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:46 GMT
 - request:
     method: get
@@ -2683,7 +2683,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:46 GMT
 - request:
     method: get
@@ -2723,7 +2723,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2763,7 +2763,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2803,7 +2803,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2843,7 +2843,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2883,7 +2883,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2923,7 +2923,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -2963,7 +2963,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -3003,7 +3003,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: post
@@ -3084,7 +3084,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: post
@@ -3164,7 +3164,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:47 GMT
 - request:
     method: get
@@ -3226,7 +3226,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:48 GMT
 - request:
     method: get
@@ -3259,7 +3259,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:48 GMT
 - request:
     method: post
@@ -3339,7 +3339,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:48 GMT
 - request:
     method: get
@@ -3372,7 +3372,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:48 GMT
 - request:
     method: get
@@ -3405,7 +3405,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:49 GMT
 - request:
     method: post
@@ -3485,7 +3485,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:49 GMT
 - request:
     method: get
@@ -3518,7 +3518,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:49 GMT
 - request:
     method: get
@@ -3573,7 +3573,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:50 GMT
 - request:
     method: get
@@ -3628,7 +3628,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:51 GMT
 - request:
     method: get
@@ -3683,7 +3683,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:51 GMT
 - request:
     method: get
@@ -3767,7 +3767,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:51 GMT
 - request:
     method: get
@@ -3807,7 +3807,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:52 GMT
 - request:
     method: get
@@ -3883,7 +3883,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:52 GMT
 - request:
     method: get
@@ -3959,7 +3959,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:53 GMT
 - request:
     method: get
@@ -4037,7 +4037,7 @@ http_interactions:
         {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:53 GMT
 - request:
     method: get
@@ -4109,7 +4109,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:54 GMT
 - request:
     method: get
@@ -4162,7 +4162,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:54 GMT
 - request:
     method: get
@@ -4197,7 +4197,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4232,7 +4232,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4267,7 +4267,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4351,7 +4351,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4391,7 +4391,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4475,7 +4475,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4515,7 +4515,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:55 GMT
 - request:
     method: get
@@ -4554,7 +4554,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "69f8f7205ade4aa59084c32c83e60b5a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:56 GMT
 - request:
     method: get
@@ -4593,7 +4593,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "b458a5c25c3749758f4c0661940b3ba8", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:56 GMT
 - request:
     method: get
@@ -4632,7 +4632,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:56 GMT
 - request:
     method: get
@@ -4671,7 +4671,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e8f744b1fc6a487681d35fb275252608", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:56 GMT
 - request:
     method: post
@@ -4751,7 +4751,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:56 GMT
 - request:
     method: get
@@ -4791,7 +4791,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:57 GMT
 - request:
     method: post
@@ -4871,7 +4871,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:57 GMT
 - request:
     method: get
@@ -4911,7 +4911,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:57 GMT
 - request:
     method: get
@@ -4951,7 +4951,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:59 GMT
 - request:
     method: post
@@ -5031,7 +5031,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:59 GMT
 - request:
     method: get
@@ -5071,7 +5071,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:59 GMT
 - request:
     method: post
@@ -5152,7 +5152,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:59 GMT
 - request:
     method: get
@@ -5184,7 +5184,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:12:59 GMT
 - request:
     method: post
@@ -5264,7 +5264,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:00 GMT
 - request:
     method: get
@@ -5299,7 +5299,7 @@ http_interactions:
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:00 GMT
 - request:
     method: post
@@ -5379,7 +5379,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:00 GMT
 - request:
     method: get
@@ -5414,7 +5414,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:00 GMT
 - request:
     method: get
@@ -5449,7 +5449,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:01 GMT
 - request:
     method: post
@@ -5529,7 +5529,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:01 GMT
 - request:
     method: get
@@ -5564,7 +5564,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:01 GMT
 - request:
     method: get
@@ -5617,7 +5617,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:01 GMT
 - request:
     method: get
@@ -5670,7 +5670,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:02 GMT
 - request:
     method: get
@@ -5723,7 +5723,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:02 GMT
 - request:
     method: get
@@ -5776,7 +5776,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:02 GMT
 - request:
     method: get
@@ -5829,11 +5829,11 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:02 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -5865,7 +5865,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:02 GMT
 - request:
     method: get
@@ -5918,11 +5918,11 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:03 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -5954,7 +5954,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:03 GMT
 - request:
     method: get
@@ -6007,7 +6007,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:03 GMT
 - request:
     method: get
@@ -6060,7 +6060,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:03 GMT
 - request:
     method: get
@@ -6113,7 +6113,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:04 GMT
 - request:
     method: post
@@ -6194,7 +6194,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:04 GMT
 - request:
     method: post
@@ -6275,7 +6275,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:04 GMT
 - request:
     method: post
@@ -6356,7 +6356,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:04 GMT
 - request:
     method: post
@@ -6437,7 +6437,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6472,7 +6472,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6535,7 +6535,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6582,7 +6582,7 @@ http_interactions:
         "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6617,7 +6617,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6652,7 +6652,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:05 GMT
 - request:
     method: get
@@ -6687,7 +6687,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6732,7 +6732,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6777,7 +6777,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6812,7 +6812,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6847,7 +6847,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6882,7 +6882,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:06 GMT
 - request:
     method: get
@@ -6917,7 +6917,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:07 GMT
 - request:
     method: get
@@ -6952,7 +6952,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:07 GMT
 - request:
     method: get
@@ -6987,7 +6987,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:07 GMT
 - request:
     method: get
@@ -7050,7 +7050,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:07 GMT
 - request:
     method: get
@@ -7121,7 +7121,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:07 GMT
 - request:
     method: get
@@ -7185,7 +7185,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:08 GMT
 - request:
     method: get
@@ -7220,7 +7220,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:08 GMT
 - request:
     method: get
@@ -7255,7 +7255,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:08 GMT
 - request:
     method: get
@@ -7290,7 +7290,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:08 GMT
 - request:
     method: get
@@ -7325,7 +7325,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:09 GMT
 - request:
     method: post
@@ -7406,7 +7406,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:10 GMT
 - request:
     method: post
@@ -7487,7 +7487,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:10 GMT
 - request:
     method: get
@@ -7585,7 +7585,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:10 GMT
 - request:
     method: post
@@ -7666,7 +7666,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: post
@@ -7705,7 +7705,7 @@ http_interactions:
         ["xxLWJJsjT-O7-Z9r67HuuQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: get
@@ -7750,7 +7750,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: post
@@ -7831,7 +7831,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: get
@@ -7876,7 +7876,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: post
@@ -7956,7 +7956,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:11 GMT
 - request:
     method: post
@@ -8036,7 +8036,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:12 GMT
 - request:
     method: post
@@ -8116,7 +8116,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:12 GMT
 - request:
     method: post
@@ -8196,7 +8196,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:12 GMT
 - request:
     method: get
@@ -8258,7 +8258,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:12 GMT
 - request:
     method: get
@@ -8291,7 +8291,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:12 GMT
 - request:
     method: post
@@ -8371,7 +8371,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:14 GMT
 - request:
     method: get
@@ -8404,7 +8404,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:14 GMT
 - request:
     method: get
@@ -8437,7 +8437,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:14 GMT
 - request:
     method: post
@@ -8517,7 +8517,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:14 GMT
 - request:
     method: get
@@ -8550,7 +8550,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:15 GMT
 - request:
     method: get
@@ -8605,7 +8605,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:15 GMT
 - request:
     method: get
@@ -8660,7 +8660,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:16 GMT
 - request:
     method: get
@@ -8715,7 +8715,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:16 GMT
 - request:
     method: get
@@ -8755,7 +8755,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:16 GMT
 - request:
     method: get
@@ -8795,7 +8795,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:17 GMT
 - request:
     method: get
@@ -8835,7 +8835,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:17 GMT
 - request:
     method: post
@@ -8915,7 +8915,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:17 GMT
 - request:
     method: get
@@ -9047,7 +9047,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:17 GMT
 - request:
     method: get
@@ -9179,7 +9179,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:17 GMT
 - request:
     method: get
@@ -9311,7 +9311,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:18 GMT
 - request:
     method: get
@@ -9443,7 +9443,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:18 GMT
 - request:
     method: post
@@ -9523,7 +9523,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:18 GMT
 - request:
     method: get
@@ -9655,7 +9655,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:18 GMT
 - request:
     method: get
@@ -9787,7 +9787,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:19 GMT
 - request:
     method: get
@@ -9919,7 +9919,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:19 GMT
 - request:
     method: get
@@ -10051,7 +10051,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:19 GMT
 - request:
     method: get
@@ -10183,7 +10183,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:19 GMT
 - request:
     method: get
@@ -10315,7 +10315,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:19 GMT
 - request:
     method: get
@@ -10447,7 +10447,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:20 GMT
 - request:
     method: post
@@ -10527,7 +10527,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:20 GMT
 - request:
     method: get
@@ -10659,7 +10659,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:20 GMT
 - request:
     method: get
@@ -10791,7 +10791,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -10923,7 +10923,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11055,7 +11055,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11125,7 +11125,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11195,7 +11195,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11265,7 +11265,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11335,7 +11335,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11405,7 +11405,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11475,7 +11475,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:21 GMT
 - request:
     method: get
@@ -11545,7 +11545,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -11615,7 +11615,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -12046,7 +12046,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -12477,7 +12477,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -12908,7 +12908,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -13339,7 +13339,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:22 GMT
 - request:
     method: get
@@ -13770,7 +13770,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:23 GMT
 - request:
     method: get
@@ -14201,7 +14201,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:23 GMT
 - request:
     method: get
@@ -14632,7 +14632,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:23 GMT
 - request:
     method: get
@@ -15063,7 +15063,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:23 GMT
 - request:
     method: get
@@ -15123,7 +15123,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:23 GMT
 - request:
     method: get
@@ -15183,7 +15183,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15243,7 +15243,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15303,7 +15303,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15363,7 +15363,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15423,7 +15423,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15483,7 +15483,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:24 GMT
 - request:
     method: get
@@ -15543,7 +15543,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -15613,7 +15613,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -15684,7 +15684,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -15747,7 +15747,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -15862,7 +15862,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -15932,7 +15932,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -16003,7 +16003,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -16066,7 +16066,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:25 GMT
 - request:
     method: get
@@ -16181,7 +16181,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16251,7 +16251,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16322,7 +16322,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16385,7 +16385,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16500,7 +16500,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16570,7 +16570,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16641,7 +16641,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:26 GMT
 - request:
     method: get
@@ -16704,7 +16704,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:28 GMT
 - request:
     method: get
@@ -16819,7 +16819,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:28 GMT
 - request:
     method: post
@@ -16900,7 +16900,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:28 GMT
 - request:
     method: post
@@ -16981,7 +16981,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: post
@@ -17020,7 +17020,7 @@ http_interactions:
         ["vMT_PLZ5TB-i0NU9d0C5yw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: get
@@ -17065,7 +17065,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: post
@@ -17146,7 +17146,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: get
@@ -17191,7 +17191,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: post
@@ -17271,7 +17271,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:29 GMT
 - request:
     method: post
@@ -17351,7 +17351,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:30 GMT
 - request:
     method: post
@@ -17431,7 +17431,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:30 GMT
 - request:
     method: post
@@ -17511,7 +17511,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:30 GMT
 - request:
     method: get
@@ -17574,7 +17574,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:31 GMT
 - request:
     method: get
@@ -17645,7 +17645,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:31 GMT
 - request:
     method: get
@@ -17709,7 +17709,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:31 GMT
 - request:
     method: get
@@ -17744,7 +17744,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:31 GMT
 - request:
     method: post
@@ -17824,7 +17824,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:31 GMT
 - request:
     method: get
@@ -17859,7 +17859,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:32 GMT
 - request:
     method: get
@@ -17894,7 +17894,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:32 GMT
 - request:
     method: post
@@ -17974,7 +17974,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:32 GMT
 - request:
     method: get
@@ -18009,7 +18009,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:32 GMT
 - request:
     method: get
@@ -18054,7 +18054,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:33 GMT
 - request:
     method: get
@@ -18099,7 +18099,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:33 GMT
 - request:
     method: get
@@ -18134,7 +18134,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:33 GMT
 - request:
     method: get
@@ -18169,7 +18169,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:33 GMT
 - request:
     method: get
@@ -18204,7 +18204,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18239,7 +18239,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18274,7 +18274,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18309,7 +18309,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18344,7 +18344,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18379,7 +18379,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18414,7 +18414,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18449,7 +18449,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18484,7 +18484,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18519,7 +18519,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18554,7 +18554,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: get
@@ -18589,7 +18589,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:34 GMT
 - request:
     method: post
@@ -18670,7 +18670,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:35 GMT
 - request:
     method: post
@@ -18751,7 +18751,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:35 GMT
 - request:
     method: post
@@ -18790,7 +18790,7 @@ http_interactions:
         ["CXv_fDOHSlujIpYvqW73BQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:35 GMT
 - request:
     method: get
@@ -18835,7 +18835,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:35 GMT
 - request:
     method: post
@@ -18916,7 +18916,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:36 GMT
 - request:
     method: get
@@ -18961,7 +18961,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:36 GMT
 - request:
     method: post
@@ -19041,7 +19041,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:36 GMT
 - request:
     method: post
@@ -19121,7 +19121,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:36 GMT
 - request:
     method: post
@@ -19201,7 +19201,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:37 GMT
 - request:
     method: post
@@ -19281,7 +19281,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:37 GMT
 - request:
     method: get
@@ -19333,7 +19333,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:37 GMT
 - request:
     method: get
@@ -19384,7 +19384,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:37 GMT
 - request:
     method: post
@@ -19464,7 +19464,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:38 GMT
 - request:
     method: get
@@ -19507,7 +19507,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:38 GMT
 - request:
     method: get
@@ -19550,7 +19550,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 - request:
     method: post
@@ -19630,7 +19630,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 - request:
     method: get
@@ -19673,7 +19673,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 - request:
     method: get
@@ -19721,7 +19721,7 @@ http_interactions:
         "bytes": 11, "name": "file_2", "content_type": "application/octet-stream"},
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 - request:
     method: get
@@ -19764,7 +19764,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 - request:
     method: get
@@ -19807,6 +19807,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -79,7 +79,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:50 GMT
 - request:
     method: get
@@ -114,7 +114,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:50 GMT
 - request:
     method: get
@@ -150,7 +150,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:50 GMT
 - request:
     method: post
@@ -231,7 +231,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:50 GMT
 - request:
     method: get
@@ -267,7 +267,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -314,7 +314,7 @@ http_interactions:
         "2018-06-27T13:13:43.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:13:43.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -361,7 +361,7 @@ http_interactions:
         "2018-06-27T13:13:43.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:13:43.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -405,7 +405,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -449,7 +449,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -494,7 +494,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: get
@@ -534,7 +534,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 16384, "OS-FLV-DISABLED:disabled": false, "vcpus":
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:51 GMT
 - request:
     method: post
@@ -615,7 +615,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:52 GMT
 - request:
     method: get
@@ -660,7 +660,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:52 GMT
 - request:
     method: get
@@ -696,7 +696,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:52 GMT
 - request:
     method: post
@@ -777,7 +777,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:52 GMT
 - request:
     method: get
@@ -816,7 +816,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:52 GMT
 - request:
     method: get
@@ -849,7 +849,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:53 GMT
 - request:
     method: get
@@ -919,7 +919,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:53 GMT
 - request:
     method: get
@@ -959,7 +959,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:54 GMT
 - request:
     method: get
@@ -999,7 +999,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:54 GMT
 - request:
     method: post
@@ -1080,7 +1080,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:54 GMT
 - request:
     method: post
@@ -1119,7 +1119,7 @@ http_interactions:
         ["J9ik2mWvQ2eXTikaWZa1KA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:54 GMT
 - request:
     method: get
@@ -1164,7 +1164,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: post
@@ -1245,7 +1245,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: get
@@ -1290,7 +1290,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: post
@@ -1370,7 +1370,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: get
@@ -1405,7 +1405,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: post
@@ -1485,7 +1485,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: get
@@ -1520,7 +1520,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:55 GMT
 - request:
     method: post
@@ -1600,7 +1600,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:56 GMT
 - request:
     method: get
@@ -1635,7 +1635,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:56 GMT
 - request:
     method: post
@@ -1715,7 +1715,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:57 GMT
 - request:
     method: get
@@ -1777,7 +1777,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:57 GMT
 - request:
     method: get
@@ -1810,7 +1810,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:57 GMT
 - request:
     method: post
@@ -1890,7 +1890,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:57 GMT
 - request:
     method: get
@@ -1923,7 +1923,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:58 GMT
 - request:
     method: get
@@ -1956,7 +1956,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:58 GMT
 - request:
     method: post
@@ -2036,7 +2036,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:58 GMT
 - request:
     method: get
@@ -2069,7 +2069,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:58 GMT
 - request:
     method: get
@@ -2124,7 +2124,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:13:59 GMT
 - request:
     method: get
@@ -2179,7 +2179,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:00 GMT
 - request:
     method: get
@@ -2234,7 +2234,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:00 GMT
 - request:
     method: get
@@ -2318,7 +2318,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:00 GMT
 - request:
     method: get
@@ -2358,7 +2358,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:03 GMT
 - request:
     method: get
@@ -2434,7 +2434,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:04 GMT
 - request:
     method: get
@@ -2510,7 +2510,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:04 GMT
 - request:
     method: get
@@ -2588,7 +2588,7 @@ http_interactions:
         {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:05 GMT
 - request:
     method: get
@@ -2660,7 +2660,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:05 GMT
 - request:
     method: get
@@ -2713,7 +2713,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:06 GMT
 - request:
     method: get
@@ -2797,7 +2797,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:06 GMT
 - request:
     method: get
@@ -2837,7 +2837,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:06 GMT
 - request:
     method: get
@@ -2921,7 +2921,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:07 GMT
 - request:
     method: get
@@ -2961,7 +2961,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:07 GMT
 - request:
     method: get
@@ -3000,7 +3000,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "69f8f7205ade4aa59084c32c83e60b5a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:07 GMT
 - request:
     method: get
@@ -3039,7 +3039,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "b458a5c25c3749758f4c0661940b3ba8", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:08 GMT
 - request:
     method: get
@@ -3078,7 +3078,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:08 GMT
 - request:
     method: get
@@ -3117,7 +3117,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e8f744b1fc6a487681d35fb275252608", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:08 GMT
 - request:
     method: post
@@ -3197,7 +3197,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:09 GMT
 - request:
     method: get
@@ -3237,7 +3237,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:09 GMT
 - request:
     method: post
@@ -3317,7 +3317,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:09 GMT
 - request:
     method: get
@@ -3357,7 +3357,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:10 GMT
 - request:
     method: get
@@ -3397,7 +3397,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:10 GMT
 - request:
     method: post
@@ -3477,7 +3477,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:10 GMT
 - request:
     method: get
@@ -3517,7 +3517,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:11 GMT
 - request:
     method: post
@@ -3598,7 +3598,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:11 GMT
 - request:
     method: get
@@ -3630,7 +3630,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:11 GMT
 - request:
     method: post
@@ -3710,7 +3710,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:11 GMT
 - request:
     method: get
@@ -3745,7 +3745,7 @@ http_interactions:
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:12 GMT
 - request:
     method: post
@@ -3825,7 +3825,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:12 GMT
 - request:
     method: get
@@ -3860,7 +3860,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:12 GMT
 - request:
     method: get
@@ -3895,7 +3895,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: post
@@ -3975,7 +3975,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: get
@@ -4010,7 +4010,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: get
@@ -4045,7 +4045,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: get
@@ -4080,7 +4080,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: get
@@ -4115,7 +4115,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:13 GMT
 - request:
     method: get
@@ -4150,7 +4150,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:14 GMT
 - request:
     method: get
@@ -4185,11 +4185,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:14 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -4221,7 +4221,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:14 GMT
 - request:
     method: get
@@ -4256,11 +4256,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:14 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -4292,7 +4292,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:14 GMT
 - request:
     method: get
@@ -4327,7 +4327,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:15 GMT
 - request:
     method: get
@@ -4362,7 +4362,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:15 GMT
 - request:
     method: get
@@ -4397,7 +4397,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:15 GMT
 - request:
     method: post
@@ -4478,7 +4478,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:16 GMT
 - request:
     method: post
@@ -4559,7 +4559,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:16 GMT
 - request:
     method: post
@@ -4640,7 +4640,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:16 GMT
 - request:
     method: post
@@ -4721,7 +4721,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:16 GMT
 - request:
     method: get
@@ -4756,7 +4756,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -4819,7 +4819,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -4866,7 +4866,7 @@ http_interactions:
         "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -4911,7 +4911,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -4956,7 +4956,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -4991,7 +4991,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:17 GMT
 - request:
     method: get
@@ -5026,7 +5026,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5061,7 +5061,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5096,7 +5096,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5131,7 +5131,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5166,7 +5166,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5229,7 +5229,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5300,7 +5300,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:18 GMT
 - request:
     method: get
@@ -5364,7 +5364,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:19 GMT
 - request:
     method: get
@@ -5399,7 +5399,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:19 GMT
 - request:
     method: post
@@ -5480,7 +5480,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:20 GMT
 - request:
     method: post
@@ -5561,7 +5561,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:20 GMT
 - request:
     method: get
@@ -5659,7 +5659,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:21 GMT
 - request:
     method: post
@@ -5740,7 +5740,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:21 GMT
 - request:
     method: post
@@ -5779,7 +5779,7 @@ http_interactions:
         ["9S9EpU9YS3OqqLRPqmhZog"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:21 GMT
 - request:
     method: get
@@ -5824,7 +5824,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:21 GMT
 - request:
     method: post
@@ -5905,7 +5905,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:21 GMT
 - request:
     method: get
@@ -5950,7 +5950,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:22 GMT
 - request:
     method: post
@@ -6030,7 +6030,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:22 GMT
 - request:
     method: post
@@ -6110,7 +6110,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:22 GMT
 - request:
     method: post
@@ -6190,7 +6190,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:23 GMT
 - request:
     method: post
@@ -6270,7 +6270,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:23 GMT
 - request:
     method: get
@@ -6332,7 +6332,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:24 GMT
 - request:
     method: get
@@ -6365,7 +6365,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:24 GMT
 - request:
     method: post
@@ -6445,7 +6445,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:24 GMT
 - request:
     method: get
@@ -6478,7 +6478,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:24 GMT
 - request:
     method: get
@@ -6511,7 +6511,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:24 GMT
 - request:
     method: post
@@ -6591,7 +6591,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:25 GMT
 - request:
     method: get
@@ -6624,7 +6624,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:25 GMT
 - request:
     method: get
@@ -6679,7 +6679,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:25 GMT
 - request:
     method: get
@@ -6734,7 +6734,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:26 GMT
 - request:
     method: get
@@ -6789,7 +6789,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:26 GMT
 - request:
     method: get
@@ -6829,7 +6829,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:27 GMT
 - request:
     method: get
@@ -6869,7 +6869,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:27 GMT
 - request:
     method: get
@@ -6909,7 +6909,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:27 GMT
 - request:
     method: get
@@ -7041,7 +7041,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:27 GMT
 - request:
     method: get
@@ -7173,7 +7173,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -7243,7 +7243,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -7313,7 +7313,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -7744,7 +7744,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -8175,7 +8175,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -8235,7 +8235,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -8295,7 +8295,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:28 GMT
 - request:
     method: get
@@ -8365,7 +8365,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:29 GMT
 - request:
     method: get
@@ -8436,7 +8436,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:29 GMT
 - request:
     method: get
@@ -8499,7 +8499,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:29 GMT
 - request:
     method: get
@@ -8614,7 +8614,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:29 GMT
 - request:
     method: post
@@ -8695,7 +8695,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: post
@@ -8776,7 +8776,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: post
@@ -8815,7 +8815,7 @@ http_interactions:
         ["vntwaJ_iRUi5SjaciTv5KQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: get
@@ -8860,7 +8860,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: post
@@ -8941,7 +8941,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: get
@@ -8986,7 +8986,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:30 GMT
 - request:
     method: post
@@ -9066,7 +9066,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:31 GMT
 - request:
     method: post
@@ -9146,7 +9146,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:31 GMT
 - request:
     method: post
@@ -9226,7 +9226,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:31 GMT
 - request:
     method: post
@@ -9306,7 +9306,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:31 GMT
 - request:
     method: get
@@ -9369,7 +9369,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:32 GMT
 - request:
     method: get
@@ -9440,7 +9440,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:32 GMT
 - request:
     method: get
@@ -9504,7 +9504,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:33 GMT
 - request:
     method: get
@@ -9539,7 +9539,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:33 GMT
 - request:
     method: post
@@ -9619,7 +9619,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:33 GMT
 - request:
     method: get
@@ -9654,7 +9654,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:33 GMT
 - request:
     method: get
@@ -9689,7 +9689,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:33 GMT
 - request:
     method: post
@@ -9769,7 +9769,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:34 GMT
 - request:
     method: get
@@ -9804,7 +9804,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:34 GMT
 - request:
     method: get
@@ -9849,7 +9849,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:34 GMT
 - request:
     method: get
@@ -9894,7 +9894,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:34 GMT
 - request:
     method: get
@@ -9929,7 +9929,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:34 GMT
 - request:
     method: get
@@ -9964,7 +9964,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:35 GMT
 - request:
     method: get
@@ -9999,7 +9999,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:35 GMT
 - request:
     method: get
@@ -10034,7 +10034,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:35 GMT
 - request:
     method: get
@@ -10069,7 +10069,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:35 GMT
 - request:
     method: get
@@ -10104,7 +10104,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:35 GMT
 - request:
     method: get
@@ -10139,7 +10139,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10174,7 +10174,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10209,7 +10209,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10244,7 +10244,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10279,7 +10279,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10314,7 +10314,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10349,7 +10349,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: get
@@ -10384,7 +10384,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:36 GMT
 - request:
     method: post
@@ -10465,7 +10465,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: post
@@ -10546,7 +10546,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: post
@@ -10585,7 +10585,7 @@ http_interactions:
         ["4yvFwsM7S7yHZ_zWdYxkng"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: get
@@ -10630,7 +10630,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: post
@@ -10711,7 +10711,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: get
@@ -10756,7 +10756,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:37 GMT
 - request:
     method: post
@@ -10836,7 +10836,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:38 GMT
 - request:
     method: post
@@ -10916,7 +10916,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:38 GMT
 - request:
     method: post
@@ -10996,7 +10996,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:38 GMT
 - request:
     method: post
@@ -11076,7 +11076,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: get
@@ -11128,7 +11128,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: get
@@ -11179,7 +11179,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: post
@@ -11259,7 +11259,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: get
@@ -11302,7 +11302,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: get
@@ -11345,7 +11345,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:39 GMT
 - request:
     method: post
@@ -11425,7 +11425,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:40 GMT
 - request:
     method: get
@@ -11468,7 +11468,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:40 GMT
 - request:
     method: get
@@ -11516,7 +11516,7 @@ http_interactions:
         "bytes": 11, "name": "file_2", "content_type": "application/octet-stream"},
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:40 GMT
 - request:
     method: get
@@ -11559,7 +11559,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:40 GMT
 - request:
     method: get
@@ -11602,6 +11602,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -118,7 +118,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1rp60f_JSyWnSsAHYNYLVw"],
         "issued_at": "2018-06-27T13:05:11.819715Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:11 GMT
 - request:
     method: get
@@ -153,7 +153,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:11 GMT
 - request:
     method: get
@@ -189,7 +189,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:12 GMT
 - request:
     method: post
@@ -309,7 +309,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["l0wnhmqDR2q2vLftPIzR9g"],
         "issued_at": "2018-06-27T13:05:13.277677Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:13 GMT
 - request:
     method: get
@@ -345,7 +345,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:14 GMT
 - request:
     method: post
@@ -385,7 +385,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FDTLQdXiTGO8ACoQGw5BKA"],
         "issued_at": "2018-06-27T13:05:14.396653Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:14 GMT
 - request:
     method: get
@@ -446,7 +446,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:14 GMT
 - request:
     method: post
@@ -566,7 +566,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XqMWbe0qSyqkaIiS_CrQeQ",
         "FDTLQdXiTGO8ACoQGw5BKA"], "issued_at": "2018-06-27T13:05:14.882560Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:14 GMT
 - request:
     method: get
@@ -627,7 +627,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:15 GMT
 - request:
     method: post
@@ -747,7 +747,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RI57LWWtTSi22ujhxu422A"],
         "issued_at": "2018-06-27T13:05:15.924018Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:17 GMT
 - request:
     method: get
@@ -782,7 +782,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:17 GMT
 - request:
     method: post
@@ -902,7 +902,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pqf7jMYCTZqVW02ewONOzw"],
         "issued_at": "2018-06-27T13:05:18.179604Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:18 GMT
 - request:
     method: get
@@ -937,7 +937,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:18 GMT
 - request:
     method: post
@@ -1057,7 +1057,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vkOldDT1Rcyq853paNp-lA"],
         "issued_at": "2018-06-27T13:05:18.627212Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:18 GMT
 - request:
     method: get
@@ -1092,7 +1092,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:18 GMT
 - request:
     method: post
@@ -1212,7 +1212,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fQUWpAT2RcihCZSctkJw0g"],
         "issued_at": "2018-06-27T13:05:19.002565Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:19 GMT
 - request:
     method: get
@@ -1247,7 +1247,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:19 GMT
 - request:
     method: post
@@ -1367,7 +1367,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7IUVQY9GRKiH8hoUJpycZQ"],
         "issued_at": "2018-06-27T13:05:19.388299Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:20 GMT
 - request:
     method: get
@@ -1402,7 +1402,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:20 GMT
 - request:
     method: post
@@ -1522,7 +1522,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4YBxqhcGTLaxEBZi8XXybA"],
         "issued_at": "2018-06-27T13:05:20.808055Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:24 GMT
 - request:
     method: get
@@ -1557,7 +1557,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:24 GMT
 - request:
     method: get
@@ -1604,7 +1604,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:24 GMT
 - request:
     method: get
@@ -1651,7 +1651,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:24 GMT
 - request:
     method: get
@@ -1698,7 +1698,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:25 GMT
 - request:
     method: get
@@ -1745,7 +1745,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:25 GMT
 - request:
     method: get
@@ -1792,7 +1792,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:25 GMT
 - request:
     method: get
@@ -1839,7 +1839,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:25 GMT
 - request:
     method: get
@@ -1886,7 +1886,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:25 GMT
 - request:
     method: get
@@ -1933,7 +1933,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:26 GMT
 - request:
     method: get
@@ -1980,7 +1980,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:26 GMT
 - request:
     method: get
@@ -2027,7 +2027,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:26 GMT
 - request:
     method: get
@@ -2074,7 +2074,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:26 GMT
 - request:
     method: get
@@ -2121,7 +2121,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:26 GMT
 - request:
     method: get
@@ -2168,7 +2168,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2215,7 +2215,7 @@ http_interactions:
         "2018-06-27T13:05:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:05:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2259,7 +2259,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2303,7 +2303,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2348,7 +2348,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2383,7 +2383,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:27 GMT
 - request:
     method: get
@@ -2427,7 +2427,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2471,7 +2471,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2516,7 +2516,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2551,7 +2551,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2595,7 +2595,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2639,7 +2639,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:28 GMT
 - request:
     method: get
@@ -2684,7 +2684,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2724,7 +2724,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 16384, "OS-FLV-DISABLED:disabled": false, "vcpus":
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2768,7 +2768,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2812,7 +2812,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2857,7 +2857,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2892,7 +2892,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:29 GMT
 - request:
     method: get
@@ -2936,7 +2936,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -2980,7 +2980,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -3025,7 +3025,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -3060,7 +3060,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -3104,7 +3104,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -3148,7 +3148,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:30 GMT
 - request:
     method: get
@@ -3193,7 +3193,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3228,7 +3228,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3272,7 +3272,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3316,7 +3316,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3361,7 +3361,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3396,7 +3396,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:31 GMT
 - request:
     method: get
@@ -3432,7 +3432,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:32 GMT
 - request:
     method: post
@@ -3552,7 +3552,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7TbAsaF0SzyY0bXspWj4cA"],
         "issued_at": "2018-06-27T13:05:32.447205Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:33 GMT
 - request:
     method: get
@@ -3591,7 +3591,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.206:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:33 GMT
 - request:
     method: post
@@ -3711,7 +3711,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rNPWSoAkQAGhdQiPadrQyw"],
         "issued_at": "2018-06-27T13:05:34.209384Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:34 GMT
 - request:
     method: get
@@ -3781,7 +3781,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:34 GMT
 - request:
     method: get
@@ -3814,7 +3814,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:34 GMT
 - request:
     method: post
@@ -3934,7 +3934,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["prTGpXEiRuiXMHqj2Z3_Kw"],
         "issued_at": "2018-06-27T13:05:35.169775Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:35 GMT
 - request:
     method: get
@@ -4004,7 +4004,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:35 GMT
 - request:
     method: get
@@ -4037,7 +4037,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:35 GMT
 - request:
     method: post
@@ -4157,7 +4157,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PedZ-KkSR_i7fockUvyUOg"],
         "issued_at": "2018-06-27T13:05:35.981963Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:36 GMT
 - request:
     method: get
@@ -4227,7 +4227,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:36 GMT
 - request:
     method: get
@@ -4260,7 +4260,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:36 GMT
 - request:
     method: post
@@ -4380,7 +4380,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["csNGt6VjSTquFGcGH5zfAA"],
         "issued_at": "2018-06-27T13:05:37.128349Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:37 GMT
 - request:
     method: get
@@ -4450,7 +4450,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:37 GMT
 - request:
     method: get
@@ -4483,7 +4483,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:37 GMT
 - request:
     method: get
@@ -4553,7 +4553,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:37 GMT
 - request:
     method: get
@@ -4586,7 +4586,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:38 GMT
 - request:
     method: post
@@ -4706,7 +4706,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["l-Dxglh4TH6pSXwHXV4H3Q"],
         "issued_at": "2018-06-27T13:05:38.601519Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:41 GMT
 - request:
     method: get
@@ -4776,7 +4776,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:41 GMT
 - request:
     method: get
@@ -4809,7 +4809,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:42 GMT
 - request:
     method: post
@@ -4929,7 +4929,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AbhFnqdlRZ-MobuMy8rc6w"],
         "issued_at": "2018-06-27T13:05:42.468518Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:42 GMT
 - request:
     method: get
@@ -4999,7 +4999,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:42 GMT
 - request:
     method: get
@@ -5032,7 +5032,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:42 GMT
 - request:
     method: get
@@ -5072,7 +5072,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5112,7 +5112,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5152,7 +5152,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5192,7 +5192,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5232,7 +5232,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5272,7 +5272,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5312,7 +5312,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5352,7 +5352,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5392,7 +5392,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5432,7 +5432,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:43 GMT
 - request:
     method: get
@@ -5472,7 +5472,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:44 GMT
 - request:
     method: get
@@ -5512,7 +5512,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:44 GMT
 - request:
     method: get
@@ -5552,7 +5552,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:44 GMT
 - request:
     method: get
@@ -5592,7 +5592,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:44 GMT
 - request:
     method: post
@@ -5712,7 +5712,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["arEA_HOZRAKbfI94BDH6Xw"],
         "issued_at": "2018-06-27T13:05:45.093171Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:45 GMT
 - request:
     method: post
@@ -5832,7 +5832,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U-09YR7SROqdtqq_13gWFA"],
         "issued_at": "2018-06-27T13:05:46.064023Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:46 GMT
 - request:
     method: get
@@ -5865,7 +5865,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:46 GMT
 - request:
     method: post
@@ -5985,7 +5985,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cTb1vJ0JRW6VfmA-hRfRDQ"],
         "issued_at": "2018-06-27T13:05:47.344877Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:47 GMT
 - request:
     method: get
@@ -6018,7 +6018,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:47 GMT
 - request:
     method: post
@@ -6138,7 +6138,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZfYSFiKzTOmbrRwkM6YTZg"],
         "issued_at": "2018-06-27T13:05:47.919028Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:50 GMT
 - request:
     method: get
@@ -6200,7 +6200,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:50 GMT
 - request:
     method: get
@@ -6233,7 +6233,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:50 GMT
 - request:
     method: post
@@ -6353,7 +6353,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FXaSqb0ySJGIJwh5ygfjLQ"],
         "issued_at": "2018-06-27T13:05:50.952939Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:50 GMT
 - request:
     method: get
@@ -6386,7 +6386,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:51 GMT
 - request:
     method: get
@@ -6419,7 +6419,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:51 GMT
 - request:
     method: post
@@ -6539,7 +6539,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pzsV82xuQ8OsnThKwxJybg"],
         "issued_at": "2018-06-27T13:05:51.837877Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:51 GMT
 - request:
     method: get
@@ -6572,7 +6572,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:52 GMT
 - request:
     method: post
@@ -6692,7 +6692,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H4p9TvEpQeCIOvPqqurc0g"],
         "issued_at": "2018-06-27T13:05:52.524972Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:52 GMT
 - request:
     method: get
@@ -6725,7 +6725,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:05:52 GMT
 - request:
     method: get
@@ -6780,7 +6780,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:08 GMT
 - request:
     method: get
@@ -6835,7 +6835,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:09 GMT
 - request:
     method: get
@@ -6890,7 +6890,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:10 GMT
 - request:
     method: get
@@ -6974,7 +6974,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:10 GMT
 - request:
     method: get
@@ -7014,7 +7014,7 @@ http_interactions:
         "2016-08-19T08:38:12", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:11 GMT
 - request:
     method: get
@@ -7049,7 +7049,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:11 GMT
 - request:
     method: get
@@ -7084,7 +7084,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:11 GMT
 - request:
     method: get
@@ -7160,7 +7160,7 @@ http_interactions:
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:12 GMT
 - request:
     method: get
@@ -7236,7 +7236,7 @@ http_interactions:
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:12 GMT
 - request:
     method: get
@@ -7314,7 +7314,7 @@ http_interactions:
         {"id": "476a0c89-4322-42aa-b7ce-3ac21be55af7"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:13 GMT
 - request:
     method: get
@@ -7386,7 +7386,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:14 GMT
 - request:
     method: get
@@ -7439,7 +7439,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:14 GMT
 - request:
     method: get
@@ -7474,7 +7474,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:15 GMT
 - request:
     method: get
@@ -7509,7 +7509,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:15 GMT
 - request:
     method: get
@@ -7544,7 +7544,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:15 GMT
 - request:
     method: get
@@ -7579,7 +7579,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:15 GMT
 - request:
     method: get
@@ -7663,7 +7663,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:15 GMT
 - request:
     method: get
@@ -7703,7 +7703,7 @@ http_interactions:
         "2016-08-19T08:38:10", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7787,7 +7787,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7827,7 +7827,7 @@ http_interactions:
         "2016-08-19T08:38:07", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7866,7 +7866,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7905,7 +7905,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "28db8f69ba9e4305b7fad82da4c86e74", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7944,7 +7944,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "4637c33fee924ebea81f8d209e452c91", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:16 GMT
 - request:
     method: get
@@ -7983,7 +7983,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "52c452d7763a4295950527948232a3e5", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:17 GMT
 - request:
     method: get
@@ -8022,7 +8022,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "88ae57d444fd485ab2dfddd5a2615d52", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:17 GMT
 - request:
     method: get
@@ -8061,7 +8061,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "d09cbe26295d47ff848ea73c74264e23", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:17 GMT
 - request:
     method: get
@@ -8100,7 +8100,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:17 GMT
 - request:
     method: post
@@ -8220,7 +8220,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HeudnbadQlipTVd80SVv4A"],
         "issued_at": "2018-06-27T13:06:18.122361Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:18 GMT
 - request:
     method: get
@@ -8260,7 +8260,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:19 GMT
 - request:
     method: post
@@ -8380,7 +8380,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3h2hpHL5SiOhyEstVQhJJQ"],
         "issued_at": "2018-06-27T13:06:19.811435Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:19 GMT
 - request:
     method: get
@@ -8420,7 +8420,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:20 GMT
 - request:
     method: post
@@ -8540,7 +8540,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5bA0ytVbT5GO36Sr0yefjA"],
         "issued_at": "2018-06-27T13:06:20.984060Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:21 GMT
 - request:
     method: get
@@ -8580,7 +8580,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:22 GMT
 - request:
     method: post
@@ -8700,7 +8700,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aed95Y2JQ8-kk4CTx7RRPQ"],
         "issued_at": "2018-06-27T13:06:22.454017Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:22 GMT
 - request:
     method: get
@@ -8740,7 +8740,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:23 GMT
 - request:
     method: get
@@ -8780,7 +8780,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:24 GMT
 - request:
     method: post
@@ -8900,7 +8900,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["msLYw7AGSI22neU18QJblA"],
         "issued_at": "2018-06-27T13:06:24.801515Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:24 GMT
 - request:
     method: get
@@ -8940,7 +8940,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:25 GMT
 - request:
     method: post
@@ -9060,7 +9060,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9mSL9HakTS--gdB-KpoBlg"],
         "issued_at": "2018-06-27T13:06:26.004411Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:26 GMT
 - request:
     method: get
@@ -9100,7 +9100,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:27 GMT
 - request:
     method: post
@@ -9220,7 +9220,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xpwn8pFsTcCW1gVBSi_IDQ"],
         "issued_at": "2018-06-27T13:06:28.082451Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:28 GMT
 - request:
     method: get
@@ -9252,7 +9252,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:28 GMT
 - request:
     method: post
@@ -9372,7 +9372,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ynKcQa4uSE6MGFjPyC8zgg"],
         "issued_at": "2018-06-27T13:06:29.060801Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:29 GMT
 - request:
     method: get
@@ -9407,7 +9407,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:29 GMT
 - request:
     method: post
@@ -9527,7 +9527,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MniZ2ovXTUSK9DwkvTIYVA"],
         "issued_at": "2018-06-27T13:06:29.669743Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:29 GMT
 - request:
     method: get
@@ -9562,7 +9562,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:30 GMT
 - request:
     method: post
@@ -9682,7 +9682,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["84waZawYToanlhPCoPjqlg"],
         "issued_at": "2018-06-27T13:06:30.544093Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:30 GMT
 - request:
     method: get
@@ -9717,7 +9717,7 @@ http_interactions:
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:31 GMT
 - request:
     method: post
@@ -9837,7 +9837,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lnEt80_YTlebY4opeuzB9Q"],
         "issued_at": "2018-06-27T13:06:31.515772Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:31 GMT
 - request:
     method: get
@@ -9872,7 +9872,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:31 GMT
 - request:
     method: get
@@ -9907,7 +9907,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:31 GMT
 - request:
     method: post
@@ -10027,7 +10027,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RQBlyrF7T8GaEGlniTV0LQ"],
         "issued_at": "2018-06-27T13:06:32.563531Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:32 GMT
 - request:
     method: get
@@ -10062,7 +10062,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:32 GMT
 - request:
     method: post
@@ -10182,7 +10182,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7vpb5lfsQOSF-BU-EuzK7w"],
         "issued_at": "2018-06-27T13:06:33.190060Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:33 GMT
 - request:
     method: get
@@ -10217,7 +10217,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:33 GMT
 - request:
     method: get
@@ -10270,7 +10270,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:34 GMT
 - request:
     method: get
@@ -10323,7 +10323,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:34 GMT
 - request:
     method: get
@@ -10376,7 +10376,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:34 GMT
 - request:
     method: get
@@ -10429,7 +10429,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:35 GMT
 - request:
     method: get
@@ -10482,11 +10482,11 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:35 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
+    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -10518,7 +10518,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:36 GMT
 - request:
     method: get
@@ -10571,11 +10571,11 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:36 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
+    uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -10607,7 +10607,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:36 GMT
 - request:
     method: get
@@ -10660,7 +10660,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:36 GMT
 - request:
     method: get
@@ -10713,7 +10713,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:37 GMT
 - request:
     method: get
@@ -10766,7 +10766,7 @@ http_interactions:
         "ip": "172.16.17.8", "fixed_ip": "192.168.1.6", "id": "c088d4ab-be13-48c3-94ab-cadbf1a28c66",
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:37 GMT
 - request:
     method: post
@@ -10886,7 +10886,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["anKFsbmUTi6Gu50eyk1ofg"],
         "issued_at": "2018-06-27T13:06:38.065102Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:38 GMT
 - request:
     method: post
@@ -11006,7 +11006,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zDC7fmpDQuW-eK2p2fnJOg",
         "anKFsbmUTi6Gu50eyk1ofg"], "issued_at": "2018-06-27T13:06:38.473866Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:38 GMT
 - request:
     method: post
@@ -11126,7 +11126,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ntTtmAKqRiq2zEjQRVb_fA"],
         "issued_at": "2018-06-27T13:06:38.823601Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:38 GMT
 - request:
     method: post
@@ -11246,7 +11246,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t35ITx02TKKT3kFMGoTrBA",
         "ntTtmAKqRiq2zEjQRVb_fA"], "issued_at": "2018-06-27T13:06:39.155662Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:39 GMT
 - request:
     method: get
@@ -11281,7 +11281,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:39 GMT
 - request:
     method: get
@@ -11316,7 +11316,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:39 GMT
 - request:
     method: get
@@ -11351,7 +11351,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:39 GMT
 - request:
     method: get
@@ -11414,7 +11414,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:40 GMT
 - request:
     method: get
@@ -11461,7 +11461,7 @@ http_interactions:
         "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:40 GMT
 - request:
     method: get
@@ -11496,7 +11496,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:40 GMT
 - request:
     method: get
@@ -11531,7 +11531,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:41 GMT
 - request:
     method: get
@@ -11566,7 +11566,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:41 GMT
 - request:
     method: get
@@ -11601,7 +11601,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:42 GMT
 - request:
     method: get
@@ -11636,7 +11636,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:42 GMT
 - request:
     method: get
@@ -11671,7 +11671,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:42 GMT
 - request:
     method: get
@@ -11706,7 +11706,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:42 GMT
 - request:
     method: get
@@ -11741,7 +11741,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:42 GMT
 - request:
     method: get
@@ -11786,7 +11786,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:43 GMT
 - request:
     method: get
@@ -11831,7 +11831,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:43 GMT
 - request:
     method: get
@@ -11866,7 +11866,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:43 GMT
 - request:
     method: get
@@ -11901,7 +11901,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:43 GMT
 - request:
     method: get
@@ -11936,7 +11936,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:43 GMT
 - request:
     method: get
@@ -11971,7 +11971,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:44 GMT
 - request:
     method: get
@@ -12006,7 +12006,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:44 GMT
 - request:
     method: get
@@ -12041,7 +12041,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:44 GMT
 - request:
     method: get
@@ -12076,7 +12076,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:45 GMT
 - request:
     method: get
@@ -12111,7 +12111,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:45 GMT
 - request:
     method: get
@@ -12146,7 +12146,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:45 GMT
 - request:
     method: get
@@ -12181,7 +12181,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:45 GMT
 - request:
     method: get
@@ -12244,7 +12244,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:45 GMT
 - request:
     method: get
@@ -12315,7 +12315,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:46 GMT
 - request:
     method: get
@@ -12379,7 +12379,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:46 GMT
 - request:
     method: get
@@ -12414,7 +12414,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:47 GMT
 - request:
     method: get
@@ -12449,7 +12449,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:47 GMT
 - request:
     method: get
@@ -12484,7 +12484,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:47 GMT
 - request:
     method: get
@@ -12519,7 +12519,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:47 GMT
 - request:
     method: get
@@ -12554,7 +12554,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:48 GMT
 - request:
     method: post
@@ -12674,7 +12674,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ttFeUqhGSS2sBXa9BbUrVA"],
         "issued_at": "2018-06-27T13:06:50.873826Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:50 GMT
 - request:
     method: post
@@ -12794,7 +12794,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FF3bzOfoRS-l70GbYgILEA"],
         "issued_at": "2018-06-27T13:06:51.220470Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:51 GMT
 - request:
     method: get
@@ -12892,7 +12892,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:51 GMT
 - request:
     method: post
@@ -13012,7 +13012,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bGdelHwFQ16dRNzlSnF45A"],
         "issued_at": "2018-06-27T13:06:51.903231Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:51 GMT
 - request:
     method: post
@@ -13052,7 +13052,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L65MsezIQO6XOV3i3ZB1PA"],
         "issued_at": "2018-06-27T13:06:52.209928Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:52 GMT
 - request:
     method: get
@@ -13113,7 +13113,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:52 GMT
 - request:
     method: post
@@ -13233,7 +13233,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G-EIr5ajSfOrNZqjI69xQg",
         "L65MsezIQO6XOV3i3ZB1PA"], "issued_at": "2018-06-27T13:06:52.652074Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:52 GMT
 - request:
     method: get
@@ -13294,7 +13294,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:52 GMT
 - request:
     method: post
@@ -13414,7 +13414,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Oc4fQxHOR-mECoxji_UBxw"],
         "issued_at": "2018-06-27T13:06:53.697384Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:53 GMT
 - request:
     method: post
@@ -13534,7 +13534,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Xor0C9SqSheaUrVFbuO_-w"],
         "issued_at": "2018-06-27T13:06:54.182806Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:54 GMT
 - request:
     method: post
@@ -13654,7 +13654,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yNddX7LmS2GX8DTCJenLPw"],
         "issued_at": "2018-06-27T13:06:54.611808Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:54 GMT
 - request:
     method: post
@@ -13774,7 +13774,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CrsfIUF1SW-V3raB6zcyqg"],
         "issued_at": "2018-06-27T13:06:55.110599Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:55 GMT
 - request:
     method: post
@@ -13894,7 +13894,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aHLtpEpLSuucEIUDfnzNRw"],
         "issued_at": "2018-06-27T13:06:55.474139Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:55 GMT
 - request:
     method: post
@@ -14014,7 +14014,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zbkiygzLTWOMIWch1ziBTA"],
         "issued_at": "2018-06-27T13:06:55.844632Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:55 GMT
 - request:
     method: post
@@ -14134,7 +14134,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dGlZKzZoSxGoAXeX97YdkQ"],
         "issued_at": "2018-06-27T13:06:56.422536Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:56 GMT
 - request:
     method: get
@@ -14167,7 +14167,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:56 GMT
 - request:
     method: post
@@ -14287,7 +14287,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KtY_sLFQQJGikgRA11pJCQ"],
         "issued_at": "2018-06-27T13:06:57.273418Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:57 GMT
 - request:
     method: get
@@ -14320,7 +14320,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:57 GMT
 - request:
     method: post
@@ -14440,7 +14440,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7EbuZaA2TRCye3ADVEI2qw"],
         "issued_at": "2018-06-27T13:06:57.876284Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:58 GMT
 - request:
     method: get
@@ -14502,7 +14502,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:58 GMT
 - request:
     method: get
@@ -14535,7 +14535,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:58 GMT
 - request:
     method: post
@@ -14655,7 +14655,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4-QqIF9hTReHAhchIUO3EQ"],
         "issued_at": "2018-06-27T13:06:58.725007Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:58 GMT
 - request:
     method: get
@@ -14688,7 +14688,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:58 GMT
 - request:
     method: get
@@ -14721,7 +14721,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:59 GMT
 - request:
     method: post
@@ -14841,7 +14841,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tcSr76S-T7WZlZ2KY05fcA"],
         "issued_at": "2018-06-27T13:06:59.304279Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:59 GMT
 - request:
     method: get
@@ -14874,7 +14874,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:59 GMT
 - request:
     method: post
@@ -14994,7 +14994,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OqSJzOLoTNWr6QnAdxl-YQ"],
         "issued_at": "2018-06-27T13:06:59.837658Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:06:59 GMT
 - request:
     method: get
@@ -15027,7 +15027,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:00 GMT
 - request:
     method: get
@@ -15082,7 +15082,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:00 GMT
 - request:
     method: get
@@ -15137,7 +15137,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:01 GMT
 - request:
     method: get
@@ -15192,7 +15192,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:01 GMT
 - request:
     method: get
@@ -15232,7 +15232,7 @@ http_interactions:
         "2016-08-19T08:38:12", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:01 GMT
 - request:
     method: get
@@ -15272,7 +15272,7 @@ http_interactions:
         "2016-08-19T08:38:10", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:02 GMT
 - request:
     method: get
@@ -15312,7 +15312,7 @@ http_interactions:
         "2016-08-19T08:38:07", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:02 GMT
 - request:
     method: post
@@ -15432,7 +15432,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tJusvlTzTiGyxB7rWfEg7A"],
         "issued_at": "2018-06-27T13:07:03.212230Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:03 GMT
 - request:
     method: get
@@ -15564,7 +15564,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:03 GMT
 - request:
     method: get
@@ -15696,7 +15696,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:03 GMT
 - request:
     method: post
@@ -15816,7 +15816,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["12ULZPQbQlW0OnkTywSJUg"],
         "issued_at": "2018-06-27T13:07:04.203270Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:04 GMT
 - request:
     method: get
@@ -15948,7 +15948,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:04 GMT
 - request:
     method: get
@@ -16080,7 +16080,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:05 GMT
 - request:
     method: post
@@ -16200,7 +16200,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0kJeG-9_Smi0DHCuPqFNzg"],
         "issued_at": "2018-06-27T13:07:05.323082Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:05 GMT
 - request:
     method: get
@@ -16332,7 +16332,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:05 GMT
 - request:
     method: get
@@ -16464,7 +16464,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:06 GMT
 - request:
     method: get
@@ -16596,7 +16596,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:06 GMT
 - request:
     method: get
@@ -16728,7 +16728,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:06 GMT
 - request:
     method: post
@@ -16848,7 +16848,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gSqTm8RUTDyaDWwKta6Dqg"],
         "issued_at": "2018-06-27T13:07:06.833948Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:06 GMT
 - request:
     method: get
@@ -16980,7 +16980,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:07 GMT
 - request:
     method: get
@@ -17112,7 +17112,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:07 GMT
 - request:
     method: get
@@ -17244,7 +17244,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:07 GMT
 - request:
     method: get
@@ -17376,7 +17376,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:07 GMT
 - request:
     method: get
@@ -17508,7 +17508,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:08 GMT
 - request:
     method: get
@@ -17640,7 +17640,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:08 GMT
 - request:
     method: post
@@ -17760,7 +17760,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y_coc8nNQTmoC8TdsziXhQ"],
         "issued_at": "2018-06-27T13:07:09.054682Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:09 GMT
 - request:
     method: get
@@ -17892,7 +17892,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:09 GMT
 - request:
     method: get
@@ -18024,7 +18024,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:09 GMT
 - request:
     method: get
@@ -18156,7 +18156,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:10 GMT
 - request:
     method: get
@@ -18288,7 +18288,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:10 GMT
 - request:
     method: get
@@ -18420,7 +18420,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:10 GMT
 - request:
     method: get
@@ -18552,7 +18552,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:11 GMT
 - request:
     method: post
@@ -18672,7 +18672,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NHnctzBCTDmSA9luaT6oXA"],
         "issued_at": "2018-06-27T13:07:11.393149Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:12 GMT
 - request:
     method: get
@@ -18804,7 +18804,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:12 GMT
 - request:
     method: get
@@ -18936,7 +18936,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:12 GMT
 - request:
     method: get
@@ -19006,7 +19006,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:12 GMT
 - request:
     method: get
@@ -19076,7 +19076,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19146,7 +19146,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19216,7 +19216,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19286,7 +19286,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19356,7 +19356,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19426,7 +19426,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19496,7 +19496,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:13 GMT
 - request:
     method: get
@@ -19566,7 +19566,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -19636,7 +19636,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -19706,7 +19706,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -19776,7 +19776,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -19846,7 +19846,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -19916,7 +19916,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -20347,7 +20347,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:14 GMT
 - request:
     method: get
@@ -20778,7 +20778,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:15 GMT
 - request:
     method: get
@@ -21209,7 +21209,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:15 GMT
 - request:
     method: get
@@ -21640,7 +21640,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:15 GMT
 - request:
     method: get
@@ -22071,7 +22071,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:15 GMT
 - request:
     method: get
@@ -22502,7 +22502,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:16 GMT
 - request:
     method: get
@@ -22933,7 +22933,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:16 GMT
 - request:
     method: get
@@ -23364,7 +23364,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:16 GMT
 - request:
     method: get
@@ -23795,7 +23795,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:16 GMT
 - request:
     method: get
@@ -24226,7 +24226,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:17 GMT
 - request:
     method: get
@@ -24657,7 +24657,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:17 GMT
 - request:
     method: get
@@ -25088,7 +25088,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:17 GMT
 - request:
     method: get
@@ -25519,7 +25519,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:17 GMT
 - request:
     method: get
@@ -25950,7 +25950,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:18 GMT
 - request:
     method: get
@@ -26010,7 +26010,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:18 GMT
 - request:
     method: get
@@ -26070,7 +26070,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:18 GMT
 - request:
     method: get
@@ -26130,7 +26130,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:18 GMT
 - request:
     method: get
@@ -26190,7 +26190,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:18 GMT
 - request:
     method: get
@@ -26250,7 +26250,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26310,7 +26310,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26370,7 +26370,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26430,7 +26430,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26490,7 +26490,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26550,7 +26550,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26610,7 +26610,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:19 GMT
 - request:
     method: get
@@ -26670,7 +26670,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -26730,7 +26730,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -26790,7 +26790,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -26853,7 +26853,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -26924,7 +26924,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -26995,7 +26995,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:20 GMT
 - request:
     method: get
@@ -27130,7 +27130,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27200,7 +27200,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27234,7 +27234,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27297,7 +27297,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27368,7 +27368,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27439,7 +27439,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:21 GMT
 - request:
     method: get
@@ -27574,7 +27574,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:22 GMT
 - request:
     method: get
@@ -27644,7 +27644,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:22 GMT
 - request:
     method: get
@@ -27678,7 +27678,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:22 GMT
 - request:
     method: get
@@ -27741,7 +27741,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:22 GMT
 - request:
     method: get
@@ -27812,7 +27812,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:22 GMT
 - request:
     method: get
@@ -27883,7 +27883,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:23 GMT
 - request:
     method: get
@@ -28018,7 +28018,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:23 GMT
 - request:
     method: get
@@ -28088,7 +28088,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:23 GMT
 - request:
     method: get
@@ -28122,7 +28122,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:23 GMT
 - request:
     method: get
@@ -28185,7 +28185,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28256,7 +28256,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28327,7 +28327,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28462,7 +28462,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28532,7 +28532,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28566,7 +28566,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:24 GMT
 - request:
     method: get
@@ -28629,7 +28629,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -28700,7 +28700,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -28771,7 +28771,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -28906,7 +28906,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -28976,7 +28976,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -29010,7 +29010,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:25 GMT
 - request:
     method: get
@@ -29073,7 +29073,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:26 GMT
 - request:
     method: get
@@ -29144,7 +29144,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:26 GMT
 - request:
     method: get
@@ -29215,7 +29215,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:26 GMT
 - request:
     method: get
@@ -29350,7 +29350,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:26 GMT
 - request:
     method: get
@@ -29420,7 +29420,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:26 GMT
 - request:
     method: get
@@ -29454,7 +29454,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29517,7 +29517,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29588,7 +29588,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29659,7 +29659,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29794,7 +29794,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29864,7 +29864,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:27 GMT
 - request:
     method: get
@@ -29898,7 +29898,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:28 GMT
 - request:
     method: post
@@ -30018,7 +30018,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RSiaFRm_Trm0oDIYIfSZDQ"],
         "issued_at": "2018-06-27T13:07:29.173561Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:29 GMT
 - request:
     method: post
@@ -30138,7 +30138,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wlDy888hTzKx25yqmU6-IA"],
         "issued_at": "2018-06-27T13:07:29.583490Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:29 GMT
 - request:
     method: post
@@ -30178,7 +30178,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J0P_rsOPTSCp7UUz6_Wjvw"],
         "issued_at": "2018-06-27T13:07:29.832935Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:29 GMT
 - request:
     method: get
@@ -30239,7 +30239,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:30 GMT
 - request:
     method: post
@@ -30359,7 +30359,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["asx1pL_zSAi1mFyqK4wZ7A",
         "J0P_rsOPTSCp7UUz6_Wjvw"], "issued_at": "2018-06-27T13:07:30.417698Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:30 GMT
 - request:
     method: get
@@ -30420,7 +30420,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:30 GMT
 - request:
     method: post
@@ -30540,7 +30540,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9X8kWTkvRWmdDktnb8InEA"],
         "issued_at": "2018-06-27T13:07:31.255375Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:31 GMT
 - request:
     method: post
@@ -30660,7 +30660,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GQS8pi3LSBak1Qh9wd3xMw"],
         "issued_at": "2018-06-27T13:07:31.606354Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:31 GMT
 - request:
     method: post
@@ -30780,7 +30780,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GUCcamBYQxiLSxMAjUZD3w"],
         "issued_at": "2018-06-27T13:07:31.952751Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:31 GMT
 - request:
     method: post
@@ -30900,7 +30900,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sY3kc0eaRNWtNga-XBSecQ"],
         "issued_at": "2018-06-27T13:07:32.367246Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:32 GMT
 - request:
     method: post
@@ -31020,7 +31020,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F4FxfWbkQmm4I7UwfsMUvA"],
         "issued_at": "2018-06-27T13:07:32.754635Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:32 GMT
 - request:
     method: post
@@ -31140,7 +31140,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h5Jp7N8jSfWFExk3afDnWQ"],
         "issued_at": "2018-06-27T13:07:33.105001Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:33 GMT
 - request:
     method: post
@@ -31260,7 +31260,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Cs4OEEY1QEGtGbJjMD6vHw"],
         "issued_at": "2018-06-27T13:07:33.461259Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:33 GMT
 - request:
     method: get
@@ -31295,7 +31295,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:33 GMT
 - request:
     method: post
@@ -31415,7 +31415,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uQ_EzRKsQCyUNtsLviB4Qg"],
         "issued_at": "2018-06-27T13:07:34.203352Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:34 GMT
 - request:
     method: get
@@ -31450,7 +31450,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:35 GMT
 - request:
     method: post
@@ -31570,7 +31570,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Vb-IFmf6TL209iH_w1KAvg"],
         "issued_at": "2018-06-27T13:07:35.885059Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:35 GMT
 - request:
     method: get
@@ -31633,7 +31633,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:36 GMT
 - request:
     method: get
@@ -31704,7 +31704,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:36 GMT
 - request:
     method: get
@@ -31768,7 +31768,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:37 GMT
 - request:
     method: get
@@ -31803,7 +31803,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:37 GMT
 - request:
     method: post
@@ -31923,7 +31923,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EFN-pRMZQcKk05d39wZ3RA"],
         "issued_at": "2018-06-27T13:07:37.765626Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:37 GMT
 - request:
     method: get
@@ -31958,7 +31958,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:38 GMT
 - request:
     method: get
@@ -31993,7 +31993,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:38 GMT
 - request:
     method: post
@@ -32113,7 +32113,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-y0UyUgDTCSha4bx5Fcsiw"],
         "issued_at": "2018-06-27T13:07:38.826644Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:39 GMT
 - request:
     method: get
@@ -32148,7 +32148,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:39 GMT
 - request:
     method: post
@@ -32268,7 +32268,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sA3GMTZBS92KA5MOBc7qIg"],
         "issued_at": "2018-06-27T13:07:39.796160Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:39 GMT
 - request:
     method: get
@@ -32303,7 +32303,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32338,7 +32338,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32373,7 +32373,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32408,7 +32408,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32443,7 +32443,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32488,7 +32488,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:40 GMT
 - request:
     method: get
@@ -32533,7 +32533,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:41 GMT
 - request:
     method: get
@@ -32568,7 +32568,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:41 GMT
 - request:
     method: get
@@ -32603,7 +32603,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:41 GMT
 - request:
     method: get
@@ -32638,7 +32638,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:41 GMT
 - request:
     method: get
@@ -32673,7 +32673,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:41 GMT
 - request:
     method: get
@@ -32708,7 +32708,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:42 GMT
 - request:
     method: get
@@ -32743,7 +32743,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:42 GMT
 - request:
     method: get
@@ -32778,7 +32778,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32813,7 +32813,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32848,7 +32848,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32883,7 +32883,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32918,7 +32918,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32953,7 +32953,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -32988,7 +32988,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -33023,7 +33023,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:43 GMT
 - request:
     method: get
@@ -33058,7 +33058,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33093,7 +33093,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33128,7 +33128,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33163,7 +33163,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33198,7 +33198,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33233,7 +33233,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33268,7 +33268,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: get
@@ -33303,7 +33303,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:45 GMT
 - request:
     method: post
@@ -33423,7 +33423,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I048GfZGR0mouB78hjbfvg"],
         "issued_at": "2018-06-27T13:07:46.418064Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:46 GMT
 - request:
     method: post
@@ -33543,7 +33543,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C4bu3RiUR5CiseXVLIOckQ"],
         "issued_at": "2018-06-27T13:07:46.939955Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:46 GMT
 - request:
     method: post
@@ -33583,7 +33583,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EcVQg6GDT0ennHsec6d40Q"],
         "issued_at": "2018-06-27T13:07:47.228181Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:47 GMT
 - request:
     method: get
@@ -33644,7 +33644,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:47 GMT
 - request:
     method: post
@@ -33764,7 +33764,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NFJqL7EqRJm_9okrzIIhHw",
         "EcVQg6GDT0ennHsec6d40Q"], "issued_at": "2018-06-27T13:07:47.712315Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:47 GMT
 - request:
     method: get
@@ -33825,7 +33825,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:47 GMT
 - request:
     method: post
@@ -33945,7 +33945,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VF6NgjJyTFiT2_x_6iO1Gw"],
         "issued_at": "2018-06-27T13:07:48.387141Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:48 GMT
 - request:
     method: post
@@ -34065,7 +34065,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["itmSvlWuS-K8Q1vpvWUWzQ"],
         "issued_at": "2018-06-27T13:07:49.172658Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:49 GMT
 - request:
     method: post
@@ -34185,7 +34185,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hIe7dXb-S7ycSYz5rvlTkQ"],
         "issued_at": "2018-06-27T13:07:49.552493Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:49 GMT
 - request:
     method: post
@@ -34305,7 +34305,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UWa9wekYTSeoPB47jVEqtw"],
         "issued_at": "2018-06-27T13:07:49.938691Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:49 GMT
 - request:
     method: post
@@ -34425,7 +34425,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QBbxzUpiSE6jq6jTFLL_YQ"],
         "issued_at": "2018-06-27T13:07:50.364726Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:50 GMT
 - request:
     method: post
@@ -34545,7 +34545,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pThG0kYHQGWcTSuCDRs2HA"],
         "issued_at": "2018-06-27T13:07:50.725968Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:50 GMT
 - request:
     method: post
@@ -34665,7 +34665,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DBIHBOjXTdetM0XIBaz4xQ"],
         "issued_at": "2018-06-27T13:07:51.088734Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:51 GMT
 - request:
     method: get
@@ -34708,7 +34708,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:51 GMT
 - request:
     method: post
@@ -34828,7 +34828,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BFg5Z4ldS_GKDIe5gfF4nw"],
         "issued_at": "2018-06-27T13:07:51.899505Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:51 GMT
 - request:
     method: get
@@ -34871,7 +34871,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:52 GMT
 - request:
     method: post
@@ -34991,7 +34991,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a1hqUIjSQvyFy7ugh1FVmg"],
         "issued_at": "2018-06-27T13:07:52.497045Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:52 GMT
 - request:
     method: get
@@ -35043,7 +35043,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:52 GMT
 - request:
     method: get
@@ -35094,7 +35094,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:52 GMT
 - request:
     method: post
@@ -35214,7 +35214,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R18E0w3NQkC1I0cCQEOpoQ"],
         "issued_at": "2018-06-27T13:07:53.171343Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:53 GMT
 - request:
     method: get
@@ -35257,7 +35257,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:53 GMT
 - request:
     method: get
@@ -35300,7 +35300,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:53 GMT
 - request:
     method: post
@@ -35420,7 +35420,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oJROEpaaTHybLpvQdgHlYQ"],
         "issued_at": "2018-06-27T13:07:54.339087Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:54 GMT
 - request:
     method: get
@@ -35463,7 +35463,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:54 GMT
 - request:
     method: post
@@ -35583,7 +35583,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UwMQQib1Sni2eEjAV5rQRg"],
         "issued_at": "2018-06-27T13:07:54.890229Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:54 GMT
 - request:
     method: get
@@ -35626,7 +35626,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:55 GMT
 - request:
     method: get
@@ -35674,7 +35674,7 @@ http_interactions:
         "bytes": 11, "name": "file_2", "content_type": "application/octet-stream"},
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:55 GMT
 - request:
     method: get
@@ -35717,7 +35717,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:55 GMT
 - request:
     method: get
@@ -35760,6 +35760,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:07:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -118,7 +118,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OS2aeWD9Q-WArLep064zYw"],
         "issued_at": "2018-06-27T13:09:24.168304Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:24 GMT
 - request:
     method: get
@@ -153,7 +153,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:24 GMT
 - request:
     method: get
@@ -189,7 +189,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:24 GMT
 - request:
     method: post
@@ -309,7 +309,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S8_GPzHnSnmKFZPyFWotFA"],
         "issued_at": "2018-06-27T13:09:24.679279Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:24 GMT
 - request:
     method: get
@@ -345,7 +345,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:24 GMT
 - request:
     method: get
@@ -392,7 +392,7 @@ http_interactions:
         "2018-06-27T13:09:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:09:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: get
@@ -439,7 +439,7 @@ http_interactions:
         "2018-06-27T13:09:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-06-27T13:09:24.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: get
@@ -483,7 +483,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: get
@@ -527,7 +527,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: get
@@ -572,7 +572,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: get
@@ -612,7 +612,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 16384, "OS-FLV-DISABLED:disabled": false, "vcpus":
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:25 GMT
 - request:
     method: post
@@ -732,7 +732,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AS_btfKSQ-OmO43i8fHZdw"],
         "issued_at": "2018-06-27T13:09:26.245037Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:26 GMT
 - request:
     method: get
@@ -793,7 +793,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:26 GMT
 - request:
     method: get
@@ -829,7 +829,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:26 GMT
 - request:
     method: post
@@ -949,7 +949,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xFj6OhV6Rcy5SFgKAawtZQ"],
         "issued_at": "2018-06-27T13:09:26.922501Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:26 GMT
 - request:
     method: get
@@ -988,7 +988,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.206:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:27 GMT
 - request:
     method: get
@@ -1021,7 +1021,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:27 GMT
 - request:
     method: get
@@ -1091,7 +1091,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "4637c33fee924ebea81f8d209e452c91",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:27 GMT
 - request:
     method: get
@@ -1131,7 +1131,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:27 GMT
 - request:
     method: get
@@ -1171,7 +1171,7 @@ http_interactions:
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "13:fb:2a:0c:78:1d:bc:b0:c2:7d:8c:3e:66:a4:d2:0d"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:27 GMT
 - request:
     method: post
@@ -1291,7 +1291,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kQfw6YqkRSGLSRi1o9tS4g"],
         "issued_at": "2018-06-27T13:09:28.111784Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:28 GMT
 - request:
     method: post
@@ -1331,7 +1331,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k1MUwnCHSo6r93gigtIjsw"],
         "issued_at": "2018-06-27T13:09:28.390526Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:28 GMT
 - request:
     method: get
@@ -1392,7 +1392,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:28 GMT
 - request:
     method: post
@@ -1512,7 +1512,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["leOFHNsPRwuKkCPfrKmvvA",
         "k1MUwnCHSo6r93gigtIjsw"], "issued_at": "2018-06-27T13:09:29.037217Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:29 GMT
 - request:
     method: get
@@ -1573,7 +1573,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:29 GMT
 - request:
     method: post
@@ -1693,7 +1693,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wce9fhJYTwa5zziNXKKd5g"],
         "issued_at": "2018-06-27T13:09:29.560216Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:29 GMT
 - request:
     method: get
@@ -1728,7 +1728,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:29 GMT
 - request:
     method: post
@@ -1848,7 +1848,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a7tB3n-XQCq1E8zVlk2_vw"],
         "issued_at": "2018-06-27T13:09:30.060954Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:30 GMT
 - request:
     method: get
@@ -1883,7 +1883,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:30 GMT
 - request:
     method: post
@@ -2003,7 +2003,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cy5x4EDUTZG9wcW9vOLNeA"],
         "issued_at": "2018-06-27T13:09:30.549948Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:30 GMT
 - request:
     method: get
@@ -2038,7 +2038,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:30 GMT
 - request:
     method: post
@@ -2158,7 +2158,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qezfdGDyS4ihmrERxprjMA"],
         "issued_at": "2018-06-27T13:09:30.954353Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:30 GMT
 - request:
     method: get
@@ -2193,7 +2193,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:31 GMT
 - request:
     method: post
@@ -2313,7 +2313,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sf8bj7vNRbiFkyjH47AkLg"],
         "issued_at": "2018-06-27T13:09:31.446268Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:31 GMT
 - request:
     method: get
@@ -2348,7 +2348,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:31 GMT
 - request:
     method: post
@@ -2468,7 +2468,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1wdfXMCFTBycGPLFhEQPcw"],
         "issued_at": "2018-06-27T13:09:31.865179Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:31 GMT
 - request:
     method: get
@@ -2503,7 +2503,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:31 GMT
 - request:
     method: post
@@ -2623,7 +2623,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3VyFxRlkQy6LnpnaIzdwjw"],
         "issued_at": "2018-06-27T13:09:32.393195Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:32 GMT
 - request:
     method: get
@@ -2656,7 +2656,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:32 GMT
 - request:
     method: post
@@ -2776,7 +2776,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m-wSNKXESWmekdCa4qY9Gw"],
         "issued_at": "2018-06-27T13:09:32.967993Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:33 GMT
 - request:
     method: get
@@ -2809,7 +2809,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:33 GMT
 - request:
     method: post
@@ -2929,7 +2929,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rPK9aePeSouIlZU30yJDoA"],
         "issued_at": "2018-06-27T13:09:33.590311Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:33 GMT
 - request:
     method: get
@@ -2991,7 +2991,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:34 GMT
 - request:
     method: get
@@ -3024,7 +3024,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:34 GMT
 - request:
     method: post
@@ -3144,7 +3144,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["23sm_zKmSieAwJvtOm0M4Q"],
         "issued_at": "2018-06-27T13:09:34.464947Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:34 GMT
 - request:
     method: get
@@ -3177,7 +3177,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:34 GMT
 - request:
     method: get
@@ -3210,7 +3210,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:35 GMT
 - request:
     method: post
@@ -3330,7 +3330,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q4SOnQVCTLC6z6uEpjynTQ"],
         "issued_at": "2018-06-27T13:09:35.342515Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:35 GMT
 - request:
     method: get
@@ -3363,7 +3363,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:35 GMT
 - request:
     method: post
@@ -3483,7 +3483,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_ZAgcuoOSXa1Lt7bQ-ckZQ"],
         "issued_at": "2018-06-27T13:09:35.903927Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:35 GMT
 - request:
     method: get
@@ -3516,7 +3516,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:36 GMT
 - request:
     method: get
@@ -3571,7 +3571,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:37 GMT
 - request:
     method: get
@@ -3626,7 +3626,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:38 GMT
 - request:
     method: get
@@ -3681,7 +3681,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:39 GMT
 - request:
     method: get
@@ -3765,7 +3765,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:39 GMT
 - request:
     method: get
@@ -3805,7 +3805,7 @@ http_interactions:
         "2016-08-19T08:38:12", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:39 GMT
 - request:
     method: get
@@ -3881,7 +3881,7 @@ http_interactions:
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:40 GMT
 - request:
     method: get
@@ -3957,7 +3957,7 @@ http_interactions:
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:40 GMT
 - request:
     method: get
@@ -4035,7 +4035,7 @@ http_interactions:
         {"id": "476a0c89-4322-42aa-b7ce-3ac21be55af7"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:41 GMT
 - request:
     method: get
@@ -4107,7 +4107,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:42 GMT
 - request:
     method: get
@@ -4160,7 +4160,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:42 GMT
 - request:
     method: get
@@ -4244,7 +4244,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:43 GMT
 - request:
     method: get
@@ -4284,7 +4284,7 @@ http_interactions:
         "2016-08-19T08:38:10", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:43 GMT
 - request:
     method: get
@@ -4368,7 +4368,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:43 GMT
 - request:
     method: get
@@ -4408,7 +4408,7 @@ http_interactions:
         "2016-08-19T08:38:07", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:43 GMT
 - request:
     method: get
@@ -4447,7 +4447,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:43 GMT
 - request:
     method: get
@@ -4486,7 +4486,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "28db8f69ba9e4305b7fad82da4c86e74", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:44 GMT
 - request:
     method: get
@@ -4525,7 +4525,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "4637c33fee924ebea81f8d209e452c91", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:45 GMT
 - request:
     method: get
@@ -4564,7 +4564,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "52c452d7763a4295950527948232a3e5", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:45 GMT
 - request:
     method: get
@@ -4603,7 +4603,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "88ae57d444fd485ab2dfddd5a2615d52", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:45 GMT
 - request:
     method: get
@@ -4642,7 +4642,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "d09cbe26295d47ff848ea73c74264e23", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:45 GMT
 - request:
     method: get
@@ -4681,7 +4681,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:45 GMT
 - request:
     method: post
@@ -4801,7 +4801,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XZVtqSW4SpeCc8yT2NrqJA"],
         "issued_at": "2018-06-27T13:09:46.170715Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:46 GMT
 - request:
     method: get
@@ -4841,7 +4841,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:46 GMT
 - request:
     method: post
@@ -4961,7 +4961,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YQxfMVBmTV-dOYHriAgRCw"],
         "issued_at": "2018-06-27T13:09:47.301249Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:47 GMT
 - request:
     method: get
@@ -5001,7 +5001,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:48 GMT
 - request:
     method: post
@@ -5121,7 +5121,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6cb6JoE9T_-fJXidMJalgQ"],
         "issued_at": "2018-06-27T13:09:48.556851Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:48 GMT
 - request:
     method: get
@@ -5161,7 +5161,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:48 GMT
 - request:
     method: post
@@ -5281,7 +5281,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3xJAXWZWT7Ok9SKclu6aWA"],
         "issued_at": "2018-06-27T13:09:49.386063Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:49 GMT
 - request:
     method: get
@@ -5321,7 +5321,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:50 GMT
 - request:
     method: get
@@ -5361,7 +5361,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:50 GMT
 - request:
     method: post
@@ -5481,7 +5481,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o8utBfgTST-ZmkDakpRrcw"],
         "issued_at": "2018-06-27T13:09:51.154022Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:51 GMT
 - request:
     method: get
@@ -5521,7 +5521,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:52 GMT
 - request:
     method: post
@@ -5641,7 +5641,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hMt-KIf6TFaWYfbKZvw7rA"],
         "issued_at": "2018-06-27T13:09:53.240160Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:53 GMT
 - request:
     method: get
@@ -5681,7 +5681,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:53 GMT
 - request:
     method: post
@@ -5801,7 +5801,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g49IzeAURYWswSBkNDfWJQ"],
         "issued_at": "2018-06-27T13:09:54.287379Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:54 GMT
 - request:
     method: get
@@ -5833,7 +5833,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:54 GMT
 - request:
     method: post
@@ -5953,7 +5953,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Vre-U9lyRXmgffIV7bxROA"],
         "issued_at": "2018-06-27T13:09:54.652999Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:54 GMT
 - request:
     method: get
@@ -5988,7 +5988,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:54 GMT
 - request:
     method: post
@@ -6108,7 +6108,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WsG337MhTkmKSwjLRo5New"],
         "issued_at": "2018-06-27T13:09:55.267456Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:56 GMT
 - request:
     method: get
@@ -6143,7 +6143,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:56 GMT
 - request:
     method: post
@@ -6263,7 +6263,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ooh_6A7RSpa9Bg73ZgIH-w"],
         "issued_at": "2018-06-27T13:09:56.891905Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:56 GMT
 - request:
     method: get
@@ -6298,7 +6298,7 @@ http_interactions:
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:57 GMT
 - request:
     method: post
@@ -6418,7 +6418,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4y2xPF24R_2WO3zOWt0BGQ"],
         "issued_at": "2018-06-27T13:09:57.378797Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:57 GMT
 - request:
     method: get
@@ -6453,7 +6453,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:57 GMT
 - request:
     method: get
@@ -6488,7 +6488,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:58 GMT
 - request:
     method: post
@@ -6608,7 +6608,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ROjkJfxISqehDsp0-otl7Q"],
         "issued_at": "2018-06-27T13:09:58.412718Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:58 GMT
 - request:
     method: get
@@ -6643,7 +6643,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:58 GMT
 - request:
     method: post
@@ -6763,7 +6763,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["urzsj59hTW6sizG0kG57SA"],
         "issued_at": "2018-06-27T13:09:58.851231Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:58 GMT
 - request:
     method: get
@@ -6798,7 +6798,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:59 GMT
 - request:
     method: get
@@ -6833,7 +6833,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:59 GMT
 - request:
     method: get
@@ -6868,7 +6868,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:09:59 GMT
 - request:
     method: get
@@ -6903,7 +6903,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:00 GMT
 - request:
     method: get
@@ -6938,7 +6938,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:00 GMT
 - request:
     method: get
@@ -6973,11 +6973,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:00 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
+    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -7009,7 +7009,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:00 GMT
 - request:
     method: get
@@ -7044,11 +7044,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:01 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
+    uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -7080,7 +7080,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:01 GMT
 - request:
     method: get
@@ -7115,7 +7115,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:01 GMT
 - request:
     method: get
@@ -7150,7 +7150,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:01 GMT
 - request:
     method: get
@@ -7185,7 +7185,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:03 GMT
 - request:
     method: post
@@ -7305,7 +7305,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2ey0MG9sRteHbX0enUjkGg"],
         "issued_at": "2018-06-27T13:10:03.454687Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:04 GMT
 - request:
     method: post
@@ -7425,7 +7425,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Bb8XJhkUTDaK0ZTPGwaU4Q",
         "2ey0MG9sRteHbX0enUjkGg"], "issued_at": "2018-06-27T13:10:04.475440Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:04 GMT
 - request:
     method: post
@@ -7545,7 +7545,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y09FGnJgSN20wrKROlvlnw"],
         "issued_at": "2018-06-27T13:10:04.860582Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:04 GMT
 - request:
     method: post
@@ -7665,7 +7665,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RZyQP9MrRd-plctaN6JLCQ",
         "Y09FGnJgSN20wrKROlvlnw"], "issued_at": "2018-06-27T13:10:05.182627Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:05 GMT
 - request:
     method: get
@@ -7700,7 +7700,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:05 GMT
 - request:
     method: get
@@ -7763,7 +7763,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:05 GMT
 - request:
     method: get
@@ -7810,7 +7810,7 @@ http_interactions:
         "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -7845,7 +7845,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -7880,7 +7880,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -7915,7 +7915,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -7950,7 +7950,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -7995,7 +7995,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:06 GMT
 - request:
     method: get
@@ -8040,7 +8040,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8075,7 +8075,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8110,7 +8110,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8145,7 +8145,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8180,7 +8180,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8215,7 +8215,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8250,7 +8250,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8285,7 +8285,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:07 GMT
 - request:
     method: get
@@ -8320,7 +8320,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:08 GMT
 - request:
     method: get
@@ -8383,7 +8383,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:08 GMT
 - request:
     method: get
@@ -8454,7 +8454,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:08 GMT
 - request:
     method: get
@@ -8518,7 +8518,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:09 GMT
 - request:
     method: get
@@ -8553,7 +8553,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:09 GMT
 - request:
     method: post
@@ -8673,7 +8673,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eD1ESrEfRm2Krmpo1-_eCg"],
         "issued_at": "2018-06-27T13:10:11.189896Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:12 GMT
 - request:
     method: post
@@ -8793,7 +8793,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iF0FXVXgSde1h8kiLISptA"],
         "issued_at": "2018-06-27T13:10:12.934480Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:12 GMT
 - request:
     method: get
@@ -8891,7 +8891,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:13 GMT
 - request:
     method: post
@@ -9011,7 +9011,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xh49D8ZpRMWxfsQjqZlq0A"],
         "issued_at": "2018-06-27T13:10:13.590929Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:13 GMT
 - request:
     method: post
@@ -9051,7 +9051,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rC4hdd3uSgqw0HCQ5xxhiQ"],
         "issued_at": "2018-06-27T13:10:13.814387Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:13 GMT
 - request:
     method: get
@@ -9112,7 +9112,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:14 GMT
 - request:
     method: post
@@ -9232,7 +9232,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kQZ7BcEcSUqYbPg_MW6UyQ",
         "rC4hdd3uSgqw0HCQ5xxhiQ"], "issued_at": "2018-06-27T13:10:19.520916Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:19 GMT
 - request:
     method: get
@@ -9293,7 +9293,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:19 GMT
 - request:
     method: post
@@ -9413,7 +9413,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8KkHFtsVS8S57sS6iNbq-Q"],
         "issued_at": "2018-06-27T13:10:25.103002Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:26 GMT
 - request:
     method: post
@@ -9533,7 +9533,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gcjVGSUsS16dHdO79nQxlg"],
         "issued_at": "2018-06-27T13:10:26.870038Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:26 GMT
 - request:
     method: post
@@ -9653,7 +9653,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rRebWAtFR0ifn-oQUo6Fjg"],
         "issued_at": "2018-06-27T13:10:27.252768Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:27 GMT
 - request:
     method: post
@@ -9773,7 +9773,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LK7pgOLwTbaJZya5L82wng"],
         "issued_at": "2018-06-27T13:10:27.612502Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:27 GMT
 - request:
     method: post
@@ -9893,7 +9893,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ndBLzB0-RnyvtRdEaFVEsg"],
         "issued_at": "2018-06-27T13:10:27.966574Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:28 GMT
 - request:
     method: post
@@ -10013,7 +10013,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["44rsLzzMRtKlLDL-YTIiwA"],
         "issued_at": "2018-06-27T13:10:28.364090Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:28 GMT
 - request:
     method: post
@@ -10133,7 +10133,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1qN2b-CPT1-DobWWQxzsgA"],
         "issued_at": "2018-06-27T13:10:28.684472Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:28 GMT
 - request:
     method: get
@@ -10166,7 +10166,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:29 GMT
 - request:
     method: post
@@ -10286,7 +10286,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MqhS4f36TfegMbaefximFA"],
         "issued_at": "2018-06-27T13:10:29.557576Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:31 GMT
 - request:
     method: get
@@ -10319,7 +10319,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:31 GMT
 - request:
     method: post
@@ -10439,7 +10439,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QBSZ29EQRoS0oF-9V7pFsQ"],
         "issued_at": "2018-06-27T13:10:31.726413Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:31 GMT
 - request:
     method: get
@@ -10501,7 +10501,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:32 GMT
 - request:
     method: get
@@ -10534,7 +10534,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:32 GMT
 - request:
     method: post
@@ -10654,7 +10654,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X6ufTgLZTx-hY57PE9tqFw"],
         "issued_at": "2018-06-27T13:10:37.910396Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:38 GMT
 - request:
     method: get
@@ -10687,7 +10687,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:38 GMT
 - request:
     method: get
@@ -10720,7 +10720,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:38 GMT
 - request:
     method: post
@@ -10840,7 +10840,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XCbcbb7TQ5ezuIVmSrwOXA"],
         "issued_at": "2018-06-27T13:10:38.988879Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:39 GMT
 - request:
     method: get
@@ -10873,7 +10873,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:39 GMT
 - request:
     method: post
@@ -10993,7 +10993,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["He3S5XgdR9G0iFIAng858Q"],
         "issued_at": "2018-06-27T13:10:39.563336Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:41 GMT
 - request:
     method: get
@@ -11026,7 +11026,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:41 GMT
 - request:
     method: get
@@ -11081,7 +11081,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:42 GMT
 - request:
     method: get
@@ -11136,7 +11136,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:43 GMT
 - request:
     method: get
@@ -11191,7 +11191,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:44 GMT
 - request:
     method: get
@@ -11231,7 +11231,7 @@ http_interactions:
         "2016-08-19T08:38:12", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:44 GMT
 - request:
     method: get
@@ -11271,7 +11271,7 @@ http_interactions:
         "2016-08-19T08:38:10", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:44 GMT
 - request:
     method: get
@@ -11311,7 +11311,7 @@ http_interactions:
         "2016-08-19T08:38:07", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:44 GMT
 - request:
     method: get
@@ -11443,7 +11443,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:44 GMT
 - request:
     method: get
@@ -11575,7 +11575,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -11707,7 +11707,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -11839,7 +11839,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -11971,7 +11971,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -12103,7 +12103,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -12235,7 +12235,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -12305,7 +12305,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:45 GMT
 - request:
     method: get
@@ -12375,7 +12375,7 @@ http_interactions:
         "router_id": null, "fixed_ip_address": null, "floating_ip_address": "172.16.17.14",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:46 GMT
 - request:
     method: get
@@ -12806,7 +12806,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:46 GMT
 - request:
     method: get
@@ -13237,7 +13237,7 @@ http_interactions:
         "name": "", "admin_state_up": true, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:46 GMT
 - request:
     method: get
@@ -13297,7 +13297,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:46 GMT
 - request:
     method: get
@@ -13357,7 +13357,7 @@ http_interactions:
         "ip_address": "172.16.21.2"}]}, "name": "EmsRefreshSpec-Router_40", "admin_state_up":
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:46 GMT
 - request:
     method: get
@@ -13420,7 +13420,7 @@ http_interactions:
         "IPv6", "tenant_id": "4637c33fee924ebea81f8d209e452c91", "port_range_max":
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: get
@@ -13491,7 +13491,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "52c452d7763a4295950527948232a3e5",
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: get
@@ -13562,7 +13562,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "88ae57d444fd485ab2dfddd5a2615d52",
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: get
@@ -13697,7 +13697,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: get
@@ -13767,7 +13767,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv6", "tenant_id": "0098405163cd4c9dbb42c2cb43eb6fd3",
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: get
@@ -13801,7 +13801,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:47 GMT
 - request:
     method: post
@@ -13921,7 +13921,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mMx8iQ0WQ_e-DPQa5JV9Gw"],
         "issued_at": "2018-06-27T13:10:48.804678Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:48 GMT
 - request:
     method: post
@@ -14041,7 +14041,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JSKlAe50S8Ko9kFevscLrg"],
         "issued_at": "2018-06-27T13:10:49.154072Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:49 GMT
 - request:
     method: post
@@ -14081,7 +14081,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y3-jt16kRuOpRdUkrQykvg"],
         "issued_at": "2018-06-27T13:10:49.397008Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:49 GMT
 - request:
     method: get
@@ -14142,7 +14142,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:49 GMT
 - request:
     method: post
@@ -14262,7 +14262,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8AbYoA2ZSseJpMdvXZKkKg",
         "Y3-jt16kRuOpRdUkrQykvg"], "issued_at": "2018-06-27T13:10:49.947097Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:50 GMT
 - request:
     method: get
@@ -14323,7 +14323,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:50 GMT
 - request:
     method: post
@@ -14443,7 +14443,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h-xUYc-ZSNWg0Ol_IZWKOg"],
         "issued_at": "2018-06-27T13:10:51.352806Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:51 GMT
 - request:
     method: post
@@ -14563,7 +14563,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3JTmTaMEQR6uT55aWTWduQ"],
         "issued_at": "2018-06-27T13:10:51.944691Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:51 GMT
 - request:
     method: post
@@ -14683,7 +14683,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tWYZEIaSSCirObI1YmzL9w"],
         "issued_at": "2018-06-27T13:10:52.414878Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:52 GMT
 - request:
     method: post
@@ -14803,7 +14803,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8sSybfbwQ4-3V60ygeX96w"],
         "issued_at": "2018-06-27T13:10:52.744953Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:52 GMT
 - request:
     method: post
@@ -14923,7 +14923,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rswWImG2TgSaOe_CzoV92g"],
         "issued_at": "2018-06-27T13:10:53.110299Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:53 GMT
 - request:
     method: post
@@ -15043,7 +15043,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ABV6geP4TWq_qfmuBy_L2Q"],
         "issued_at": "2018-06-27T13:10:53.464580Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:53 GMT
 - request:
     method: post
@@ -15163,7 +15163,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BcyXhfq5QkKOqdkoJaj9kA"],
         "issued_at": "2018-06-27T13:10:53.825819Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:53 GMT
 - request:
     method: get
@@ -15198,7 +15198,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:54 GMT
 - request:
     method: post
@@ -15318,7 +15318,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ye_A-u9gQTqp5FhNKyVG3Q"],
         "issued_at": "2018-06-27T13:10:54.619879Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:54 GMT
 - request:
     method: get
@@ -15353,7 +15353,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:54 GMT
 - request:
     method: post
@@ -15473,7 +15473,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PdOHzMPrRCmxrhGzEaMrfw"],
         "issued_at": "2018-06-27T13:10:55.240812Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:55 GMT
 - request:
     method: get
@@ -15536,7 +15536,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:56 GMT
 - request:
     method: get
@@ -15607,7 +15607,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:58 GMT
 - request:
     method: get
@@ -15671,7 +15671,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:58 GMT
 - request:
     method: get
@@ -15706,7 +15706,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:58 GMT
 - request:
     method: post
@@ -15826,7 +15826,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["618jyYIlSRKyCQnvVke74w"],
         "issued_at": "2018-06-27T13:10:59.220853Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:59 GMT
 - request:
     method: get
@@ -15861,7 +15861,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:59 GMT
 - request:
     method: get
@@ -15896,7 +15896,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:10:59 GMT
 - request:
     method: post
@@ -16016,7 +16016,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x-n_lzzUSBq2_ktIwTkr3A"],
         "issued_at": "2018-06-27T13:11:00.125971Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:00 GMT
 - request:
     method: get
@@ -16051,7 +16051,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:00 GMT
 - request:
     method: post
@@ -16171,7 +16171,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8qoNkz-dRsWHe5MxievdRg"],
         "issued_at": "2018-06-27T13:11:00.885339Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:00 GMT
 - request:
     method: get
@@ -16206,7 +16206,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16241,7 +16241,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16276,7 +16276,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16311,7 +16311,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16346,7 +16346,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16391,7 +16391,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16436,7 +16436,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:01 GMT
 - request:
     method: get
@@ -16471,7 +16471,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16506,7 +16506,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16541,7 +16541,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16576,7 +16576,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16611,7 +16611,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16646,7 +16646,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16681,7 +16681,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:02 GMT
 - request:
     method: get
@@ -16716,7 +16716,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16751,7 +16751,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16786,7 +16786,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16821,7 +16821,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16856,7 +16856,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16891,7 +16891,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16926,7 +16926,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:03 GMT
 - request:
     method: get
@@ -16961,7 +16961,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -16996,7 +16996,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17031,7 +17031,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17066,7 +17066,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17101,7 +17101,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17136,7 +17136,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17171,7 +17171,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: get
@@ -17206,7 +17206,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:04 GMT
 - request:
     method: post
@@ -17326,7 +17326,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dEeBj1C_SbioiYovugqRFg"],
         "issued_at": "2018-06-27T13:11:05.033564Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:05 GMT
 - request:
     method: post
@@ -17446,7 +17446,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cDGzy3b-SxmFRdOjCVvZbg"],
         "issued_at": "2018-06-27T13:11:05.383449Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:05 GMT
 - request:
     method: post
@@ -17486,7 +17486,7 @@ http_interactions:
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
         "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cu-ND50mRPK-QRhv3Pftww"],
         "issued_at": "2018-06-27T13:11:05.657958Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:05 GMT
 - request:
     method: get
@@ -17547,7 +17547,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://11.22.33.44:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:05 GMT
 - request:
     method: post
@@ -17667,7 +17667,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0Ur__QjvSvCKQFJHTsLBBA",
         "cu-ND50mRPK-QRhv3Pftww"], "issued_at": "2018-06-27T13:11:06.184500Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:06 GMT
 - request:
     method: get
@@ -17728,7 +17728,7 @@ http_interactions:
         false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:06 GMT
 - request:
     method: post
@@ -17848,7 +17848,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yxeEm7kzTdGoYxBLoXlwDA"],
         "issued_at": "2018-06-27T13:11:06.851722Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:06 GMT
 - request:
     method: post
@@ -17968,7 +17968,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g6Xfa8FMTI-qCGqR4EjJYQ"],
         "issued_at": "2018-06-27T13:11:07.201605Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:07 GMT
 - request:
     method: post
@@ -18088,7 +18088,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6NlQOQfxT_C_x3XuFNMgKw"],
         "issued_at": "2018-06-27T13:11:07.529158Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:07 GMT
 - request:
     method: post
@@ -18208,7 +18208,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["34dFHA70SDiyzhhIuZ-HLQ"],
         "issued_at": "2018-06-27T13:11:07.867687Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:07 GMT
 - request:
     method: post
@@ -18328,7 +18328,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ddwVZfS8SJWbVhzrPREU1g"],
         "issued_at": "2018-06-27T13:11:08.436236Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:08 GMT
 - request:
     method: post
@@ -18448,7 +18448,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0PlTFvXPSaqkOOGeegHsvg"],
         "issued_at": "2018-06-27T13:11:09.951781Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:09 GMT
 - request:
     method: post
@@ -18568,7 +18568,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XXFLc-JvTMO0dXL_fREv3w"],
         "issued_at": "2018-06-27T13:11:10.495471Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:10 GMT
 - request:
     method: get
@@ -18611,7 +18611,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:10 GMT
 - request:
     method: post
@@ -18731,7 +18731,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lCmioK6YTYqYfFeZXiNbSw"],
         "issued_at": "2018-06-27T13:11:11.080481Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:11 GMT
 - request:
     method: get
@@ -18774,7 +18774,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:11 GMT
 - request:
     method: post
@@ -18894,7 +18894,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["18lOyP7MTkmKZcZit69bmg"],
         "issued_at": "2018-06-27T13:11:11.666252Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:11 GMT
 - request:
     method: get
@@ -18946,7 +18946,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:12 GMT
 - request:
     method: get
@@ -18997,7 +18997,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:12 GMT
 - request:
     method: post
@@ -19117,7 +19117,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ktpwmMPoTGempnJffxXbEA"],
         "issued_at": "2018-06-27T13:11:12.502096Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:12 GMT
 - request:
     method: get
@@ -19160,7 +19160,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:12 GMT
 - request:
     method: get
@@ -19203,7 +19203,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:12 GMT
 - request:
     method: post
@@ -19323,7 +19323,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["05mT19xPROOEVWbchNBCTw"],
         "issued_at": "2018-06-27T13:11:13.320493Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:13 GMT
 - request:
     method: get
@@ -19366,7 +19366,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:13 GMT
 - request:
     method: post
@@ -19486,7 +19486,7 @@ http_interactions:
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
         "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UhIMtov5Qk6fcPe_0jQwBw"],
         "issued_at": "2018-06-27T13:11:13.953831Z"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:13 GMT
 - request:
     method: get
@@ -19529,7 +19529,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:14 GMT
 - request:
     method: get
@@ -19577,7 +19577,7 @@ http_interactions:
         "bytes": 11, "name": "file_2", "content_type": "application/octet-stream"},
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:14 GMT
 - request:
     method: get
@@ -19620,7 +19620,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:14 GMT
 - request:
     method: get
@@ -19663,6 +19663,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:11:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -79,7 +79,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:54 GMT
 - request:
     method: get
@@ -114,7 +114,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:55 GMT
 - request:
     method: get
@@ -150,7 +150,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:55 GMT
 - request:
     method: post
@@ -231,7 +231,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:55 GMT
 - request:
     method: get
@@ -267,7 +267,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:56 GMT
 - request:
     method: post
@@ -306,7 +306,7 @@ http_interactions:
         ["6OJ1b-AmSRyejsOgNO1JBw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:56 GMT
 - request:
     method: get
@@ -351,7 +351,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:56 GMT
 - request:
     method: post
@@ -432,7 +432,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: get
@@ -477,7 +477,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: post
@@ -557,7 +557,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: get
@@ -592,7 +592,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: post
@@ -672,7 +672,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: get
@@ -707,7 +707,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: post
@@ -787,7 +787,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:57 GMT
 - request:
     method: get
@@ -822,7 +822,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:58 GMT
 - request:
     method: get
@@ -869,7 +869,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:58 GMT
 - request:
     method: get
@@ -916,7 +916,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:58 GMT
 - request:
     method: get
@@ -963,7 +963,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:58 GMT
 - request:
     method: get
@@ -1010,7 +1010,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:58 GMT
 - request:
     method: get
@@ -1057,7 +1057,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1104,7 +1104,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1151,7 +1151,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1198,7 +1198,7 @@ http_interactions:
         "2018-06-27T13:14:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
         "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-06-27T13:14:53.000000"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1242,7 +1242,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1286,7 +1286,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:14:59 GMT
 - request:
     method: get
@@ -1331,7 +1331,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1371,7 +1371,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 16384, "OS-FLV-DISABLED:disabled": false, "vcpus":
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1415,7 +1415,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1459,7 +1459,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1504,7 +1504,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1539,7 +1539,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1583,7 +1583,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1627,7 +1627,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:00 GMT
 - request:
     method: get
@@ -1672,7 +1672,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:01 GMT
 - request:
     method: get
@@ -1707,7 +1707,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:01 GMT
 - request:
     method: get
@@ -1751,7 +1751,7 @@ http_interactions:
         1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=2",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:01 GMT
 - request:
     method: get
@@ -1795,7 +1795,7 @@ http_interactions:
         4, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=4",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:01 GMT
 - request:
     method: get
@@ -1840,7 +1840,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/flavors/detail?limit=1000&marker=6",
         "rel": "next"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:02 GMT
 - request:
     method: get
@@ -1875,7 +1875,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:02 GMT
 - request:
     method: get
@@ -1911,7 +1911,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:02 GMT
 - request:
     method: post
@@ -1992,7 +1992,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:02 GMT
 - request:
     method: get
@@ -2031,7 +2031,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:03 GMT
 - request:
     method: post
@@ -2111,7 +2111,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:03 GMT
 - request:
     method: get
@@ -2181,7 +2181,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:03 GMT
 - request:
     method: get
@@ -2214,7 +2214,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:03 GMT
 - request:
     method: post
@@ -2294,7 +2294,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:04 GMT
 - request:
     method: get
@@ -2364,7 +2364,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:04 GMT
 - request:
     method: get
@@ -2397,7 +2397,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:04 GMT
 - request:
     method: get
@@ -2467,7 +2467,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:05 GMT
 - request:
     method: get
@@ -2500,7 +2500,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:05 GMT
 - request:
     method: post
@@ -2580,7 +2580,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:05 GMT
 - request:
     method: get
@@ -2650,7 +2650,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2683,7 +2683,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2723,7 +2723,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2763,7 +2763,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2803,7 +2803,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2843,7 +2843,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2883,7 +2883,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2923,7 +2923,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:06 GMT
 - request:
     method: get
@@ -2963,7 +2963,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:07 GMT
 - request:
     method: get
@@ -3003,7 +3003,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:07 GMT
 - request:
     method: post
@@ -3084,7 +3084,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:07 GMT
 - request:
     method: post
@@ -3164,7 +3164,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:07 GMT
 - request:
     method: get
@@ -3226,7 +3226,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:08 GMT
 - request:
     method: get
@@ -3259,7 +3259,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:08 GMT
 - request:
     method: post
@@ -3339,7 +3339,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:08 GMT
 - request:
     method: get
@@ -3372,7 +3372,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:09 GMT
 - request:
     method: get
@@ -3405,7 +3405,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:09 GMT
 - request:
     method: post
@@ -3485,7 +3485,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:10 GMT
 - request:
     method: get
@@ -3518,7 +3518,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:10 GMT
 - request:
     method: get
@@ -3573,7 +3573,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:11 GMT
 - request:
     method: get
@@ -3628,7 +3628,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:12 GMT
 - request:
     method: get
@@ -3683,7 +3683,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:12 GMT
 - request:
     method: get
@@ -3767,7 +3767,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:13 GMT
 - request:
     method: get
@@ -3807,7 +3807,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:13 GMT
 - request:
     method: get
@@ -3883,7 +3883,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:13 GMT
 - request:
     method: get
@@ -3959,7 +3959,7 @@ http_interactions:
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:14 GMT
 - request:
     method: get
@@ -4037,7 +4037,7 @@ http_interactions:
         {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:15 GMT
 - request:
     method: get
@@ -4109,7 +4109,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:15 GMT
 - request:
     method: get
@@ -4162,7 +4162,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [],
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:16 GMT
 - request:
     method: get
@@ -4197,7 +4197,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:16 GMT
 - request:
     method: get
@@ -4232,7 +4232,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4267,7 +4267,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4351,7 +4351,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4391,7 +4391,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4475,7 +4475,7 @@ http_interactions:
         -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4515,7 +4515,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:17 GMT
 - request:
     method: get
@@ -4554,7 +4554,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "69f8f7205ade4aa59084c32c83e60b5a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:18 GMT
 - request:
     method: get
@@ -4593,7 +4593,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "b458a5c25c3749758f4c0661940b3ba8", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:18 GMT
 - request:
     method: get
@@ -4632,7 +4632,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:18 GMT
 - request:
     method: get
@@ -4671,7 +4671,7 @@ http_interactions:
         10, "key_pairs": 100, "id": "e8f744b1fc6a487681d35fb275252608", "instances":
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:18 GMT
 - request:
     method: post
@@ -4751,7 +4751,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:18 GMT
 - request:
     method: get
@@ -4791,7 +4791,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:19 GMT
 - request:
     method: post
@@ -4871,7 +4871,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:21 GMT
 - request:
     method: get
@@ -4911,7 +4911,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:22 GMT
 - request:
     method: get
@@ -4951,7 +4951,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:23 GMT
 - request:
     method: post
@@ -5031,7 +5031,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:23 GMT
 - request:
     method: get
@@ -5071,7 +5071,7 @@ http_interactions:
         -1, "volumes_iscsi": -1, "volumes": 10, "volumes_random": -1, "gigabytes_random":
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:24 GMT
 - request:
     method: post
@@ -5152,7 +5152,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:25 GMT
 - request:
     method: get
@@ -5184,7 +5184,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:25 GMT
 - request:
     method: post
@@ -5264,7 +5264,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:25 GMT
 - request:
     method: get
@@ -5299,7 +5299,7 @@ http_interactions:
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:25 GMT
 - request:
     method: post
@@ -5379,7 +5379,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:25 GMT
 - request:
     method: get
@@ -5414,7 +5414,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:26 GMT
 - request:
     method: get
@@ -5449,7 +5449,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:26 GMT
 - request:
     method: post
@@ -5529,7 +5529,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:26 GMT
 - request:
     method: get
@@ -5564,7 +5564,7 @@ http_interactions:
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:27 GMT
 - request:
     method: get
@@ -5617,7 +5617,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:27 GMT
 - request:
     method: get
@@ -5670,7 +5670,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:27 GMT
 - request:
     method: get
@@ -5723,7 +5723,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:28 GMT
 - request:
     method: get
@@ -5776,7 +5776,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:28 GMT
 - request:
     method: get
@@ -5829,11 +5829,11 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:29 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -5865,7 +5865,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:29 GMT
 - request:
     method: get
@@ -5918,11 +5918,11 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:29 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -5954,7 +5954,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:29 GMT
 - request:
     method: get
@@ -6007,7 +6007,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:30 GMT
 - request:
     method: get
@@ -6060,7 +6060,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:31 GMT
 - request:
     method: get
@@ -6113,7 +6113,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": "ca1fc357-ee31-45e9-a38d-98723d6c8876",
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:31 GMT
 - request:
     method: post
@@ -6194,7 +6194,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:31 GMT
 - request:
     method: post
@@ -6275,7 +6275,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:32 GMT
 - request:
     method: post
@@ -6356,7 +6356,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:32 GMT
 - request:
     method: post
@@ -6437,7 +6437,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:32 GMT
 - request:
     method: get
@@ -6472,7 +6472,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:32 GMT
 - request:
     method: get
@@ -6535,7 +6535,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:33 GMT
 - request:
     method: get
@@ -6582,7 +6582,7 @@ http_interactions:
         "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:33 GMT
 - request:
     method: get
@@ -6617,7 +6617,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:34 GMT
 - request:
     method: get
@@ -6652,7 +6652,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:34 GMT
 - request:
     method: get
@@ -6687,7 +6687,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:34 GMT
 - request:
     method: get
@@ -6732,7 +6732,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:34 GMT
 - request:
     method: get
@@ -6777,7 +6777,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:34 GMT
 - request:
     method: get
@@ -6812,7 +6812,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -6847,7 +6847,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -6882,7 +6882,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -6917,7 +6917,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -6952,7 +6952,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -6987,7 +6987,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:35 GMT
 - request:
     method: get
@@ -7050,7 +7050,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:36 GMT
 - request:
     method: get
@@ -7121,7 +7121,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:36 GMT
 - request:
     method: get
@@ -7185,7 +7185,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:36 GMT
 - request:
     method: get
@@ -7220,7 +7220,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:37 GMT
 - request:
     method: get
@@ -7255,7 +7255,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:37 GMT
 - request:
     method: get
@@ -7290,7 +7290,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:37 GMT
 - request:
     method: get
@@ -7325,7 +7325,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:37 GMT
 - request:
     method: post
@@ -7406,7 +7406,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:39 GMT
 - request:
     method: post
@@ -7487,7 +7487,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:39 GMT
 - request:
     method: get
@@ -7585,7 +7585,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:39 GMT
 - request:
     method: post
@@ -7666,7 +7666,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:40 GMT
 - request:
     method: post
@@ -7705,7 +7705,7 @@ http_interactions:
         ["xYVhfZebSYKwYBGKNIxkHA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:40 GMT
 - request:
     method: get
@@ -7750,7 +7750,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:40 GMT
 - request:
     method: post
@@ -7831,7 +7831,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:40 GMT
 - request:
     method: get
@@ -7876,7 +7876,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:40 GMT
 - request:
     method: post
@@ -7956,7 +7956,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:41 GMT
 - request:
     method: post
@@ -8036,7 +8036,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:41 GMT
 - request:
     method: post
@@ -8116,7 +8116,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:41 GMT
 - request:
     method: post
@@ -8196,7 +8196,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:42 GMT
 - request:
     method: get
@@ -8258,7 +8258,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:42 GMT
 - request:
     method: get
@@ -8291,7 +8291,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:42 GMT
 - request:
     method: post
@@ -8371,7 +8371,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:43 GMT
 - request:
     method: get
@@ -8404,7 +8404,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:43 GMT
 - request:
     method: get
@@ -8437,7 +8437,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:43 GMT
 - request:
     method: post
@@ -8517,7 +8517,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:44 GMT
 - request:
     method: get
@@ -8550,7 +8550,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:44 GMT
 - request:
     method: get
@@ -8605,7 +8605,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:45 GMT
 - request:
     method: get
@@ -8660,7 +8660,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:46 GMT
 - request:
     method: get
@@ -8715,7 +8715,7 @@ http_interactions:
         for heat-cfntools in the image. WordPress is web software you can use to create
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:47 GMT
 - request:
     method: get
@@ -8755,7 +8755,7 @@ http_interactions:
         "2016-11-11T13:50:13", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:47 GMT
 - request:
     method: get
@@ -8795,7 +8795,7 @@ http_interactions:
         "2016-11-11T13:50:11", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:47 GMT
 - request:
     method: get
@@ -8835,7 +8835,7 @@ http_interactions:
         "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:47 GMT
 - request:
     method: post
@@ -8915,7 +8915,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:48 GMT
 - request:
     method: get
@@ -9047,7 +9047,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:48 GMT
 - request:
     method: get
@@ -9179,7 +9179,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:48 GMT
 - request:
     method: post
@@ -9259,7 +9259,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:49 GMT
 - request:
     method: get
@@ -9391,7 +9391,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:50 GMT
 - request:
     method: get
@@ -9523,7 +9523,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:50 GMT
 - request:
     method: get
@@ -9655,7 +9655,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:50 GMT
 - request:
     method: get
@@ -9787,7 +9787,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:51 GMT
 - request:
     method: get
@@ -9919,7 +9919,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:51 GMT
 - request:
     method: get
@@ -10051,7 +10051,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:51 GMT
 - request:
     method: post
@@ -10131,7 +10131,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:51 GMT
 - request:
     method: get
@@ -10263,7 +10263,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10395,7 +10395,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10465,7 +10465,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10535,7 +10535,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10605,7 +10605,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10675,7 +10675,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10745,7 +10745,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10815,7 +10815,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10885,7 +10885,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -10955,7 +10955,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:52 GMT
 - request:
     method: get
@@ -11386,7 +11386,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:53 GMT
 - request:
     method: get
@@ -11817,7 +11817,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:53 GMT
 - request:
     method: get
@@ -12248,7 +12248,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:53 GMT
 - request:
     method: get
@@ -12679,7 +12679,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:53 GMT
 - request:
     method: get
@@ -13110,7 +13110,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:54 GMT
 - request:
     method: get
@@ -13541,7 +13541,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:54 GMT
 - request:
     method: get
@@ -13972,7 +13972,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:54 GMT
 - request:
     method: get
@@ -14403,7 +14403,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:54 GMT
 - request:
     method: get
@@ -14463,7 +14463,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:56 GMT
 - request:
     method: get
@@ -14523,7 +14523,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:56 GMT
 - request:
     method: get
@@ -14583,7 +14583,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:56 GMT
 - request:
     method: get
@@ -14643,7 +14643,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -14703,7 +14703,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -14763,7 +14763,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -14823,7 +14823,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -14883,7 +14883,7 @@ http_interactions:
         "ip_address": "172.16.19.21"}]}, "name": "EmsRefreshSpec-Router_20", "admin_state_up":
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -14953,7 +14953,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:57 GMT
 - request:
     method: get
@@ -15024,7 +15024,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:58 GMT
 - request:
     method: get
@@ -15087,7 +15087,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:58 GMT
 - request:
     method: get
@@ -15202,7 +15202,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:58 GMT
 - request:
     method: get
@@ -15272,7 +15272,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:58 GMT
 - request:
     method: get
@@ -15343,7 +15343,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:58 GMT
 - request:
     method: get
@@ -15406,7 +15406,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15521,7 +15521,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15591,7 +15591,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15662,7 +15662,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15725,7 +15725,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15840,7 +15840,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15910,7 +15910,7 @@ http_interactions:
         "IPv6", "tenant_id": "b458a5c25c3749758f4c0661940b3ba8", "port_range_max":
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:15:59 GMT
 - request:
     method: get
@@ -15981,7 +15981,7 @@ http_interactions:
         null, "protocol": null, "ethertype": "IPv4", "tenant_id": "e54e5c3c19e34720b05661f2ea1ea00a",
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:00 GMT
 - request:
     method: get
@@ -16044,7 +16044,7 @@ http_interactions:
         "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:00 GMT
 - request:
     method: get
@@ -16159,7 +16159,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:00 GMT
 - request:
     method: post
@@ -16240,7 +16240,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:01 GMT
 - request:
     method: post
@@ -16321,7 +16321,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:01 GMT
 - request:
     method: post
@@ -16360,7 +16360,7 @@ http_interactions:
         ["8yPBqSa0SE-B_ZR9J5aMBQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:01 GMT
 - request:
     method: get
@@ -16405,7 +16405,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:01 GMT
 - request:
     method: post
@@ -16486,7 +16486,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:02 GMT
 - request:
     method: get
@@ -16531,7 +16531,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:02 GMT
 - request:
     method: post
@@ -16611,7 +16611,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:02 GMT
 - request:
     method: post
@@ -16691,7 +16691,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:02 GMT
 - request:
     method: post
@@ -16771,7 +16771,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:02 GMT
 - request:
     method: post
@@ -16851,7 +16851,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:03 GMT
 - request:
     method: get
@@ -16914,7 +16914,7 @@ http_interactions:
         null, "source_volid": null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id":
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:03 GMT
 - request:
     method: get
@@ -16985,7 +16985,7 @@ http_interactions:
         null, "consistencygroup_id": null, "os-vol-mig-status-attr:name_id": null,
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:03 GMT
 - request:
     method: get
@@ -17049,7 +17049,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:04 GMT
 - request:
     method: get
@@ -17084,7 +17084,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:04 GMT
 - request:
     method: post
@@ -17164,7 +17164,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:04 GMT
 - request:
     method: get
@@ -17199,7 +17199,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:05 GMT
 - request:
     method: get
@@ -17234,7 +17234,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:06 GMT
 - request:
     method: post
@@ -17314,7 +17314,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:06 GMT
 - request:
     method: get
@@ -17349,7 +17349,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:07 GMT
 - request:
     method: get
@@ -17394,7 +17394,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:07 GMT
 - request:
     method: get
@@ -17439,7 +17439,7 @@ http_interactions:
         "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:07 GMT
 - request:
     method: get
@@ -17474,7 +17474,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:07 GMT
 - request:
     method: get
@@ -17509,7 +17509,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:07 GMT
 - request:
     method: get
@@ -17544,7 +17544,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:08 GMT
 - request:
     method: get
@@ -17579,7 +17579,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:08 GMT
 - request:
     method: get
@@ -17614,7 +17614,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:08 GMT
 - request:
     method: get
@@ -17649,7 +17649,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:08 GMT
 - request:
     method: get
@@ -17684,7 +17684,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:08 GMT
 - request:
     method: get
@@ -17719,7 +17719,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17754,7 +17754,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17789,7 +17789,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17824,7 +17824,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17859,7 +17859,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17894,7 +17894,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: get
@@ -17929,7 +17929,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:09 GMT
 - request:
     method: post
@@ -18010,7 +18010,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:10 GMT
 - request:
     method: post
@@ -18091,7 +18091,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:10 GMT
 - request:
     method: post
@@ -18130,7 +18130,7 @@ http_interactions:
         ["rg4Yd_DWQ7G19dgHEpA9TQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:10 GMT
 - request:
     method: get
@@ -18175,7 +18175,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:10 GMT
 - request:
     method: post
@@ -18256,7 +18256,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:11 GMT
 - request:
     method: get
@@ -18301,7 +18301,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:11 GMT
 - request:
     method: post
@@ -18381,7 +18381,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:11 GMT
 - request:
     method: post
@@ -18461,7 +18461,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:11 GMT
 - request:
     method: post
@@ -18541,7 +18541,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:12 GMT
 - request:
     method: post
@@ -18621,7 +18621,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:12 GMT
 - request:
     method: get
@@ -18673,7 +18673,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:12 GMT
 - request:
     method: get
@@ -18724,7 +18724,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:12 GMT
 - request:
     method: post
@@ -18804,7 +18804,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:12 GMT
 - request:
     method: get
@@ -18847,7 +18847,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:13 GMT
 - request:
     method: get
@@ -18890,7 +18890,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:13 GMT
 - request:
     method: post
@@ -18970,7 +18970,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:14 GMT
 - request:
     method: get
@@ -19013,7 +19013,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19061,7 +19061,7 @@ http_interactions:
         "bytes": 11, "name": "file_2", "content_type": "application/octet-stream"},
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19104,7 +19104,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19147,7 +19147,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19185,7 +19185,7 @@ http_interactions:
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19317,7 +19317,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:15 GMT
 - request:
     method: get
@@ -19449,7 +19449,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:16 GMT
 - request:
     method: get
@@ -19581,7 +19581,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:16 GMT
 - request:
     method: get
@@ -19713,7 +19713,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:17 GMT
 - request:
     method: get
@@ -19845,7 +19845,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:17 GMT
 - request:
     method: get
@@ -19977,7 +19977,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:17 GMT
 - request:
     method: get
@@ -20109,7 +20109,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20241,7 +20241,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20373,7 +20373,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20505,7 +20505,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20637,7 +20637,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20769,7 +20769,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:18 GMT
 - request:
     method: get
@@ -20901,7 +20901,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:19 GMT
 - request:
     method: get
@@ -21033,6 +21033,6 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:19 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -79,7 +79,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:37 GMT
 - request:
     method: get
@@ -114,7 +114,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:37 GMT
 - request:
     method: get
@@ -171,7 +171,7 @@ http_interactions:
         {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:38 GMT
 - request:
     method: get
@@ -209,7 +209,7 @@ http_interactions:
         "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.5"}], "port_id":
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:39 GMT
 - request:
     method: get
@@ -291,7 +291,7 @@ http_interactions:
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "id": "e4836528-d0df-425e-a117-ae8ec6f356d4",
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:39 GMT
 - request:
     method: get
@@ -326,7 +326,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:39 GMT
 - request:
     method: post
@@ -407,7 +407,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:39 GMT
 - request:
     method: get
@@ -439,7 +439,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:39 GMT
 - request:
     method: get
@@ -476,7 +476,7 @@ http_interactions:
         "floating_ip_address": "172.16.17.4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:40 GMT
 - request:
     method: post
@@ -557,7 +557,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:40 GMT
 - request:
     method: get
@@ -602,7 +602,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:40 GMT
 - request:
     method: get
@@ -641,7 +641,7 @@ http_interactions:
         "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:40 GMT
 - request:
     method: post
@@ -722,7 +722,7 @@ http_interactions:
         {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
@@ -761,7 +761,7 @@ http_interactions:
         "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
@@ -800,7 +800,7 @@ http_interactions:
         false, "id": "bb799f70-5e02-461b-8324-17ee88259c7b", "file": "/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/file",
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
@@ -840,7 +840,7 @@ http_interactions:
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
@@ -879,11 +879,11 @@ http_interactions:
         "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -915,7 +915,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:41 GMT
 - request:
     method: get
@@ -953,7 +953,7 @@ http_interactions:
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:42 GMT
 - request:
     method: get
@@ -991,7 +991,7 @@ http_interactions:
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:42 GMT
 - request:
     method: post
@@ -1030,7 +1030,7 @@ http_interactions:
         ["rkeEpp5WTviGvfSBHNOx-A"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:42 GMT
 - request:
     method: get
@@ -1075,7 +1075,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:42 GMT
 - request:
     method: post
@@ -1156,7 +1156,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:43 GMT
 - request:
     method: get
@@ -1201,7 +1201,7 @@ http_interactions:
         "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:43 GMT
 - request:
     method: post
@@ -1281,7 +1281,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:43 GMT
 - request:
     method: get
@@ -1316,7 +1316,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:43 GMT
 - request:
     method: post
@@ -1396,7 +1396,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: get
@@ -1431,7 +1431,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: post
@@ -1511,7 +1511,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: get
@@ -1546,7 +1546,7 @@ http_interactions:
         "", "version": "", "id": "v2.0"}, {"status": "CURRENT", "updated": "2013-07-23T11:33:21Z",
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: post
@@ -1626,7 +1626,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: get
@@ -1758,7 +1758,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:44 GMT
 - request:
     method: get
@@ -1890,7 +1890,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:45 GMT
 - request:
     method: post
@@ -1970,7 +1970,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:45 GMT
 - request:
     method: get
@@ -2102,7 +2102,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:45 GMT
 - request:
     method: get
@@ -2234,7 +2234,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:45 GMT
 - request:
     method: get
@@ -2366,7 +2366,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:46 GMT
 - request:
     method: get
@@ -2498,7 +2498,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:46 GMT
 - request:
     method: get
@@ -2630,7 +2630,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:46 GMT
 - request:
     method: get
@@ -2762,7 +2762,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:46 GMT
 - request:
     method: get
@@ -2894,7 +2894,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:47 GMT
 - request:
     method: get
@@ -3026,7 +3026,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:47 GMT
 - request:
     method: post
@@ -3106,7 +3106,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:47 GMT
 - request:
     method: get
@@ -3238,7 +3238,7 @@ http_interactions:
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:47 GMT
 - request:
     method: get
@@ -3370,7 +3370,7 @@ http_interactions:
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:47 GMT
 - request:
     method: get
@@ -3502,7 +3502,7 @@ http_interactions:
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3545,7 +3545,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {"port_filter": true, "ovs_hybrid_plug":
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3609,7 +3609,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3673,7 +3673,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3737,7 +3737,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3801,7 +3801,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:48 GMT
 - request:
     method: get
@@ -3865,7 +3865,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -3929,7 +3929,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -3993,7 +3993,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -4057,7 +4057,7 @@ http_interactions:
         "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -4094,7 +4094,7 @@ http_interactions:
         [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}]},
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -4208,7 +4208,7 @@ http_interactions:
         "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: get
@@ -4250,7 +4250,7 @@ http_interactions:
         "protocol": null, "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:49 GMT
 - request:
     method: post
@@ -4330,7 +4330,7 @@ http_interactions:
         [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:50 GMT
 - request:
     method: get
@@ -4381,7 +4381,7 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:50 GMT
 - request:
     method: get
@@ -4432,6 +4432,6 @@ http_interactions:
         null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jun 2018 13:16:50 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Also fixes vcr cassettes to work with fog-openstack 0.1.27 because of redudant `/` in Compute which was fixed by https://github.com/fog/fog-openstack/commit/19fff350b3d5af3f7108da7bbc4bc8b8463aebfa

Required to support:
https://bugzilla.redhat.com/show_bug.cgi?id=1596320
https://bugzilla.redhat.com/show_bug.cgi?id=1589766