### PR TITLE
Require hostname if provider is enabled

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -54,6 +54,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   before_update :ensure_managers_zone_and_provider_region
 
+  def hostname_required?
+    enabled?
+  end
+
   def ensure_managers_zone_and_provider_region
     if network_manager
       network_manager.zone_id         = zone_id


### PR DESCRIPTION
This should prevent requiring hostname during deletion.
https://bugzilla.redhat.com/show_bug.cgi?id=1590204