### PR TITLE
Targeted refresh workaround for events that don't identify objects

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
@@ -32,6 +32,8 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
       collect_image_references!(target_collection, ems_event)
     elsif ems_event.event_type.start_with?("aggregate.")
       collect_host_aggregate_references!(target_collection, ems_event)
+    elsif ems_event.event_type.start_with?("keypair")
+      collect_key_pair_references!(target_collection, ems_event)
     end
 
     target_collection.targets
@@ -72,5 +74,9 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
     aggregate_id = ems_event.full_data.fetch_path(:content, 'payload', 'service')
     aggregate_id&.sub!('aggregate.', '')
     add_target(target_collection, :host_aggregates, aggregate_id) if aggregate_id
+  end
+
+  def collect_key_pair_references!(target_collection, _ems_event)
+    add_target(target_collection, :key_pairs, nil)
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -124,8 +124,14 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
       builder.add_properties(
         :model_class => ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair,
       )
-
-      builder.add_default_values(:resource => manager) unless targeted?
+      # targeted refresh workaround-- always refresh the whole keypair collection
+      # regardless of whether this is a TargetCollection or not
+      # because OpenStack doesn't give us UUIDs of changed keypairs,
+      # we just get an event that one of them changed
+      if references(:key_pairs).present?
+        builder.add_properties(:targeted => false)
+      end
+      builder.add_default_values(:resource => manager)
     end
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/storage_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/storage_collections.rb
@@ -4,7 +4,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Storag
   def initialize_storage_inventory_collections
     %i(cloud_volumes
        cloud_volume_snapshots
-       cloud_volume_backups
        cloud_volume_types
        ).each do |name|
 
@@ -15,6 +14,25 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Storag
         else
           builder.add_default_values(:ems_id => manager.id)
         end
+      end
+    end
+    add_cloud_volume_backups
+  end
+
+  def add_cloud_volume_backups(extra_properties = {})
+    add_collection(cloud, :cloud_volume_backups, extra_properties) do |builder|
+      if targeted?
+        builder.add_properties(:parent => manager.cinder_manager)
+        builder.add_default_values(:ems_id => manager.cinder_manager.try(:id))
+      else
+        builder.add_default_values(:ems_id => manager.id)
+      end
+      # targeted refresh workaround-- always refresh the whole backup collection
+      # regardless of whether this is a TargetCollection or not
+      # because OpenStack doesn't give us UUIDs of changed volume_backups,
+      # we just get an event that one of them changed
+      if references(:cloud_volume_backups).present?
+        builder.add_properties(:targeted => false)
       end
     end
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
@@ -46,12 +46,11 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
     add_target(target_collection, :cloud_volumes, volume_id, :tenant_id => tenant_id) if volume_id
   end
 
-  def collect_backup_references!(target_collection, ems_event)
-    tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'project_id')
-    resource_id = ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
-    add_target(target_collection, :cloud_volume_backups, resource_id, :tenant_id => tenant_id) if resource_id
-    volume_id = ems_event.full_data.fetch_path(:content, 'payload', 'volume_id')
-    add_target(target_collection, :cloud_volumes, volume_id, :tenant_id => tenant_id) if volume_id
+  def collect_backup_references!(target_collection, _ems_event)
+    # backup notifications from panko don't include IDs, so we can't target
+    # a single backup. Add a dummy backup target which will allow us to collect
+    # all backups as a workaround.
+    add_target(target_collection, :cloud_volume_backups, nil)
   end
 
   def parsed_targets(target_collection = {})

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_spec.rb
@@ -81,11 +81,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
     it "will perform a targeted VM refresh against RHOS #{@environment}" do
       # EmsRefreshSpec-PoweredOn
       vm_target = ManagerRefresh::Target.new(:manager => @ems, :association => :vms, :manager_ref => {:ems_ref => "ca4f3a16-bae3-4407-83e9-f77b28af0f2b"})
-      2.times do # Run twice to verify that a second run with existing data does not change anything
-        with_cassette("#{@environment}_vm_targeted_refresh", @ems) do
-          EmsRefresh.refresh(vm_target)
-          assert_targeted_vm("EmsRefreshSpec-PoweredOn", :power_state => "on",)
-        end
+      # Run twice to verify that a second run with existing data does not change anything.
+      with_cassette("#{@environment}_vm_targeted_refresh", @ems) do
+        EmsRefresh.refresh(vm_target)
+        assert_targeted_vm("EmsRefreshSpec-PoweredOn", :power_state => "on",)
+        EmsRefresh.refresh(vm_target)
+        assert_targeted_vm("EmsRefreshSpec-PoweredOn", :power_state => "on",)
       end
     end
 

--- a/spec/models/manageiq/providers/openstack/openstack_stubs.rb
+++ b/spec/models/manageiq/providers/openstack/openstack_stubs.rb
@@ -24,6 +24,7 @@ module OpenstackStubs
       :vms_count                       => scaling * 10,
       :volume_templates_count          => scaling * 10,
       :volume_snapshot_templates_count => scaling * 10,
+      :cloud_volume_backups_count      => scaling * 10,
     }
   end
 
@@ -264,5 +265,16 @@ module OpenstackStubs
       )
     end
     mocked_volume_snapshot_templates
+  end
+
+  def mocked_cloud_volume_backups
+    mocked_cloud_volume_backups = []
+    test_counts[:cloud_volume_backups_count].times do |i|
+      mocked_cloud_volume_backups << OpenStruct.new(
+        :id   => "cloud_volume_backup_#{i}",
+        :name => "cloud_volume_backup_#{i}",
+      )
+    end
+    mocked_cloud_volume_backups
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:12 GMT
+      - Mon, 06 Aug 2018 16:57:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f7733be-65d1-4c63-8467-cefd9f4e349e
+      - req-e44905d6-64b2-41b2-b489-ec8ed0268454
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:13.167603", "expires":
-        "2018-08-03T20:33:13Z", "id": "ab435abb74f040c29989a1ede2bb70e5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:14.384528", "expires":
+        "2018-08-06T17:57:14Z", "id": "078eaa69e9c543878ec7c68aecb0c5e8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jpjFfGalQoCcSXIpTTu4zg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["l9qbFqv6Q526yrzzPruQrA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:33:13 GMT
+      - Mon, 06 Aug 2018 16:57:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-9ce1a2c2-8256-42ef-a0e4-9c3ce5a34245
+      - req-8cdaca07-9993-4cf5-897c-838216b40f5c
       Date:
-      - Fri, 03 Aug 2018 19:33:14 GMT
+      - Mon, 06 Aug 2018 16:57:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:14 GMT
+      - Mon, 06 Aug 2018 16:57:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bf9ccc07-47c9-4476-81b6-61587ed5243d
+      - req-7fa3c2ea-c8e4-4447-9eb9-224e11622701
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:14.651440", "expires":
-        "2018-08-03T20:33:14Z", "id": "b85548844eab4b3ba62305cc7a2c5b34", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:15.212709", "expires":
+        "2018-08-06T17:57:15Z", "id": "0ba8b8791b9e44aa94346ec3c8eb29a6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["U_6BTcuRQ3Oi8f9B_nJqyA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["alQEUIb0R_y_f53JMo6WsQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c8e057e-4275-441f-ab4a-0387f66c5791
+      - req-1199358b-e037-4d08-b6b5-24d94144f4ef
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-2c8e057e-4275-441f-ab4a-0387f66c5791
+      - req-1199358b-e037-4d08-b6b5-24d94144f4ef
       Date:
-      - Fri, 03 Aug 2018 19:33:15 GMT
+      - Mon, 06 Aug 2018 16:57:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:15 GMT
+      - Mon, 06 Aug 2018 16:57:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbc6b416-4e6b-4b78-ade9-1d279f869036
+      - req-01e3b811-ef86-42fc-84bd-f7d61a3030bf
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:15.728394", "expires":
-        "2018-08-03T20:33:15Z", "id": "9790f95a4fa843ea8652f5ec50a701ce", "audit_ids":
-        ["_QrpjMBmRIuAqTWjFezMrw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:15.758472", "expires":
+        "2018-08-06T17:57:15Z", "id": "5476d7db35b64f88a1fe7b6e6700830f", "audit_ids":
+        ["X_IQ4sMLRTasVgrw8_VNrg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9790f95a4fa843ea8652f5ec50a701ce
+      - 5476d7db35b64f88a1fe7b6e6700830f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:15 GMT
+      - Mon, 06 Aug 2018 16:57:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-15fcb111-98bf-41af-aa2a-1c4dabad119e
+      - req-1d16d7d3-08d5-4a77-8047-8573ec791ae1
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9790f95a4fa843ea8652f5ec50a701ce"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"5476d7db35b64f88a1fe7b6e6700830f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:16 GMT
+      - Mon, 06 Aug 2018 16:57:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-807b4af9-9f6d-40fa-b7b1-6519e041eddc
+      - req-37ed4162-aba6-4c03-ac27-11b9030d30e6
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:16.235303", "expires":
-        "2018-08-03T20:33:15Z", "id": "817754e7685a40238f7ac717f181ed0d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:16.227625", "expires":
+        "2018-08-06T17:57:15Z", "id": "2a6b4ce579924a9d8b68b5781d094f0f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UBoOA9_-TqWlOWAWU6UEFg",
-        "_QrpjMBmRIuAqTWjFezMrw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Slkk_tbfSlqZC35NQ4DENQ",
+        "X_IQ4sMLRTasVgrw8_VNrg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9790f95a4fa843ea8652f5ec50a701ce
+      - 5476d7db35b64f88a1fe7b6e6700830f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:16 GMT
+      - Mon, 06 Aug 2018 16:57:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1895c9f9-69fb-446d-8294-8afeb34202e3
+      - req-95666deb-9e79-4e7f-8e35-58366d46b9b9
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:16 GMT
+      - Mon, 06 Aug 2018 16:57:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-77e2cce1-62cf-4a3a-a4f7-f86cb4978e85
+      - req-64e5576a-4c4c-4c4e-8f19-cf899685347f
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:16.675839", "expires":
-        "2018-08-03T20:33:16Z", "id": "9419e31de876437695f2e683da78d45c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:16.793382", "expires":
+        "2018-08-06T17:57:16Z", "id": "4aafc2c7239043219b0cb7566f19d2e9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XFakeeTFS7igbBO--avO-Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9nkpnLHLRN238DMd8PN4mg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:33:16 GMT
+      - Mon, 06 Aug 2018 16:57:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:16 GMT
+      - Mon, 06 Aug 2018 16:57:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f40e6e6c-edb7-4f09-a137-b9a32c63c4b1
+      - req-1a2581f5-1d0f-4f4e-b47b-c189c683f0a0
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:17.080547", "expires":
-        "2018-08-03T20:33:17Z", "id": "7cf046284ddc458e85efb0636007c1cb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:17.273608", "expires":
+        "2018-08-06T17:57:17Z", "id": "5c242fc7622b4e68a0397f0d7c2e5168", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fhpGrXC7SlOQnhTiO6yEzQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kQK9Xc1pTlGA3-hyFHmIgA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:33:17 GMT
+      - Mon, 06 Aug 2018 16:57:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:17 GMT
+      - Mon, 06 Aug 2018 16:57:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ec659d8-9609-4428-b9ae-8d0e106743ad
+      - req-509a9994-3639-4ae4-a443-eb1ba6f44808
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:17.543654", "expires":
-        "2018-08-03T20:33:17Z", "id": "6dd9fcb23f7b4ad5b8968b8538116f1f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:17.601488", "expires":
+        "2018-08-06T17:57:17Z", "id": "0ee26b136abb42faa6ddceba1fa46897", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SJ-PlKjvSEKhY6wP_Y3RHg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1VLRw12XR8eGrjOLLz41DA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:33:17 GMT
+      - Mon, 06 Aug 2018 16:57:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-4ba0bcb8-d7d2-4e53-9595-886458057445
+      - req-d8c8657c-64ef-4eea-b5a6-2855d7698afd
       Date:
-      - Fri, 03 Aug 2018 19:33:17 GMT
+      - Mon, 06 Aug 2018 16:57:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a382c41f-d079-4cb1-a115-f0e5b0935e06
+      - req-1ac4e352-1d88-40ac-9ef9-f68b9b051531
       Date:
-      - Fri, 03 Aug 2018 19:33:18 GMT
+      - Mon, 06 Aug 2018 16:57:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-382d98b8-f6da-4e8d-9891-4182919eb697
+      - req-499b2771-731e-4084-8bb9-76475dea6354
       Date:
-      - Fri, 03 Aug 2018 19:33:18 GMT
+      - Mon, 06 Aug 2018 16:57:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ea7957bb-b06b-45fd-a822-afbdbb76e568
+      - req-83b48cca-172a-4977-acd4-b642df8ca8ac
       Date:
-      - Fri, 03 Aug 2018 19:33:18 GMT
+      - Mon, 06 Aug 2018 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d757136e-dcdf-41cc-9add-57a22d6e1349
+      - req-b6eb027f-dbfb-4311-a68e-8bbe4f5a3e2d
       Date:
-      - Fri, 03 Aug 2018 19:33:19 GMT
+      - Mon, 06 Aug 2018 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7d830542-690b-4b51-b4b8-e244dbb2a328
+      - req-1e926000-0690-4e83-a004-4e98137479e7
       Date:
-      - Fri, 03 Aug 2018 19:33:19 GMT
+      - Mon, 06 Aug 2018 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-8b80a7fa-dbbb-414a-93c3-4926b6709bbd
+      - req-253f5d5d-b775-42d2-b09c-81fa1f44edb5
       Date:
-      - Fri, 03 Aug 2018 19:33:19 GMT
+      - Mon, 06 Aug 2018 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7be3fb85-5056-417c-833c-7002f1436b2b
+      - req-9ca286f9-3ead-4846-b3d6-0aeb42b87443
       Date:
-      - Fri, 03 Aug 2018 19:33:19 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:33:11.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:33:12.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:33:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:33:13.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:33:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-32046355-3898-4b43-9255-afd2ca13f903
+      - req-880d3b56-ad19-4e58-a2c8-5af579549bc7
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-c42fcfc5-a5bc-490c-a5d1-51576f8abb93
+      - req-0f54ea48-61e7-47ef-b469-5348019f0c3e
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-7d3e73c7-342f-4097-9998-e53fdcacbd7e
+      - req-8e6123a2-07c2-445e-954f-02ab2a9765e6
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-231c20ae-80a2-46b8-865e-a0de928e3034
+      - req-e0022011-2dd6-4f48-ab1d-62754f7ed1ea
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1400,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-e3b56b59-9a97-4476-b8f8-9285a6aa083c
+      - req-d1e20db8-3c59-41d1-bfe2-e44a2474f547
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:20 GMT
+      - Mon, 06 Aug 2018 16:57:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e0186bb3-ed44-443a-b6c0-1c939e285ab3
+      - req-d6f4942e-fdad-4cac-871f-60a805d8fbc4
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1441,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:21.047649", "expires":
-        "2018-08-03T20:33:20Z", "id": "866a352ec8d142a5970a71d24f523eb6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:21.073526", "expires":
+        "2018-08-06T17:57:21Z", "id": "89b70f91398e45419f2e24ab3afc1b36", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["lo6jlverTimdIz-Nva_RYg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YIs6ObHlRtydhXg5i8cn-g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,7 +1489,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 866a352ec8d142a5970a71d24f523eb6
+      - 89b70f91398e45419f2e24ab3afc1b36
   response:
     status:
       code: 300
@@ -1515,7 +1515,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:33:21 GMT
+      - Mon, 06 Aug 2018 16:57:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -1528,7 +1528,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:21 GMT
+      - Mon, 06 Aug 2018 16:57:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0b3a2e7a-e571-4c3d-a852-4fba2c1d6551
+      - req-580af0cc-0262-4f26-afbe-ab3e4580af71
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:21.480847", "expires":
-        "2018-08-03T20:33:21Z", "id": "a9d7d88a3fec489c9135167d589012a9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:21.389086", "expires":
+        "2018-08-06T17:57:21Z", "id": "c2835f47fcd645e8820d15c2a30d4bc5", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SnBTGTa7QiSs7T8VywezZw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GojZzZILSYWMSWcnk-I5SA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9d7d88a3fec489c9135167d589012a9
+      - c2835f47fcd645e8820d15c2a30d4bc5
   response:
     status:
       code: 200
@@ -1634,9 +1634,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2013dd00-85ea-417b-8ae8-74996fa2fcd4
+      - req-927dfba4-9902-4ad2-a32b-9487250d07e5
       Date:
-      - Fri, 03 Aug 2018 19:33:21 GMT
+      - Mon, 06 Aug 2018 16:57:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1678,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9d7d88a3fec489c9135167d589012a9
+      - c2835f47fcd645e8820d15c2a30d4bc5
   response:
     status:
       code: 200
@@ -1704,14 +1704,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6025da97-0643-456f-8eb4-576af78cfd5e
+      - req-efe5e07c-55b5-4d57-bd02-74f0e10f445d
       Date:
-      - Fri, 03 Aug 2018 19:33:22 GMT
+      - Mon, 06 Aug 2018 16:57:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1729,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:22 GMT
+      - Mon, 06 Aug 2018 16:57:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-19070117-82a1-44d5-89cd-ca511912852b
+      - req-2a647d8e-af9e-463a-b3a9-7227078bea91
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1744,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:22.451870", "expires":
-        "2018-08-03T20:33:22Z", "id": "2f34bd8cf7e64844a806798738f3d58f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:22.108729", "expires":
+        "2018-08-06T17:57:22Z", "id": "ebea12ca90a44a778d7f66a3efc49a56", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DxIe-MXJQOmH772iMBCnUQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UA9u1ZzUTAGO_AyAHwrwag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1791,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f34bd8cf7e64844a806798738f3d58f
+      - ebea12ca90a44a778d7f66a3efc49a56
   response:
     status:
       code: 200
@@ -1817,9 +1817,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f0659e16-e10d-44d0-8501-a873c0348551
+      - req-a419c51b-1266-4512-9965-d1501c1c3edc
       Date:
-      - Fri, 03 Aug 2018 19:33:22 GMT
+      - Mon, 06 Aug 2018 16:57:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1861,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f34bd8cf7e64844a806798738f3d58f
+      - ebea12ca90a44a778d7f66a3efc49a56
   response:
     status:
       code: 200
@@ -1887,14 +1887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e448b4af-3b87-44f8-a112-8b2b7af99d0b
+      - req-16237b71-c35e-4cb8-ac82-e1b4e952ff9a
       Date:
-      - Fri, 03 Aug 2018 19:33:23 GMT
+      - Mon, 06 Aug 2018 16:57:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 866a352ec8d142a5970a71d24f523eb6
+      - 89b70f91398e45419f2e24ab3afc1b36
   response:
     status:
       code: 200
@@ -1920,9 +1920,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b2723b7f-579e-4bd7-9bc3-7bbfcdd91ec2
+      - req-66bd886a-6504-4613-8524-e6b9e5bbcc07
       Date:
-      - Fri, 03 Aug 2018 19:33:23 GMT
+      - Mon, 06 Aug 2018 16:57:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1964,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 866a352ec8d142a5970a71d24f523eb6
+      - 89b70f91398e45419f2e24ab3afc1b36
   response:
     status:
       code: 200
@@ -1990,14 +1990,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c5eb6361-2a95-405a-b131-b3d90b94c9ef
+      - req-02a8fb02-b2e2-41cd-b3bc-6bb7e5f0f6f9
       Date:
-      - Fri, 03 Aug 2018 19:33:24 GMT
+      - Mon, 06 Aug 2018 16:57:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +2015,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:24 GMT
+      - Mon, 06 Aug 2018 16:57:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0f486bb-26bd-49b1-b7e9-3b5b14ee5a05
+      - req-6a932ada-04cf-4685-9786-f547397ded23
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +2030,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:24.295759", "expires":
-        "2018-08-03T20:33:24Z", "id": "a83f4a9bdaae445cb12f3e72e81f97dd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:23.738999", "expires":
+        "2018-08-06T17:57:23Z", "id": "37e1db40c62c4c028a5d164e30758c41", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["V6RDmOtEQ5GsZLqjY48B8A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ao15b_o2RdiVtYeuWpYg5w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +2077,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +2092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a83f4a9bdaae445cb12f3e72e81f97dd
+      - 37e1db40c62c4c028a5d164e30758c41
   response:
     status:
       code: 200
@@ -2103,9 +2103,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3b495367-d710-4e2d-82f5-e882aa3f9753
+      - req-1f3d719d-0411-4ae7-991b-fc34ed41f6e8
       Date:
-      - Fri, 03 Aug 2018 19:33:24 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +2147,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +2162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a83f4a9bdaae445cb12f3e72e81f97dd
+      - 37e1db40c62c4c028a5d164e30758c41
   response:
     status:
       code: 200
@@ -2173,14 +2173,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-345aca8a-c0d9-45f4-b43c-ac2adb910475
+      - req-320aee33-cdbb-4cb1-af6c-6bb8e2f99ca3
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2208,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d6811a39-4d4f-4407-9706-60eba365af80
+      - req-647b2713-f697-44f0-960e-45533cb0dc42
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2220,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2248,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ac03b54e-cc45-438e-a866-00c5bc5c15cd
+      - req-d44e8d63-2f53-4b3b-8b36-be4599e9f035
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2260,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a2471f2e-d8a8-4536-8610-fdf613fca457
+      - req-a6a652e0-a118-4860-91b9-6e609b96d265
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2300,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2328,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d7bbf075-8003-4f49-975b-5ea926d0db85
+      - req-fc089e0a-39f3-4232-ab58-bade3c71372f
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2340,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2368,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-0b67de4c-cbb7-45c6-a150-3c324633090f
+      - req-d7e2a50e-5cf1-436b-9176-4d1468d83df4
       Date:
-      - Fri, 03 Aug 2018 19:33:25 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2380,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-228397ec-1d73-411f-9cce-d6d004804ee8
+      - req-20a96c74-108f-4e50-84dc-4f3c664e2e27
       Date:
-      - Fri, 03 Aug 2018 19:33:26 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2420,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2448,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6a6f3d4c-b73d-4a49-b41b-f7744d828d07
+      - req-49fe008d-049e-49d6-af10-d8c671c0ef61
       Date:
-      - Fri, 03 Aug 2018 19:33:26 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2460,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2488,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5e65aeab-5169-4e36-af13-c83fa9c1bf1c
+      - req-f20d8dec-3a4d-4b8e-baf3-c183980f243f
       Date:
-      - Fri, 03 Aug 2018 19:33:26 GMT
+      - Mon, 06 Aug 2018 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2500,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2518,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:26 GMT
+      - Mon, 06 Aug 2018 16:57:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f73337a-12c6-4660-94b9-60ece0f11d29
+      - req-476b425b-489e-4f7c-b090-d495adfa1335
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2533,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:26.532805", "expires":
-        "2018-08-03T20:33:26Z", "id": "a431aa0a6214451bbcc46a5c952a3c75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:25.283441", "expires":
+        "2018-08-06T17:57:25Z", "id": "563414bd6a354ebabc7436dace579f99", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kBwq7r7-RqqHwekHgOq-7w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["u-cVx4yVQBS21d9gJdq31A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2599,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:26 GMT
+      - Mon, 06 Aug 2018 16:57:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d59f8602-938b-4721-a500-a43e2b9bf739
+      - req-f26d89f2-0f3d-45db-a996-6c9ac8ebacf2
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2614,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:26.814560", "expires":
-        "2018-08-03T20:33:26Z", "id": "07c891adf66a4d1488e3f8a9cdd65858", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:25.494953", "expires":
+        "2018-08-06T17:57:25Z", "id": "4f02042fa9d14dd592d7b848b02771e6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hAYEWUeZSVO4TQPqHkeOlg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EFcOjI4gREqul33Nl0Qb_g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2661,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -2687,9 +2687,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-10813b92-d556-4508-b52c-4e924ae22f73
+      - req-ed2a6b23-08a2-430a-952b-9b7dcb9a8906
       Date:
-      - Fri, 03 Aug 2018 19:33:27 GMT
+      - Mon, 06 Aug 2018 16:57:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2723,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -2749,14 +2749,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9169ac50-302a-44ce-8c2e-5e33e70c3935
+      - req-763528bf-d00d-4b2d-ab0f-3789c0e681b4
       Date:
-      - Fri, 03 Aug 2018 19:33:27 GMT
+      - Mon, 06 Aug 2018 16:57:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2774,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:27 GMT
+      - Mon, 06 Aug 2018 16:57:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a906ccc-2bf4-4f9d-a77f-5e6a56384515
+      - req-316e8166-4fb5-4915-b183-eeab39f473cf
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2789,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:28.151303", "expires":
-        "2018-08-03T20:33:28Z", "id": "9d65b9cc42914b0389419dc73ae2cd73", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:26.030458", "expires":
+        "2018-08-06T17:57:26Z", "id": "018558d0a26340809b0d267393f9ed47", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1G6-HOCaRM6_tMRZcmDHlg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["85BWgzCAT8iHuOqEKnR5Vw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2836,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d65b9cc42914b0389419dc73ae2cd73
+      - '018558d0a26340809b0d267393f9ed47'
   response:
     status:
       code: 200
@@ -2862,14 +2862,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ffe5079f-6e54-4c4a-824f-ba40bfb0edd4
+      - req-97f81259-7df5-4522-8d7e-2d5c154a3e65
       Date:
-      - Fri, 03 Aug 2018 19:33:28 GMT
+      - Mon, 06 Aug 2018 16:57:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a431aa0a6214451bbcc46a5c952a3c75
+      - 563414bd6a354ebabc7436dace579f99
   response:
     status:
       code: 200
@@ -2895,14 +2895,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c7269cd9-c7f2-4a8f-9230-24ff3a318b4f
+      - req-cb8b6dd2-bfbc-40f4-b801-f376880fff27
       Date:
-      - Fri, 03 Aug 2018 19:33:28 GMT
+      - Mon, 06 Aug 2018 16:57:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:28 GMT
+      - Mon, 06 Aug 2018 16:57:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9bf1e51c-ea91-4c5e-9da1-562a72914a4f
+      - req-721c6fe2-5628-4c14-a3ad-d0c1f30b3c96
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:29.131024", "expires":
-        "2018-08-03T20:33:28Z", "id": "aa4d875a96a24b55af96bf5ce2df454d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:26.710214", "expires":
+        "2018-08-06T17:57:26Z", "id": "2e2b7948134e419d802f404b3e9ff8b3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ph8YYWXmQYWLjIOSA5GHMA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8rMeploMRpmRqTpfk6ZNzA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2982,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa4d875a96a24b55af96bf5ce2df454d
+      - 2e2b7948134e419d802f404b3e9ff8b3
   response:
     status:
       code: 200
@@ -3008,14 +3008,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ca2591d2-9547-454e-8432-d33846996190
+      - req-65fb128d-1180-40a9-8eff-3e340fbdc673
       Date:
-      - Fri, 03 Aug 2018 19:33:29 GMT
+      - Mon, 06 Aug 2018 16:57:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9ea2e6ce-0ee1-402f-ace6-2ed9b64727f8
+      - req-8b6f5d57-2394-4158-90cb-f853f07ca86a
       Date:
-      - Fri, 03 Aug 2018 19:33:34 GMT
+      - Mon, 06 Aug 2018 16:57:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +3070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +3085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3096,9 +3096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9df2daac-86ba-44f8-bc32-ac956bf0064f
+      - req-45d1634c-b343-44da-921c-e6706b60c36f
       Date:
-      - Fri, 03 Aug 2018 19:33:35 GMT
+      - Mon, 06 Aug 2018 16:57:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +3125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +3140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3151,9 +3151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fe33a96e-fb65-4ef3-aec3-51293f85e626
+      - req-acc9a746-967f-445d-b233-d3ee0ab89f81
       Date:
-      - Fri, 03 Aug 2018 19:33:35 GMT
+      - Mon, 06 Aug 2018 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3206,9 +3206,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-a21958bd-866e-4165-a804-1caf52c250ab
+      - req-2a9b53e9-12cd-4452-b0e5-c227777de8b8
       Date:
-      - Fri, 03 Aug 2018 19:33:36 GMT
+      - Mon, 06 Aug 2018 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3264,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3290,9 +3290,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d525bf4c-05d4-4587-87b0-981560a24006
+      - req-143abf17-16c2-4ac3-be6e-bd74a1ea014f
       Date:
-      - Fri, 03 Aug 2018 19:33:36 GMT
+      - Mon, 06 Aug 2018 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3304,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,9 +3332,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-b839f910-d23d-4692-acdf-5879a403cfb7
+      - req-304a6d7d-834d-4998-9483-0fa3ce983a25
       Date:
-      - Fri, 03 Aug 2018 19:33:37 GMT
+      - Mon, 06 Aug 2018 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3380,7 +3380,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3408,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-a256bbaa-909f-4543-8d19-3d8f0a31bdcc
+      - req-d9f9f200-d5a4-4eba-adff-88b13b560a5e
       Date:
-      - Fri, 03 Aug 2018 19:33:38 GMT
+      - Mon, 06 Aug 2018 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3456,7 +3456,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,9 +3484,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-6b481f91-0673-465c-8e96-3682c9a7b6a5
+      - req-2d24952e-cf5f-49a8-9bc2-75896a178ba7
       Date:
-      - Fri, 03 Aug 2018 19:33:38 GMT
+      - Mon, 06 Aug 2018 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3534,7 +3534,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3562,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-cd48c4d5-ab1d-4ae3-8aeb-1f184fd4a4a3
+      - req-76270dd2-c846-4ac7-99ee-e2b0fceb5228
       Date:
-      - Fri, 03 Aug 2018 19:33:39 GMT
+      - Mon, 06 Aug 2018 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3606,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-dd213bd5-1167-4b95-b015-470e2a915b89
+      - req-d06de6c9-3bea-4563-af3e-df6588a8e4aa
       Date:
-      - Fri, 03 Aug 2018 19:33:40 GMT
+      - Mon, 06 Aug 2018 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3659,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3687,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-cd9f5e93-010d-4e63-bee3-d0ff431fc497
+      - req-9233cc84-9f6a-4c08-9f0d-c72b98dda7e7
       Date:
-      - Fri, 03 Aug 2018 19:33:40 GMT
+      - Mon, 06 Aug 2018 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3722,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-543c0d2e-7b8e-462d-94e6-34aed84e5379
+      - req-503c8f02-bd14-4435-8e15-038686f63ff8
       Date:
-      - Fri, 03 Aug 2018 19:33:40 GMT
+      - Mon, 06 Aug 2018 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3757,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-40e1e051-57b3-4184-aab7-0266d16fccca
+      - req-346ad0eb-b16e-49e0-8adf-752669230814
       Date:
-      - Fri, 03 Aug 2018 19:33:40 GMT
+      - Mon, 06 Aug 2018 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3790,9 +3790,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d6ac690d-f691-46dd-b01d-c086e3689335
+      - req-4e253dc6-a8ab-4851-8301-d7facc040ab0
       Date:
-      - Fri, 03 Aug 2018 19:33:41 GMT
+      - Mon, 06 Aug 2018 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3848,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3874,9 +3874,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e5c64e96-33a8-4e64-9309-7dc0231deb8d
+      - req-c8d76dd0-bb0e-412f-8bbc-2a401d0e9e39
       Date:
-      - Fri, 03 Aug 2018 19:33:41 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3888,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d69b2972-61d2-47d3-9b12-de8f3b71a454
+      - req-2b5148b7-e9f0-46d6-a14d-6310dcc0c768
       Date:
-      - Fri, 03 Aug 2018 19:33:41 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3972,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3987,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c891adf66a4d1488e3f8a9cdd65858
+      - 4f02042fa9d14dd592d7b848b02771e6
   response:
     status:
       code: 200
@@ -3998,9 +3998,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3c19ec25-c956-4ed2-a7da-5c294c58cc65
+      - req-dfab3524-2fcf-40be-bad7-4a4c38840f3c
       Date:
-      - Fri, 03 Aug 2018 19:33:41 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +4012,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +4027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +4040,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-4dd41981-74b9-4d8e-9ed0-38f0e916be74
+      - req-962d0a0f-5866-4136-b87d-24fdaf625029
       Date:
-      - Fri, 03 Aug 2018 19:33:41 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +4051,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +4066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf046284ddc458e85efb0636007c1cb
+      - 5c242fc7622b4e68a0397f0d7c2e5168
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +4079,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7e9ddca4-fb6f-4595-9264-abf6e1eaeeae
+      - req-71bdb20d-598d-4852-82f9-3b80c24877dc
       Date:
-      - Fri, 03 Aug 2018 19:33:42 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +4090,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +4105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +4118,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c301e891-ce59-4925-981f-97bae317fa19
+      - req-74941136-1513-433d-b142-a1c549f0c4fc
       Date:
-      - Fri, 03 Aug 2018 19:33:42 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +4129,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd9fcb23f7b4ad5b8968b8538116f1f
+      - 0ee26b136abb42faa6ddceba1fa46897
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +4157,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-50128407-51a4-4ce0-a14b-c3132a30fa18
+      - req-81ecd6b1-af50-40d9-9a12-4151005dbd67
       Date:
-      - Fri, 03 Aug 2018 19:33:42 GMT
+      - Mon, 06 Aug 2018 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4168,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4186,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:42 GMT
+      - Mon, 06 Aug 2018 16:57:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d66552e-277d-4200-94db-f47a0ef9712f
+      - req-1afe23f3-2a7c-4f18-bb7b-3bd9f820534a
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4201,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:42.969889", "expires":
-        "2018-08-03T20:33:42Z", "id": "ca1225ff60b64ebabfa51e062a0bbad1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:34.275881", "expires":
+        "2018-08-06T17:57:34Z", "id": "7090925b3b954307813e2467e7dd908d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OdBrSpnBRL6n3R0c0tDf4g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BSHAnUwLS6mmIPDVLCJHNw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4248,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81354f2d-23ee-486b-96eb-72b08a9c7f1f
+      - req-bccd6614-a1ce-4a0f-98b6-3e58ffd6fae6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-81354f2d-23ee-486b-96eb-72b08a9c7f1f
+      - req-bccd6614-a1ce-4a0f-98b6-3e58ffd6fae6
       Date:
-      - Fri, 03 Aug 2018 19:33:43 GMT
+      - Mon, 06 Aug 2018 16:57:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4288,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4306,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:44 GMT
+      - Mon, 06 Aug 2018 16:57:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1e88785-e6b1-4f64-8bea-68c4ae05d06b
+      - req-3db4b271-dd05-4e0f-ab4e-a3434428822e
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4321,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:44.246569", "expires":
-        "2018-08-03T20:33:44Z", "id": "f04e88125e1642989842b3652bdbd5b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:34.941678", "expires":
+        "2018-08-06T17:57:34Z", "id": "57c2ba61eb0b49de944f293a8d4ed095", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Zb3yEDi9TvyImqsvlkk8xQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["H6ri1B-xRTWOThKsIWVDCg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4368,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4383,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f04e88125e1642989842b3652bdbd5b7
+      - 57c2ba61eb0b49de944f293a8d4ed095
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93cf56bc-4649-4e7d-b41e-3414d584b00d
+      - req-91e125a3-dc9c-4cf0-b5d3-798e02301c36
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-93cf56bc-4649-4e7d-b41e-3414d584b00d
+      - req-91e125a3-dc9c-4cf0-b5d3-798e02301c36
       Date:
-      - Fri, 03 Aug 2018 19:33:45 GMT
+      - Mon, 06 Aug 2018 16:57:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4408,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4423,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8c7509c-4119-49b9-b2c6-8e2ef656eb36
+      - req-070e7410-2a09-48f3-bd54-e173f472e7bd
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d8c7509c-4119-49b9-b2c6-8e2ef656eb36
+      - req-070e7410-2a09-48f3-bd54-e173f472e7bd
       Date:
-      - Fri, 03 Aug 2018 19:33:46 GMT
+      - Mon, 06 Aug 2018 16:57:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4448,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:46 GMT
+      - Mon, 06 Aug 2018 16:57:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f209d69f-bab9-49dd-8e4e-bdd3ec679920
+      - req-e0a7a6ec-d377-46d0-8d23-3920cc492e41
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:46.477119", "expires":
-        "2018-08-03T20:33:46Z", "id": "ad7d0cde61554cceb7e8dc5db2ee4116", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:36.032736", "expires":
+        "2018-08-06T17:57:36Z", "id": "f33b74384ee7469da63c4cd45454349c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["40AnzuiBRgeZ8uZGIuc0dQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xupt7mIsTl2ZAjOr8XUU-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4543,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7d0cde61554cceb7e8dc5db2ee4116
+      - f33b74384ee7469da63c4cd45454349c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-55b7fe33-92c1-480f-8300-a2b5d05a80f4
+      - req-88be64c4-ccfb-440d-af98-093fd4f64489
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-55b7fe33-92c1-480f-8300-a2b5d05a80f4
+      - req-88be64c4-ccfb-440d-af98-093fd4f64489
       Date:
-      - Fri, 03 Aug 2018 19:33:47 GMT
+      - Mon, 06 Aug 2018 16:57:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4568,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:47 GMT
+      - Mon, 06 Aug 2018 16:57:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2a04029-61d6-4d66-adba-e4e476c7775b
+      - req-bf4ae0ce-139f-48a1-8afe-40001c7a6a7b
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:47.756179", "expires":
-        "2018-08-03T20:33:47Z", "id": "6bca8029365b41179ea2adf4ef842601", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:36.706126", "expires":
+        "2018-08-06T17:57:36Z", "id": "b6bfb521bad14ac487a2884792f844bc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["aBeOcbuvQ_O2q0UpdnyLXA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DwPZefJWQSuSA1Nq92Cf0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,7 +4649,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -4664,7 +4664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6bca8029365b41179ea2adf4ef842601
+      - b6bfb521bad14ac487a2884792f844bc
   response:
     status:
       code: 200
@@ -4675,13 +4675,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:33:47 GMT
+      - Mon, 06 Aug 2018 16:57:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4699,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:47 GMT
+      - Mon, 06 Aug 2018 16:57:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cabb75a1-8b63-47b3-8650-748d6b196af1
+      - req-255133e0-7811-4f2f-abb2-8e852701aa23
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4714,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:48.082823", "expires":
-        "2018-08-03T20:33:48Z", "id": "3938aa5666e54a59b5eca99d3feab822", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:37.121481", "expires":
+        "2018-08-06T17:57:37Z", "id": "5a15beacaa9f4534b7d7383f2a614d2e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TQVSwcVPQuSj1NeNSOTFpw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kA3GOxQYSu-7mEJbREgXCg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4761,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3938aa5666e54a59b5eca99d3feab822
+      - 5a15beacaa9f4534b7d7383f2a614d2e
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b204629a-96a7-4f0d-8714-2f6a7fd59609
+      - req-78b5cb12-3270-4b1c-9c0a-d68a8969b1d8
       Date:
-      - Fri, 03 Aug 2018 19:33:48 GMT
+      - Mon, 06 Aug 2018 16:57:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4814,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:48 GMT
+      - Mon, 06 Aug 2018 16:57:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9dbe7266-5a4c-4d9e-8fb4-1707cb079132
+      - req-3b27f4e7-dce4-438e-b4a8-861037a4c3e4
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4829,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:48.504758", "expires":
-        "2018-08-03T20:33:48Z", "id": "3828fb0732f6472091fa12d33aa386b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:37.812790", "expires":
+        "2018-08-06T17:57:37Z", "id": "50ac831e4bb344f19bad38a5545bfba4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mfWa9PkbSLOp5PdhtFyOSA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["b_TdRB1fRrmqzkgM1sYAsA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4876,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3828fb0732f6472091fa12d33aa386b6
+      - 50ac831e4bb344f19bad38a5545bfba4
   response:
     status:
       code: 200
@@ -4902,16 +4902,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-51a3f8b3-7955-4145-95f0-2a8742c304fa
+      - req-e275c4f7-b594-476b-beac-a2176b4fe241
       Date:
-      - Fri, 03 Aug 2018 19:33:48 GMT
+      - Mon, 06 Aug 2018 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6bca8029365b41179ea2adf4ef842601
+      - b6bfb521bad14ac487a2884792f844bc
   response:
     status:
       code: 200
@@ -4937,16 +4937,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2ab07bf7-96a3-4b32-8265-a4c3a095e3a2
+      - req-fb6d91a0-fb2b-4c0c-9099-e30279786fbf
       Date:
-      - Fri, 03 Aug 2018 19:33:48 GMT
+      - Mon, 06 Aug 2018 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:49 GMT
+      - Mon, 06 Aug 2018 16:57:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b23ac64-c350-4cc1-8878-1fc35eee53a8
+      - req-850d80ef-035c-4c26-a39b-2e1f102603de
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:49.199417", "expires":
-        "2018-08-03T20:33:49Z", "id": "3799d5f0e8774618aa4e1b97ab9bbaa7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:38.774177", "expires":
+        "2018-08-06T17:57:38Z", "id": "41cd06dca68b4dc8aca6aba47e058bb3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lpUgWuTKQcSSqBLkB1e7Gw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xPObz_VGROGtC4IjikENxw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +5026,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +5041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3799d5f0e8774618aa4e1b97ab9bbaa7
+      - 41cd06dca68b4dc8aca6aba47e058bb3
   response:
     status:
       code: 200
@@ -5052,16 +5052,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b0a23206-f3e9-43e0-b83e-c399f3164aa0
+      - req-6acac745-5c8b-42da-87cc-1de85ae9196f
       Date:
-      - Fri, 03 Aug 2018 19:33:49 GMT
+      - Mon, 06 Aug 2018 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +5076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +5089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-8fa4b398-f16b-4a5b-ad45-684c2842fbe5
+      - req-938a6406-cfd4-49ef-90f2-fe928916d826
       Date:
-      - Fri, 03 Aug 2018 19:33:49 GMT
+      - Mon, 06 Aug 2018 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +5114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +5129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +5142,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-9636f651-0dd7-4ea5-ac98-67ac3fbbe94f
+      - req-1fffd602-8170-4185-9a73-40d650fe91dd
       Date:
-      - Fri, 03 Aug 2018 19:33:50 GMT
+      - Mon, 06 Aug 2018 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +5167,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +5182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +5195,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-c07bac0e-87ff-4cf3-955b-36b25d9d92a4
+      - req-5f8646c4-1906-422f-9c7a-dbb749bec3bb
       Date:
-      - Fri, 03 Aug 2018 19:33:50 GMT
+      - Mon, 06 Aug 2018 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5220,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5248,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-293d7693-df1e-4744-b1cc-25c26540d5fb
+      - req-bb90a561-3627-4f19-a65c-b2b3913b401a
       Date:
-      - Fri, 03 Aug 2018 19:33:50 GMT
+      - Mon, 06 Aug 2018 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5273,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5301,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-6769efb3-22bd-4446-b86d-c8192b7c4903
+      - req-1ca7c613-e0b6-4b31-8282-f2c80f85fedb
       Date:
-      - Fri, 03 Aug 2018 19:33:50 GMT
+      - Mon, 06 Aug 2018 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5326,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5354,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c92d4f3c-9336-46c7-95ff-c40eef8de308
+      - req-c1eecc91-ae05-4bdb-9709-d05536133d4f
       Date:
-      - Fri, 03 Aug 2018 19:33:51 GMT
+      - Mon, 06 Aug 2018 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5390,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3a03a9df-b2ba-43b6-a270-8f41f12cd642
+      - req-3429e20b-1d0c-46c3-9e2f-0bdd073e7e6c
       Date:
-      - Fri, 03 Aug 2018 19:33:51 GMT
+      - Mon, 06 Aug 2018 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5415,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5443,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-98b56303-52dd-4752-a4fb-7e70a0792029
+      - req-74ff6b02-95c8-4819-9025-6e1830c8238d
       Date:
-      - Fri, 03 Aug 2018 19:33:51 GMT
+      - Mon, 06 Aug 2018 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5479,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-688b27f5-e88c-4fd1-9d0c-ac2e66794f61
+      - req-42ccdc57-f7d8-47d3-804b-ba364d5799c3
       Date:
-      - Fri, 03 Aug 2018 19:33:51 GMT
+      - Mon, 06 Aug 2018 16:57:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5504,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5532,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-f313dd2e-cbe2-409a-9ff6-f10509662a96
+      - req-b56d9503-ae54-4ccf-8ad6-532111362290
       Date:
-      - Fri, 03 Aug 2018 19:33:52 GMT
+      - Mon, 06 Aug 2018 16:57:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5557,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9419e31de876437695f2e683da78d45c
+      - 4aafc2c7239043219b0cb7566f19d2e9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5585,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-997f6431-2d49-45ec-9d29-71e5b0169b64
+      - req-91b264d5-9af5-4b26-a5a2-7b8a7c54feac
       Date:
-      - Fri, 03 Aug 2018 19:33:52 GMT
+      - Mon, 06 Aug 2018 16:57:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5610,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5628,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:52 GMT
+      - Mon, 06 Aug 2018 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b2e91ca8-a58d-4225-8a62-aebac3d872c1
+      - req-a2c4eec1-7f7a-428e-a078-f70f2231f851
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5643,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:52.729543", "expires":
-        "2018-08-03T20:33:52Z", "id": "e4b05fe56a614ccbbbbbc02785d82cbc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.227441", "expires":
+        "2018-08-06T17:57:42Z", "id": "8381b78e078d4d05baf39ec32f109e37", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["bQ0rFg4fReKNRYDzeiucyA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NNPA06YhTnmWwByDb4rrAQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,13 +5691,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"e4b05fe56a614ccbbbbbc02785d82cbc"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"8381b78e078d4d05baf39ec32f109e37"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5709,13 +5709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:52 GMT
+      - Mon, 06 Aug 2018 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d799500-6502-4fc0-b60b-2c155169597e
+      - req-b73d55a7-ce3b-46c5-9030-c24220f260a6
       Content-Length:
       - '4196'
       Connection:
@@ -5724,10 +5724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:52.956017", "expires":
-        "2018-08-03T20:33:52Z", "id": "39266cf35da8458ebec879087c0a8bc3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.452231", "expires":
+        "2018-08-06T17:57:42Z", "id": "0508fc0f99f74fcab682c4eb80c81b84", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["PEM6E7fpQt2mBJouWvxOTw", "bQ0rFg4fReKNRYDzeiucyA"]},
+        "name": "admin"}, "audit_ids": ["8X2W7KNcRRe18BZeHOTtoQ", "NNPA06YhTnmWwByDb4rrAQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5772,7 +5772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:53 GMT
+      - Mon, 06 Aug 2018 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dbc927eb-1445-47ae-b3e1-809100700a25
+      - req-8a72ff0b-abe9-4c3c-a0d2-a93ac90e7704
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:53.315146", "expires":
-        "2018-08-03T20:33:53Z", "id": "0ae1c84086534f74971edad711da1a1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.773822", "expires":
+        "2018-08-06T17:57:42Z", "id": "dc650f367f40425f8da1d91bdf14b619", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XeW416dxSA2yNLA0lS6GCQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["8VLGoTYiQze8Y3XxYPfTLw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,13 +5853,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"0ae1c84086534f74971edad711da1a1c"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"dc650f367f40425f8da1d91bdf14b619"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5871,13 +5871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:33:53 GMT
+      - Mon, 06 Aug 2018 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b064f5a-cccb-4a4f-a09d-4ae24104b631
+      - req-9a10f984-4959-4b1c-b4f2-21b35f317cf8
       Content-Length:
       - '4196'
       Connection:
@@ -5886,10 +5886,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:33:53.531703", "expires":
-        "2018-08-03T20:33:53Z", "id": "03d38fc8693f4a1692732fe08fd759c1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:43.037412", "expires":
+        "2018-08-06T17:57:42Z", "id": "3afb64507b6f416ab3b7c64d26f6e61e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["loIqdIdeR5On7Ha0V9onLg", "XeW416dxSA2yNLA0lS6GCQ"]},
+        "name": "admin"}, "audit_ids": ["LKAGM51qRPiy5vJ8K9N6zw", "8VLGoTYiQze8Y3XxYPfTLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5934,7 +5934,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab435abb74f040c29989a1ede2bb70e5
+      - '078eaa69e9c543878ec7c68aecb0c5e8'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5962,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-682fa169-c97e-4cab-9b85-9882d53e8c31
+      - req-6506627a-35d6-4e43-a094-e3a18923a1de
       Date:
-      - Fri, 03 Aug 2018 19:33:53 GMT
+      - Mon, 06 Aug 2018 16:57:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5984,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a3c0cd36-f24c-4c13-811c-0041086c2de7
+      - req-c76efeb8-42d3-4385-8784-046516c062f8
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-a3c0cd36-f24c-4c13-811c-0041086c2de7
+      - req-c76efeb8-42d3-4385-8784-046516c062f8
       Date:
-      - Fri, 03 Aug 2018 19:33:54 GMT
+      - Mon, 06 Aug 2018 16:57:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +6032,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +6047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d5c3051e-1b09-4ba6-9e5a-e50aeb561cbf
+      - req-25f0705d-3c70-4809-9939-e29f1c17711f
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-d5c3051e-1b09-4ba6-9e5a-e50aeb561cbf
+      - req-25f0705d-3c70-4809-9939-e29f1c17711f
       Date:
-      - Fri, 03 Aug 2018 19:33:54 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +6079,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +6094,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f04e88125e1642989842b3652bdbd5b7
+      - 57c2ba61eb0b49de944f293a8d4ed095
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65576dac-d7f8-47dd-bfc4-96a89f22a493
+      - req-4a100ecc-712b-4965-9ec5-5a671beb54d6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-65576dac-d7f8-47dd-bfc4-96a89f22a493
+      - req-4a100ecc-712b-4965-9ec5-5a671beb54d6
       Date:
-      - Fri, 03 Aug 2018 19:33:54 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +6129,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3f4b933-4ee0-449a-bb8e-63973a7ebb72
+      - req-8a766368-6572-41b9-93de-951f51ff6c15
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d3f4b933-4ee0-449a-bb8e-63973a7ebb72
+      - req-8a766368-6572-41b9-93de-951f51ff6c15
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +6164,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7d0cde61554cceb7e8dc5db2ee4116
+      - f33b74384ee7469da63c4cd45454349c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1724771d-2309-4584-85a7-f1360140d249
+      - req-7839e31c-13e6-4ff1-a517-d6f59677e806
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1724771d-2309-4584-85a7-f1360140d249
+      - req-7839e31c-13e6-4ff1-a517-d6f59677e806
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +6199,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95e61902-8973-4e07-bab5-b7fa2231864d
+      - req-d66d8781-0810-4833-9b6b-f5f619207355
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-95e61902-8973-4e07-bab5-b7fa2231864d
+      - req-d66d8781-0810-4833-9b6b-f5f619207355
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +6229,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +6244,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf7d2085-6215-4f9f-bb94-354f9096303a
+      - req-44268025-29cb-4ab4-babc-1de9c81f1200
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-bf7d2085-6215-4f9f-bb94-354f9096303a
+      - req-44268025-29cb-4ab4-babc-1de9c81f1200
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +6274,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +6289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f04e88125e1642989842b3652bdbd5b7
+      - 57c2ba61eb0b49de944f293a8d4ed095
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb5c33a8-b369-4f22-8de4-515db9dd4245
+      - req-f0720bbb-9256-4b6b-b015-fe13b56cd9c0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fb5c33a8-b369-4f22-8de4-515db9dd4245
+      - req-f0720bbb-9256-4b6b-b015-fe13b56cd9c0
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +6324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f04e88125e1642989842b3652bdbd5b7
+      - 57c2ba61eb0b49de944f293a8d4ed095
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-006587fa-e4fb-4ee6-9809-d5780e7fba24
+      - req-e298a624-b36e-4e8d-9dd5-5baf75f81dcf
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-006587fa-e4fb-4ee6-9809-d5780e7fba24
+      - req-e298a624-b36e-4e8d-9dd5-5baf75f81dcf
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-30649fb6-9ef8-4152-91c6-f4ad05f97802
+      - req-dd9483a2-ed77-44e8-942b-232feec08fac
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-30649fb6-9ef8-4152-91c6-f4ad05f97802
+      - req-dd9483a2-ed77-44e8-942b-232feec08fac
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c58740b7-9e82-448c-b902-3ad8cc3c4680
+      - req-afdd1005-9012-4516-b359-72f653e7ddfc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c58740b7-9e82-448c-b902-3ad8cc3c4680
+      - req-afdd1005-9012-4516-b359-72f653e7ddfc
       Date:
-      - Fri, 03 Aug 2018 19:33:55 GMT
+      - Mon, 06 Aug 2018 16:57:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7d0cde61554cceb7e8dc5db2ee4116
+      - f33b74384ee7469da63c4cd45454349c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-57e8c1c9-04f8-4bba-a620-2dea1524a5ab
+      - req-e9ce6bd3-ca6a-4c05-85c3-3a5276b62761
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-57e8c1c9-04f8-4bba-a620-2dea1524a5ab
+      - req-e9ce6bd3-ca6a-4c05-85c3-3a5276b62761
       Date:
-      - Fri, 03 Aug 2018 19:33:56 GMT
+      - Mon, 06 Aug 2018 16:57:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7d0cde61554cceb7e8dc5db2ee4116
+      - f33b74384ee7469da63c4cd45454349c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8bdbba99-7673-4bb9-8825-9f4aaebe66ff
+      - req-a161aca3-ce6e-40da-acbb-8b809db84744
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8bdbba99-7673-4bb9-8825-9f4aaebe66ff
+      - req-a161aca3-ce6e-40da-acbb-8b809db84744
       Date:
-      - Fri, 03 Aug 2018 19:33:56 GMT
+      - Mon, 06 Aug 2018 16:57:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6499,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-232b1042-84e4-4587-88c5-ba0d075ff613
+      - req-c50e0c1c-9499-4b25-b305-c345c1c2ba71
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-232b1042-84e4-4587-88c5-ba0d075ff613
+      - req-c50e0c1c-9499-4b25-b305-c345c1c2ba71
       Date:
-      - Fri, 03 Aug 2018 19:33:56 GMT
+      - Mon, 06 Aug 2018 16:57:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6547,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6562,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-372597fa-cbcf-4235-abbe-0922f67a1f0c
+      - req-b6b36a64-4fef-4f2d-985a-2211bc731805
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-372597fa-cbcf-4235-abbe-0922f67a1f0c
+      - req-b6b36a64-4fef-4f2d-985a-2211bc731805
       Date:
-      - Fri, 03 Aug 2018 19:33:56 GMT
+      - Mon, 06 Aug 2018 16:57:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6618,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6633,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9c53490-4f77-4ab3-8efd-b9324ffc6002
+      - req-4fec052d-2c14-4d34-bbba-d8f5bcd20a07
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-b9c53490-4f77-4ab3-8efd-b9324ffc6002
+      - req-4fec052d-2c14-4d34-bbba-d8f5bcd20a07
       Date:
-      - Fri, 03 Aug 2018 19:33:56 GMT
+      - Mon, 06 Aug 2018 16:57:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6682,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6697,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca1225ff60b64ebabfa51e062a0bbad1
+      - 7090925b3b954307813e2467e7dd908d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac204651-5d73-4345-a92c-d040cdffa809
+      - req-4f8e17a5-cbfa-4677-9e4b-95561f2a17a2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ac204651-5d73-4345-a92c-d040cdffa809
+      - req-4f8e17a5-cbfa-4677-9e4b-95561f2a17a2
       Date:
-      - Fri, 03 Aug 2018 19:33:57 GMT
+      - Mon, 06 Aug 2018 16:57:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6732,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f04e88125e1642989842b3652bdbd5b7
+      - 57c2ba61eb0b49de944f293a8d4ed095
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-79d2a4ca-df03-4522-9874-bcf333ab0ad9
+      - req-88dbc837-e886-4c67-a9f7-1052935e581c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-79d2a4ca-df03-4522-9874-bcf333ab0ad9
+      - req-88dbc837-e886-4c67-a9f7-1052935e581c
       Date:
-      - Fri, 03 Aug 2018 19:33:57 GMT
+      - Mon, 06 Aug 2018 16:57:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6767,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85548844eab4b3ba62305cc7a2c5b34
+      - 0ba8b8791b9e44aa94346ec3c8eb29a6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-77e49bbe-3f9e-40b2-9851-acb126c73517
+      - req-bdb696fe-adbd-436c-b8ad-4b3d93461960
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-77e49bbe-3f9e-40b2-9851-acb126c73517
+      - req-bdb696fe-adbd-436c-b8ad-4b3d93461960
       Date:
-      - Fri, 03 Aug 2018 19:33:57 GMT
+      - Mon, 06 Aug 2018 16:57:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6802,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7d0cde61554cceb7e8dc5db2ee4116
+      - f33b74384ee7469da63c4cd45454349c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-929cdd02-b049-4f1f-98e9-accf3500d87e
+      - req-0f017cb3-e95e-444c-8097-5c842e605aec
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-929cdd02-b049-4f1f-98e9-accf3500d87e
+      - req-0f017cb3-e95e-444c-8097-5c842e605aec
       Date:
-      - Fri, 03 Aug 2018 19:33:57 GMT
+      - Mon, 06 Aug 2018 16:57:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:33:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6840,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:00 GMT
+      - Mon, 06 Aug 2018 16:57:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6933fd89-4a53-44cf-928a-19dc844e9ca7
+      - req-b9f4a7a8-9130-4fc9-a32f-b29c8323cbb6
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6855,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:00.315709", "expires":
-        "2018-08-03T20:34:00Z", "id": "9016015263ce471db74a831a71323234", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:49.187206", "expires":
+        "2018-08-06T17:57:49Z", "id": "dd57888855324c91a179cb7006ca8254", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6eynWgueQg-46SHkMk8uaA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["VclPafzVR9GTxcJCi6UFew"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6903,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:00 GMT
+      - Mon, 06 Aug 2018 16:57:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-171f6f72-841a-485a-b10c-a03cce8dc956
+      - req-13436c7e-5076-4cec-826e-6c2adea8697d
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6936,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:00.520633", "expires":
-        "2018-08-03T20:34:00Z", "id": "48751a7cc0de4a4b92a1b1abc750bf18", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:49.606674", "expires":
+        "2018-08-06T17:57:49Z", "id": "6580d3d4ca194423aca5e349bb6e8405", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ctEVIEFYTQiKxaUwOu4ybw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["3g5PCKERRB-7o2TA8OzY9w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6984,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -7010,17 +7010,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-d51da24a-f04b-4587-b5ff-d51916736ff7
+      - req-44d858fc-dbb0-4ed7-b534-b9724c75af04
       Date:
-      - Fri, 03 Aug 2018 19:34:00 GMT
+      - Mon, 06 Aug 2018 16:57:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
+        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
@@ -7030,22 +7040,17 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
         "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -7055,26 +7060,21 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -7082,7 +7082,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +7100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:00 GMT
+      - Mon, 06 Aug 2018 16:57:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4a596b72-d954-44a7-a137-965ca6919849
+      - req-490adb6d-47a5-4ae0-9f4a-0fa10bb61b5a
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +7115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:00.999002", "expires":
-        "2018-08-03T20:34:00Z", "id": "9cc2117bbcbe4658a8ac440bf5b5c957", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:50.313088", "expires":
+        "2018-08-06T17:57:50Z", "id": "9e5d0d94a7d44f918721b716bd706c07", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_zlCVqSgRre2OebTGGclmg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["JPf_rMigTTW7icUuuTB_mQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,7 +7163,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7181,13 +7181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:01 GMT
+      - Mon, 06 Aug 2018 16:57:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-477c4b81-ffd6-4442-b032-45982207f483
+      - req-83588a47-a060-425b-bf5d-02e9e0845e52
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +7196,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:01.161200", "expires":
-        "2018-08-03T20:34:01Z", "id": "e290066f48e64db89e6427916ed46ecb", "audit_ids":
-        ["C1nETqouRqOBGr4HkEOczg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:50.508478", "expires":
+        "2018-08-06T17:57:50Z", "id": "28deb78239334386bf4059015f8a4029", "audit_ids":
+        ["o5u6svz_T36jhJmDkJ91EA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +7217,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e290066f48e64db89e6427916ed46ecb
+      - 28deb78239334386bf4059015f8a4029
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:01 GMT
+      - Mon, 06 Aug 2018 16:57:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0eb9516-2132-45d7-84f1-2b06bf47161b
+      - req-3a8d4e66-b661-4902-aee3-a429a7a3a98a
       Content-Length:
       - '500'
       Connection:
@@ -7247,13 +7247,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"e290066f48e64db89e6427916ed46ecb"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"28deb78239334386bf4059015f8a4029"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7265,13 +7265,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:01 GMT
+      - Mon, 06 Aug 2018 16:57:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5340cb46-fc7b-4b99-8ff6-2ef843723927
+      - req-c9b4b5c9-a2d4-4be3-9ab9-9dc8a261cd47
       Content-Length:
       - '4143'
       Connection:
@@ -7280,11 +7280,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:01.512432", "expires":
-        "2018-08-03T20:34:01Z", "id": "f9febf055c7e4c66ad987ef07756cd0a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.035031", "expires":
+        "2018-08-06T17:57:50Z", "id": "16d137641b3a4633ae709b93f4addcab", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9pArroYCR-OU3u0kxO0HUw",
-        "C1nETqouRqOBGr4HkEOczg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sFYwbaqwQ82JaWkIdJaTAg",
+        "o5u6svz_T36jhJmDkJ91EA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7328,7 +7328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7343,20 +7343,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e290066f48e64db89e6427916ed46ecb
+      - 28deb78239334386bf4059015f8a4029
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:01 GMT
+      - Mon, 06 Aug 2018 16:57:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ea5667bc-6be7-4e12-a273-e223aeacb5bc
+      - req-1785e0fc-d1e0-41e1-afc4-747ede533e36
       Content-Length:
       - '500'
       Connection:
@@ -7373,7 +7373,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +7391,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:01 GMT
+      - Mon, 06 Aug 2018 16:57:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a26cb1ab-908c-4eff-9da2-448992054afe
+      - req-4a1d6115-d556-443c-89d3-699ea80b4618
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +7406,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:01.925541", "expires":
-        "2018-08-03T20:34:01Z", "id": "c2d7d95ee766481daab534f6ca607512", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.564893", "expires":
+        "2018-08-06T17:57:51Z", "id": "b3211cb00ade41bba702ecc60cbca352", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4KNAw1r5QOuYNrgkm-OxfQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BM2kd74uSCenz15y2P2pOg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +7453,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +7471,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:02 GMT
+      - Mon, 06 Aug 2018 16:57:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-67eb505b-addd-4c71-9e78-2cfb876dcd30
+      - req-285064d5-5464-48df-85dd-5236176f6f3e
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7486,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:02.170000", "expires":
-        "2018-08-03T20:34:02Z", "id": "1bff217e0b994d1a9a012b404e29ddfa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.992766", "expires":
+        "2018-08-06T17:57:51Z", "id": "3b0d9774798c4ce39073f5999ac99c74", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0_-DrsMBReijMqqixxxbjQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eQ5Iu0ZNRg6us4jlKjxv9A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7533,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7551,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:02 GMT
+      - Mon, 06 Aug 2018 16:57:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-feb8540c-ba2b-4480-b7ea-0738a995470d
+      - req-47acbcb0-ae9a-4f43-85b4-27919e79d7bf
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7566,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:02.421667", "expires":
-        "2018-08-03T20:34:02Z", "id": "499ae9fa2f614f409e95ea4c663d9369", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:52.215565", "expires":
+        "2018-08-06T17:57:52Z", "id": "b9e4cf23459043e78059f36316f6ad6c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ZKr1RZkTQ1-u9U7xpHQ1rg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Pxrlr0o2Sm2L5GW0_piJgA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7613,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7631,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:02 GMT
+      - Mon, 06 Aug 2018 16:57:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f441866a-cf2a-4b41-97ab-2174b582f83c
+      - req-5ee38814-f10d-4795-8294-20d99dad7080
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7646,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:02.630320", "expires":
-        "2018-08-03T20:34:02Z", "id": "4e77e0c7652c48a588969a3be7dbd2cc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:52.418709", "expires":
+        "2018-08-06T17:57:52Z", "id": "97270ec95e3f4658a3b06b6dd2eb5e9b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["i2FyCGCSTKmHf4DcdhDkig"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9E8umNwlSPyXFVc1kCxOug"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7693,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -7719,9 +7719,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-34d0e756-5b9e-4726-bdc1-417e0d5c798e
+      - req-ebc838a2-20a3-4181-a49c-acaf17be085f
       Date:
-      - Fri, 03 Aug 2018 19:34:02 GMT
+      - Mon, 06 Aug 2018 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7755,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -7781,14 +7781,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-71685d5f-f75b-4901-8614-9619e1ca5258
+      - req-ddf09db8-bf99-4561-a1ad-1b49aff3aeaf
       Date:
-      - Fri, 03 Aug 2018 19:34:03 GMT
+      - Mon, 06 Aug 2018 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7806,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:03 GMT
+      - Mon, 06 Aug 2018 16:57:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4180d24b-c0aa-4273-bbfd-ea3d51f14f36
+      - req-49d7e653-55f6-4937-8593-326660184385
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7821,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:03.280675", "expires":
-        "2018-08-03T20:34:03Z", "id": "888304b53f104de1b8b556a1c44992fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:53.179080", "expires":
+        "2018-08-06T17:57:53Z", "id": "1b87cc2b937b417da18fb6ef67a3f25c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Pg5YXPvLRLaX4PMKDjJCyQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aMzPNuHQQymqZqCkphmXfQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7868,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7883,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 888304b53f104de1b8b556a1c44992fc
+      - 1b87cc2b937b417da18fb6ef67a3f25c
   response:
     status:
       code: 200
@@ -7894,14 +7894,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a4ce01f8-96fe-43a4-bb7b-3874fbd52d85
+      - req-89bb3092-a0e4-4678-a1ff-d23fec95bdd0
       Date:
-      - Fri, 03 Aug 2018 19:34:03 GMT
+      - Mon, 06 Aug 2018 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cc2117bbcbe4658a8ac440bf5b5c957
+      - 9e5d0d94a7d44f918721b716bd706c07
   response:
     status:
       code: 200
@@ -7927,14 +7927,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7fbc0c33-f99e-4e61-bc55-4375d41fa624
+      - req-f4096b94-ef84-4e63-9d40-ca30842c2d94
       Date:
-      - Fri, 03 Aug 2018 19:34:03 GMT
+      - Mon, 06 Aug 2018 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7952,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:03 GMT
+      - Mon, 06 Aug 2018 16:57:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3aeef784-e5a3-46cb-9e32-897a48df61e4
+      - req-68d6c272-bd8d-4cd4-bf86-d3a41877affd
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7967,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:03.894945", "expires":
-        "2018-08-03T20:34:03Z", "id": "d06cd9aa7b8c43b7af2f2e6cf3204143", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:54.261776", "expires":
+        "2018-08-06T17:57:54Z", "id": "2f28f691c6a440488f8a0f36ae15a686", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kuUCh2z2Q9yeVWzkYj2sgg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["toceDb3JTaC2rNkiLnHvIg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +8014,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +8029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d06cd9aa7b8c43b7af2f2e6cf3204143
+      - 2f28f691c6a440488f8a0f36ae15a686
   response:
     status:
       code: 200
@@ -8040,14 +8040,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-447bff0c-ab00-4cfd-a97f-326d53d1efce
+      - req-3cd1cb39-ea42-440b-a09c-980ecefa14e7
       Date:
-      - Fri, 03 Aug 2018 19:34:04 GMT
+      - Mon, 06 Aug 2018 16:57:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +8062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8073,9 +8073,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b523e8e9-c012-4bd7-a12b-dc7a906b9212
+      - req-ec84223a-7bbd-4b84-ba12-dc8e647b103d
       Date:
-      - Fri, 03 Aug 2018 19:34:04 GMT
+      - Mon, 06 Aug 2018 16:57:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +8102,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +8117,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8128,9 +8128,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-52e2e872-9b6a-496c-b5aa-c7078db92184
+      - req-2a579b5f-5578-4909-8dc8-9abc0dc9bc7c
       Date:
-      - Fri, 03 Aug 2018 19:34:05 GMT
+      - Mon, 06 Aug 2018 16:57:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +8157,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +8172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8183,9 +8183,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1ef51a3e-7f78-4792-af47-6feb08517803
+      - req-23156b55-8057-4de6-8c2e-6f485730db78
       Date:
-      - Fri, 03 Aug 2018 19:34:05 GMT
+      - Mon, 06 Aug 2018 16:57:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +8212,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +8227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8238,9 +8238,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6435ecef-3d38-4d91-b770-4e154346f55d
+      - req-936bfb5c-8283-40f3-b36e-5dc26dcd0717
       Date:
-      - Fri, 03 Aug 2018 19:34:05 GMT
+      - Mon, 06 Aug 2018 16:57:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +8252,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +8267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8278,9 +8278,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-42f65d9a-897b-4ee8-8473-cbea1ed1a86f
+      - req-417fa88f-f768-4059-8862-a5466a497644
       Date:
-      - Fri, 03 Aug 2018 19:34:05 GMT
+      - Mon, 06 Aug 2018 16:57:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +8292,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +8307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e77e0c7652c48a588969a3be7dbd2cc
+      - 97270ec95e3f4658a3b06b6dd2eb5e9b
   response:
     status:
       code: 200
@@ -8318,9 +8318,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0f948c95-9e59-4167-bcf8-b79654636c5f
+      - req-455d1bc1-be08-4aba-9340-352472a1bd2a
       Date:
-      - Fri, 03 Aug 2018 19:34:06 GMT
+      - Mon, 06 Aug 2018 16:57:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +8332,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +8350,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:06 GMT
+      - Mon, 06 Aug 2018 16:57:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8033bc4e-3182-4486-a871-9783dc22645f
+      - req-fcf63cd1-62d7-468a-bbf3-09a91b11e618
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +8365,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:06.340018", "expires":
-        "2018-08-03T20:34:06Z", "id": "c55a063738704be18a63997ff93b441c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:58.189777", "expires":
+        "2018-08-06T17:57:58Z", "id": "ebca8a3245c74e5d8fe718cd15f2d453", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wmgAUZ0aSF6catSMc8CsTQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0gj4YHYzRoekJPRSTkVlwg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +8412,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +8427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -8438,17 +8438,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-de1a8ba3-17e9-4c74-af0e-1c281dd53849
+      - req-d4f81d09-5343-4629-a099-7e7592f2210e
       Date:
-      - Fri, 03 Aug 2018 19:34:06 GMT
+      - Mon, 06 Aug 2018 16:57:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -8461,12 +8472,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -8479,58 +8484,53 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8544,7 +8544,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8559,7 +8559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -8570,9 +8570,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b6d3c5af-3a2f-4143-a6eb-e64d09200281
+      - req-e4cbe544-a8d9-40bc-8510-289fe54300e6
       Date:
-      - Fri, 03 Aug 2018 19:34:06 GMT
+      - Mon, 06 Aug 2018 16:57:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -8676,7 +8676,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8694,13 +8694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:06 GMT
+      - Mon, 06 Aug 2018 16:57:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fccb1f2f-53e4-47b4-bfa3-e38a8bd139fe
+      - req-b25c7cf2-af53-4b71-bbdc-817a68af9ebf
       Content-Length:
       - '4131'
       Connection:
@@ -8709,10 +8709,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:07.011024", "expires":
-        "2018-08-03T20:34:06Z", "id": "594665b8b36043a6a0f4f2fe1ebb048c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:58.911829", "expires":
+        "2018-08-06T17:57:58Z", "id": "28f1ee43c2b844b8837e4f4a4c1c9bcb", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mvBkaYJoTKa9R60KjH_e9w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5z6HttG5QPK94C7Fd3Q-Rw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8756,7 +8756,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8771,7 +8771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -8782,185 +8782,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-06c63596-e25c-4d4a-b12a-abb7ed444c75
+      - req-bc097615-ce8d-4d27-8a3b-27aff3442b59
       Date:
-      - Fri, 03 Aug 2018 19:34:07 GMT
+      - Mon, 06 Aug 2018 16:57:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d4b2229d-2017-4785-8f3b-f1b0504ff7e6
-      Date:
-      - Fri, 03 Aug 2018 19:34:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -9007,259 +8834,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cb15d48b-0686-42a5-ab84-bf695b775b60
-      Date:
-      - Fri, 03 Aug 2018 19:34:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-68094644-8bde-43f5-801b-66da2542afd6
-      Date:
-      - Fri, 03 Aug 2018 19:34:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -9271,6 +8851,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9284,7 +8888,403 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3dade0a8-2e50-4652-a4ea-1003745b9682
+      Date:
+      - Mon, 06 Aug 2018 16:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6580d3d4ca194423aca5e349bb6e8405
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8f1eb7e0-9c90-4380-b240-420c99a2795a
+      Date:
+      - Mon, 06 Aug 2018 16:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6580d3d4ca194423aca5e349bb6e8405
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-15fd2da5-5ed4-4a17-a1f0-f42514f90a36
+      Date:
+      - Mon, 06 Aug 2018 16:58:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9302,13 +9302,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:08 GMT
+      - Mon, 06 Aug 2018 16:58:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-93528956-5835-4266-99db-d6fbd9b72a2b
+      - req-68ef61bb-4384-4250-a27c-8132a33af2a3
       Content-Length:
       - '4118'
       Connection:
@@ -9317,10 +9317,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:08.129051", "expires":
-        "2018-08-03T20:34:08Z", "id": "669992bb80f34b6a8a77037c703383ff", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:00.435681", "expires":
+        "2018-08-06T17:58:00Z", "id": "e5b45e72f7c545e0848ce2189e655c70", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["iVTUxh8HSPy6k1lFIJ0Jpw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Q3ppyOPjTg2kNIswRQUZ7g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9364,7 +9364,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9379,7 +9379,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -9390,141 +9390,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-858b119f-68f9-4b49-b922-0d5f6b772d26
+      - req-2114197d-4c33-4c11-a454-f07058cf5cf4
       Date:
-      - Fri, 03 Aug 2018 19:34:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c379b3b9-4811-45fc-bcd4-357692775e8f
-      Date:
-      - Fri, 03 Aug 2018 19:34:08 GMT
+      - Mon, 06 Aug 2018 16:58:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -9628,7 +9496,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e5b45e72f7c545e0848ce2189e655c70
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9db08189-8205-4523-ba12-02fca065d7ce
+      Date:
+      - Mon, 06 Aug 2018 16:58:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9643,7 +9643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -9654,9 +9654,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-78002d37-4e9a-4d57-ad87-5b3ec594e227
+      - req-3c63fc51-aced-4cfb-9fad-77ec7a9886da
       Date:
-      - Fri, 03 Aug 2018 19:34:08 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9698,7 +9698,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9713,7 +9713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -9724,9 +9724,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-fa90419c-37cb-4875-b23f-aa21700e2e87
+      - req-369d245e-80de-4780-9091-321e6b15d3f3
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9768,7 +9768,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9783,7 +9783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -9794,9 +9794,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3332278e-2559-4013-83e7-c2e0d06aa15a
+      - req-9057010d-b4c9-4290-8b12-23615acf1b3f
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9838,7 +9838,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9853,7 +9853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -9864,9 +9864,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-41a8f613-ea8e-4322-aed3-03bad731ad28
+      - req-5f993e44-cbe2-4544-be6f-765071478cb4
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9908,7 +9908,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9923,7 +9923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -9934,9 +9934,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-345770a6-b4f5-489c-8525-1a8ff0880862
+      - req-6ecd0003-91c0-4d52-85fb-37b90f587670
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9978,7 +9978,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9993,7 +9993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -10004,9 +10004,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4b82de03-526a-41cf-b112-34e9ac169ee4
+      - req-0048b54b-bfca-447a-8f5a-08a164a4c28b
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10048,7 +10048,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10063,7 +10063,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -10074,9 +10074,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-05632555-a724-41d8-9427-31ccbe774ebc
+      - req-a8bc7e6e-b985-44b2-9b39-164f711654c1
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10118,7 +10118,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10133,7 +10133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -10144,9 +10144,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3ced8e1b-1b07-46a9-b735-c79c420be2fd
+      - req-c4b8ab85-0885-4084-9ca3-f618bad4b96a
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10188,7 +10188,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10203,7 +10203,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -10214,9 +10214,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-930776d9-153a-47d8-b5f6-79cc5cc7a035
+      - req-39955d62-49f3-4239-bcf9-34d7c1a7681c
       Date:
-      - Fri, 03 Aug 2018 19:34:09 GMT
+      - Mon, 06 Aug 2018 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10619,7 +10619,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10634,7 +10634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -10645,9 +10645,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-df293801-4724-4c39-b42b-ca1bec9550e8
+      - req-ec845b99-23d8-4ab1-9a81-4917e4a14dd4
       Date:
-      - Fri, 03 Aug 2018 19:34:10 GMT
+      - Mon, 06 Aug 2018 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11050,7 +11050,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11065,7 +11065,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -11076,9 +11076,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b7c91844-878d-4b6d-9e25-cfbbbe963f8e
+      - req-8df45697-e5a1-46e2-b196-37dd6aca2d99
       Date:
-      - Fri, 03 Aug 2018 19:34:10 GMT
+      - Mon, 06 Aug 2018 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11481,7 +11481,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11496,7 +11496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -11507,9 +11507,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f5caa59a-6b8d-43da-a074-bb653faa1e20
+      - req-60c49536-bcaa-4755-bfc1-2a36268a8f7f
       Date:
-      - Fri, 03 Aug 2018 19:34:10 GMT
+      - Mon, 06 Aug 2018 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11912,7 +11912,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11927,7 +11927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -11938,9 +11938,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-80947e68-6e7d-432a-8203-c95278a06abd
+      - req-893a3a1e-ae1b-434d-9d5d-bb4df93e4e1d
       Date:
-      - Fri, 03 Aug 2018 19:34:10 GMT
+      - Mon, 06 Aug 2018 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12343,7 +12343,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12358,7 +12358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -12369,9 +12369,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bb7bce7c-f238-4e37-bec9-2d6d6a1b7adb
+      - req-4d33d86c-b357-40fd-9654-959f90e06cf2
       Date:
-      - Fri, 03 Aug 2018 19:34:10 GMT
+      - Mon, 06 Aug 2018 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12774,7 +12774,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12789,7 +12789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -12800,9 +12800,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-068f18cb-0563-490c-a399-b3dc8c88cf43
+      - req-f34e6fda-7f95-4f02-aa6d-c7e629416a5d
       Date:
-      - Fri, 03 Aug 2018 19:34:11 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13205,7 +13205,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13220,7 +13220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -13231,9 +13231,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-1314d8d6-5811-4067-8cba-860a21e336c7
+      - req-b3e4d363-63d7-4970-a2cc-4433b03e6f32
       Date:
-      - Fri, 03 Aug 2018 19:34:11 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13636,7 +13636,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13651,7 +13651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -13662,9 +13662,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ad672ef0-1109-4fd1-8c78-6177d90a0bd7
+      - req-a4fe7987-961c-45f7-9401-9cb73609dfee
       Date:
-      - Fri, 03 Aug 2018 19:34:11 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13696,7 +13696,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13711,7 +13711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -13722,9 +13722,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9b5ce23b-71bf-4e37-b262-64685c674909
+      - req-dbbd2311-78aa-45e5-9492-ee214fe00e23
       Date:
-      - Fri, 03 Aug 2018 19:34:11 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13756,7 +13756,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13771,7 +13771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -13782,9 +13782,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-809ff0c6-f713-4c8b-b8e1-fcd747e6c3bb
+      - req-8b202cf1-53cf-4631-bb3a-50e583d78431
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13816,7 +13816,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13831,7 +13831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -13842,9 +13842,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-887bfbce-b343-43f7-9cec-8419cabd402f
+      - req-c27ce2d4-033b-448b-8408-e56d9805f979
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13876,7 +13876,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13891,7 +13891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -13902,9 +13902,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d6d47944-ca60-4226-9664-e44b9d674eb1
+      - req-34b97ffe-7d7e-409a-a779-5b48d4c72b5c
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13936,7 +13936,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13951,7 +13951,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -13962,9 +13962,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-4e6224fc-53d6-4691-9b69-33b2ae0f2222
+      - req-9a5c8bdb-a088-4613-b9cc-fff72e12d350
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13996,7 +13996,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14011,7 +14011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -14022,9 +14022,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-140ea142-6c13-4ddb-97ec-b595bb02784e
+      - req-d35e0188-4482-4948-8247-a7d45791d8d6
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14056,7 +14056,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14071,7 +14071,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -14082,9 +14082,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-59e11a81-f086-4826-bc38-d7c8d90f561a
+      - req-ce49134a-4b19-4519-a24f-198871872700
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14116,7 +14116,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14131,7 +14131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -14142,9 +14142,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ed3ab988-efc5-42d9-9f87-481494c87ab7
+      - req-2750d2f5-4cf0-4e6b-993e-f94ba61f7391
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14186,7 +14186,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14201,7 +14201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -14212,9 +14212,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-74c20bf5-d404-4226-8a4b-7c2b5791e5d4
+      - req-19217c11-b8d9-4d75-8009-638f8e3794d1
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14257,7 +14257,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14272,7 +14272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -14283,9 +14283,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-d68214e4-5e7d-4701-879c-f7ca7f113c06
+      - req-8bb3b333-18d4-4023-a85c-74f014afa0c5
       Date:
-      - Fri, 03 Aug 2018 19:34:12 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14320,7 +14320,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14335,7 +14335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c55a063738704be18a63997ff93b441c
+      - ebca8a3245c74e5d8fe718cd15f2d453
   response:
     status:
       code: 200
@@ -14346,9 +14346,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-413cb350-ab89-4535-91dc-e2594e38f6c1
+      - req-d17f8b56-b291-4da3-a67f-79ecbfcf28ae
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14435,7 +14435,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14450,7 +14450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -14461,9 +14461,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-be19b4c0-f8d8-46bb-b687-d928f69befff
+      - req-117164b3-8125-43b5-9ac0-0a7231b8d316
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14505,7 +14505,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14520,7 +14520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -14531,9 +14531,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-3947c6e9-0198-4a7d-9742-a31ed4de5bfc
+      - req-7d4c01e4-e081-4cd1-bb3b-b48a1e599704
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14576,7 +14576,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14591,7 +14591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -14602,9 +14602,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-4019ffd6-dddc-4144-9637-93af1cecd804
+      - req-2215fe27-e212-428b-8e3a-b5f798638dfa
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14639,7 +14639,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14654,7 +14654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594665b8b36043a6a0f4f2fe1ebb048c
+      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
   response:
     status:
       code: 200
@@ -14665,9 +14665,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-75ffee82-02a5-4690-ad33-d7b5550148e5
+      - req-6147a530-3e68-43d8-8fb4-25422b8468d0
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14754,7 +14754,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14769,7 +14769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -14780,9 +14780,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6a35583b-f2b4-46a3-b156-0df837b7165c
+      - req-e3d4aaa8-1e6c-4fd9-86e5-f5a5ce75f095
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14824,7 +14824,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14839,7 +14839,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -14850,9 +14850,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-298b89f6-6e2d-4288-aa7b-3510b2a57004
+      - req-72d50d05-1ce2-4cf8-bfcf-9b79634b8f1e
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14895,7 +14895,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14910,7 +14910,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -14921,9 +14921,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-d831a678-0efc-4afb-ae9d-b83488f5cf2f
+      - req-1296b837-c1d7-4276-bf9a-11d0e2e91925
       Date:
-      - Fri, 03 Aug 2018 19:34:13 GMT
+      - Mon, 06 Aug 2018 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14958,7 +14958,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14973,7 +14973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48751a7cc0de4a4b92a1b1abc750bf18
+      - 6580d3d4ca194423aca5e349bb6e8405
   response:
     status:
       code: 200
@@ -14984,9 +14984,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-04cbdfe4-6dbf-47c2-9caa-c38a91937b05
+      - req-ac23658e-af8b-4e63-b336-fdc8b327bd2c
       Date:
-      - Fri, 03 Aug 2018 19:34:14 GMT
+      - Mon, 06 Aug 2018 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15073,7 +15073,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15088,7 +15088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -15099,9 +15099,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2a9c1a87-f777-44c6-897b-62698bf78f05
+      - req-e78d7761-c88e-46a9-bbb7-369bbea7b34b
       Date:
-      - Fri, 03 Aug 2018 19:34:14 GMT
+      - Mon, 06 Aug 2018 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15143,7 +15143,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15158,7 +15158,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -15169,9 +15169,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fae90987-b1ef-4675-b785-ab263692da50
+      - req-b487ea0e-48e0-44b1-a357-163de480e5d5
       Date:
-      - Fri, 03 Aug 2018 19:34:14 GMT
+      - Mon, 06 Aug 2018 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15214,7 +15214,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15229,7 +15229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -15240,9 +15240,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-dd75a6c2-c30a-4796-98fd-3402d0ccf8e9
+      - req-1c79df6b-1077-4ac8-aa92-7fb23f5ad00c
       Date:
-      - Fri, 03 Aug 2018 19:34:14 GMT
+      - Mon, 06 Aug 2018 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15277,7 +15277,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15292,7 +15292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669992bb80f34b6a8a77037c703383ff
+      - e5b45e72f7c545e0848ce2189e655c70
   response:
     status:
       code: 200
@@ -15303,9 +15303,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-bdba31c4-487b-4e8f-a110-75a3322fffb3
+      - req-d57fb18d-c1a9-45be-8824-4ff8f05f9893
       Date:
-      - Fri, 03 Aug 2018 19:34:14 GMT
+      - Mon, 06 Aug 2018 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15392,7 +15392,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15410,13 +15410,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:15 GMT
+      - Mon, 06 Aug 2018 16:58:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dcd4089e-fb0c-41e9-8172-f17a503f1262
+      - req-76def99f-4475-49e3-9901-0bf80de58aa4
       Content-Length:
       - '4170'
       Connection:
@@ -15425,10 +15425,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:15.385115", "expires":
-        "2018-08-03T20:34:15Z", "id": "a217bc3a1c4346339fef058dce2ddc5b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:08.786420", "expires":
+        "2018-08-06T17:58:08Z", "id": "c45a6c362e614772aec9f34a6a7a3adf", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uA_Jt_s4Qx-e2YtM0u643A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["nyQQqrKSR0GHi9cymJDL_Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15473,7 +15473,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15491,13 +15491,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:15 GMT
+      - Mon, 06 Aug 2018 16:58:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5315f1c-8383-4631-8d75-8a780272057e
+      - req-9f0e532c-3a33-4c48-abd3-bb15382f1700
       Content-Length:
       - '4170'
       Connection:
@@ -15506,10 +15506,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:15.629506", "expires":
-        "2018-08-03T20:34:15Z", "id": "1044e95492354d858308a40e6b63d1a7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:09.309394", "expires":
+        "2018-08-06T17:58:09Z", "id": "1a39c26dfda042d9a2bc616fa21f5ab5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["z190twJBRcGdCEthxLoNzA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Br9qU0ROSJCTEAxB5YHqLQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15554,7 +15554,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15572,13 +15572,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:15 GMT
+      - Mon, 06 Aug 2018 16:58:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-adb079fc-66bd-4ccc-bacd-5a133731f2bf
+      - req-ea7b1e86-97f8-416e-976a-679ca8eef099
       Content-Length:
       - '370'
       Connection:
@@ -15587,13 +15587,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:15.812824", "expires":
-        "2018-08-03T20:34:15Z", "id": "5fb685ab56964eb3a1dae88c5ea0b155", "audit_ids":
-        ["lnur7NbdS-2Mmhj-9M_6Hg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:09.545425", "expires":
+        "2018-08-06T17:58:09Z", "id": "43397a2bf5514cfaa007bbd6fce93751", "audit_ids":
+        ["jYI8_x6oQ4WS3keEzIefRg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15608,20 +15608,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5fb685ab56964eb3a1dae88c5ea0b155
+      - 43397a2bf5514cfaa007bbd6fce93751
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:15 GMT
+      - Mon, 06 Aug 2018 16:58:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a30f2b2-0ad8-4c75-83e9-53641744835f
+      - req-8b8baf87-3eab-498b-8dcd-9356f9d50729
       Content-Length:
       - '500'
       Connection:
@@ -15638,13 +15638,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"5fb685ab56964eb3a1dae88c5ea0b155"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"43397a2bf5514cfaa007bbd6fce93751"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15656,13 +15656,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:16 GMT
+      - Mon, 06 Aug 2018 16:58:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e566edf4-e23a-4b02-b6d7-f59d863d3c83
+      - req-fa394b3a-aacb-4ce5-a4a7-a1c39a96df12
       Content-Length:
       - '4143'
       Connection:
@@ -15671,11 +15671,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:16.217907", "expires":
-        "2018-08-03T20:34:15Z", "id": "0dc6c08e838a41b6882ce3ae779cc1be", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:10.059561", "expires":
+        "2018-08-06T17:58:09Z", "id": "204d1822832141e898e0a037d4845cb6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["s2oyWTY2Q1a426t39bCfvw",
-        "lnur7NbdS-2Mmhj-9M_6Hg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OYXv7G77R_u468C6qTlHLw",
+        "jYI8_x6oQ4WS3keEzIefRg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15719,7 +15719,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15734,20 +15734,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5fb685ab56964eb3a1dae88c5ea0b155
+      - 43397a2bf5514cfaa007bbd6fce93751
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:16 GMT
+      - Mon, 06 Aug 2018 16:58:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d8d487a-a421-4f49-bf6b-47bfae67055e
+      - req-f656bb1f-1ab5-49a2-9974-36e5010b12c7
       Content-Length:
       - '500'
       Connection:
@@ -15764,7 +15764,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15782,13 +15782,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:16 GMT
+      - Mon, 06 Aug 2018 16:58:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-71fe975d-18ca-46df-a398-2ac7081e5cff
+      - req-1ed92542-9802-490d-be59-37938d24efe4
       Content-Length:
       - '4117'
       Connection:
@@ -15797,10 +15797,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:16.558231", "expires":
-        "2018-08-03T20:34:16Z", "id": "7a88e0d91c50472bb2e847dc2015f3cb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:10.533686", "expires":
+        "2018-08-06T17:58:10Z", "id": "a1b5f52afe474f379a09ac4201219d7e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qggWUNVXQFO1uU9c6lWA_A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KI-J42_8Q_yqRpQzWmrqCQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15844,7 +15844,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15862,13 +15862,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:16 GMT
+      - Mon, 06 Aug 2018 16:58:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f11d8174-d9bf-4f60-9415-cbe0dba087ff
+      - req-712c3c0b-62c1-4ee9-a220-482767e909fc
       Content-Length:
       - '4131'
       Connection:
@@ -15877,10 +15877,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:16.796428", "expires":
-        "2018-08-03T20:34:16Z", "id": "8b2e60bd72ef43f4bb78df1f70e59fef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.003462", "expires":
+        "2018-08-06T17:58:10Z", "id": "122a4a23871846ba9fb32c62be41e8f5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["k8LxVn7wRoCRXv9VFC-drA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aOIabNegQamhRuhPNJdZfg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15924,7 +15924,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15942,13 +15942,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:17 GMT
+      - Mon, 06 Aug 2018 16:58:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b6b8f5ac-784e-4148-afa2-075d404ae6c1
+      - req-044e9382-f4f5-4ac9-bda9-4f7e804b9db4
       Content-Length:
       - '4118'
       Connection:
@@ -15957,10 +15957,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:17.354626", "expires":
-        "2018-08-03T20:34:17Z", "id": "801aa9c7db6e4a1dbbafa12fa9ac0fb4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.353077", "expires":
+        "2018-08-06T17:58:11Z", "id": "affcbfe46cf741368509a41d86187990", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["sQC7uASbT1qDOjHJHALjQw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FGgptCD-S0OqDigMa0usYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16004,7 +16004,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16022,13 +16022,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:17 GMT
+      - Mon, 06 Aug 2018 16:58:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ad465003-83a4-4bd0-bf5e-5f9f74bb22c3
+      - req-c764e730-e0a5-4fcc-948a-50a7bd7de032
       Content-Length:
       - '4117'
       Connection:
@@ -16037,10 +16037,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:17.596954", "expires":
-        "2018-08-03T20:34:17Z", "id": "28a74c3fdd044d908a1609ab263649f6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.629038", "expires":
+        "2018-08-06T17:58:11Z", "id": "cd02b4b039874654a5cf39bb78e41848", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2KHwqZ0rQ5uTNg5gcJJtLQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zCexhadsSp2_LlTQvBl5IQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16084,7 +16084,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16099,22 +16099,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95422de1-301b-4518-854d-070ec5dff1bf
+      - req-30fb9b27-aa44-4abc-be38-839b3b9af813
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-95422de1-301b-4518-854d-070ec5dff1bf
+      - req-30fb9b27-aa44-4abc-be38-839b3b9af813
       Date:
-      - Fri, 03 Aug 2018 19:34:17 GMT
+      - Mon, 06 Aug 2018 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16147,7 +16147,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16162,22 +16162,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07e09c97-0eeb-418e-b806-b421eec31e5d
+      - req-61a2a9ec-1365-498d-b094-e813b39761bd
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-07e09c97-0eeb-418e-b806-b421eec31e5d
+      - req-61a2a9ec-1365-498d-b094-e813b39761bd
       Date:
-      - Fri, 03 Aug 2018 19:34:18 GMT
+      - Mon, 06 Aug 2018 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16218,7 +16218,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16233,22 +16233,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-67194638-7e02-478b-a3be-f48c3d4d46c2
+      - req-a837afcf-7142-4c1a-aac6-5c90250e2964
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-67194638-7e02-478b-a3be-f48c3d4d46c2
+      - req-a837afcf-7142-4c1a-aac6-5c90250e2964
       Date:
-      - Fri, 03 Aug 2018 19:34:18 GMT
+      - Mon, 06 Aug 2018 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16282,7 +16282,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16297,27 +16297,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31ca3972-24ee-49df-8d92-e461f89cc484
+      - req-84e6e1d7-de16-47ca-b201-82d89acaee2f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-31ca3972-24ee-49df-8d92-e461f89cc484
+      - req-84e6e1d7-de16-47ca-b201-82d89acaee2f
       Date:
-      - Fri, 03 Aug 2018 19:34:18 GMT
+      - Mon, 06 Aug 2018 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16335,13 +16335,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:18 GMT
+      - Mon, 06 Aug 2018 16:58:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a39a51ef-3b3f-4a52-823f-7d34cb54c7bc
+      - req-8737bff2-c973-4505-b382-4dc2a432d0b5
       Content-Length:
       - '4131'
       Connection:
@@ -16350,10 +16350,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:19.060816", "expires":
-        "2018-08-03T20:34:19Z", "id": "d33179864f3f4615a6be0c84486ed793", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:13.080960", "expires":
+        "2018-08-06T17:58:13Z", "id": "7a0874fc80964edc829f1d82639a36a0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7cC5L_a-ReWUU6Ht6ESNiQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gd5Bn7IeQvOOBkdOm16y0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16397,7 +16397,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16412,27 +16412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4928496b-3cbc-44f8-9947-feb30d19e7d4
+      - req-ed94a5db-d91f-4dea-9972-222292520b2a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4928496b-3cbc-44f8-9947-feb30d19e7d4
+      - req-ed94a5db-d91f-4dea-9972-222292520b2a
       Date:
-      - Fri, 03 Aug 2018 19:34:19 GMT
+      - Mon, 06 Aug 2018 16:58:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16447,27 +16447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0bb07400-0a0b-4e30-aeca-379a02318c77
+      - req-04a590da-6954-46c6-956b-a870d8f08f1f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0bb07400-0a0b-4e30-aeca-379a02318c77
+      - req-04a590da-6954-46c6-956b-a870d8f08f1f
       Date:
-      - Fri, 03 Aug 2018 19:34:19 GMT
+      - Mon, 06 Aug 2018 16:58:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16485,13 +16485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:19 GMT
+      - Mon, 06 Aug 2018 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b713cb8f-9fa0-43f7-99dc-7b1d2d93c57e
+      - req-0238a50a-e3d7-4156-aea5-ada1c6f146ce
       Content-Length:
       - '4118'
       Connection:
@@ -16500,10 +16500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:19.925057", "expires":
-        "2018-08-03T20:34:19Z", "id": "07a651d029d14572a9ec0de5621a4f14", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:13.875328", "expires":
+        "2018-08-06T17:58:13Z", "id": "74975b8911e548af9490df36a6485b26", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BQ8g-gTrSYy63zXyVIoTrg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nc63IVw-RcaYTsyebea7MQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16547,7 +16547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16562,27 +16562,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8feefab8-11bf-4342-b64b-8ef04c61040c
+      - req-a5c965b1-83b5-417e-b4b7-54774d6a2b0c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8feefab8-11bf-4342-b64b-8ef04c61040c
+      - req-a5c965b1-83b5-417e-b4b7-54774d6a2b0c
       Date:
-      - Fri, 03 Aug 2018 19:34:20 GMT
+      - Mon, 06 Aug 2018 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16597,22 +16597,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7dc2377f-ba3e-4e35-8697-0bfc8516a80c
+      - req-741af599-b5b1-40b0-86fa-afc81628194d
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7dc2377f-ba3e-4e35-8697-0bfc8516a80c
+      - req-741af599-b5b1-40b0-86fa-afc81628194d
       Date:
-      - Fri, 03 Aug 2018 19:34:20 GMT
+      - Mon, 06 Aug 2018 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16627,7 +16627,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16642,22 +16642,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a6615206-9bd5-4eb7-9a1e-c77e73e0aae6
+      - req-9466f7fc-be86-470b-aa8a-3e98d9ef9219
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-a6615206-9bd5-4eb7-9a1e-c77e73e0aae6
+      - req-9466f7fc-be86-470b-aa8a-3e98d9ef9219
       Date:
-      - Fri, 03 Aug 2018 19:34:20 GMT
+      - Mon, 06 Aug 2018 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16672,7 +16672,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16687,27 +16687,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21ce852d-b847-45ae-a4ac-01b6908c2115
+      - req-3177b38c-2b00-4ac2-a0f4-db52e3c02486
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-21ce852d-b847-45ae-a4ac-01b6908c2115
+      - req-3177b38c-2b00-4ac2-a0f4-db52e3c02486
       Date:
-      - Fri, 03 Aug 2018 19:34:20 GMT
+      - Mon, 06 Aug 2018 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16722,27 +16722,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ee97d9d-b5f9-48e5-a8e3-3e09bcb48625
+      - req-a6a0b65b-3948-4d76-bd9c-4bc3a927ad03
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0ee97d9d-b5f9-48e5-a8e3-3e09bcb48625
+      - req-a6a0b65b-3948-4d76-bd9c-4bc3a927ad03
       Date:
-      - Fri, 03 Aug 2018 19:34:20 GMT
+      - Mon, 06 Aug 2018 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16757,27 +16757,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e2aac28-e889-4a62-a09d-e383820322b4
+      - req-ae8044a4-1baf-4d4a-b19b-da7d8349c371
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0e2aac28-e889-4a62-a09d-e383820322b4
+      - req-ae8044a4-1baf-4d4a-b19b-da7d8349c371
       Date:
-      - Fri, 03 Aug 2018 19:34:21 GMT
+      - Mon, 06 Aug 2018 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16792,27 +16792,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b4e31cab-ce62-4eb8-a0ba-15fe184553e6
+      - req-2c1ffb93-68cd-4a6f-9980-956cb297cb29
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b4e31cab-ce62-4eb8-a0ba-15fe184553e6
+      - req-2c1ffb93-68cd-4a6f-9980-956cb297cb29
       Date:
-      - Fri, 03 Aug 2018 19:34:21 GMT
+      - Mon, 06 Aug 2018 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16827,27 +16827,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6cb2b54-3b1a-4f65-b4e6-bb4d4922cabf
+      - req-e2ce6df2-7387-4d39-be43-2ca93b8b591e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b6cb2b54-3b1a-4f65-b4e6-bb4d4922cabf
+      - req-e2ce6df2-7387-4d39-be43-2ca93b8b591e
       Date:
-      - Fri, 03 Aug 2018 19:34:21 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16862,27 +16862,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3f1824f-820f-4d50-9dee-e4fa11f25391
+      - req-70b60372-eac7-4e09-a60f-4a4f12b429f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b3f1824f-820f-4d50-9dee-e4fa11f25391
+      - req-70b60372-eac7-4e09-a60f-4a4f12b429f0
       Date:
-      - Fri, 03 Aug 2018 19:34:21 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16897,27 +16897,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e58c4f5c-1d60-4d8b-aa58-74713714cc7b
+      - req-5ec533a7-d0ff-41f8-9667-6d0c74b03de8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e58c4f5c-1d60-4d8b-aa58-74713714cc7b
+      - req-5ec533a7-d0ff-41f8-9667-6d0c74b03de8
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16932,27 +16932,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4568f3f2-6096-4ea6-a9f8-c4f275534002
+      - req-e4c912c6-9fec-4986-ade2-0f4ae2be9c16
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4568f3f2-6096-4ea6-a9f8-c4f275534002
+      - req-e4c912c6-9fec-4986-ade2-0f4ae2be9c16
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16967,27 +16967,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4af02f3c-0bb6-4e9f-b565-6bc3fde63f74
+      - req-48c87f85-fb88-4c2e-9cae-1dcc5897c22b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4af02f3c-0bb6-4e9f-b565-6bc3fde63f74
+      - req-48c87f85-fb88-4c2e-9cae-1dcc5897c22b
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17002,27 +17002,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-45aab558-d369-4ddd-86aa-cccd21a8995c
+      - req-05e06093-230a-4577-8d3f-770b629c8ef5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-45aab558-d369-4ddd-86aa-cccd21a8995c
+      - req-05e06093-230a-4577-8d3f-770b629c8ef5
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17037,27 +17037,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-539f62ad-af80-4d7d-9405-ea52a0740d32
+      - req-e2d3a838-9cd2-44c6-a70a-65a0bc9678e9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-539f62ad-af80-4d7d-9405-ea52a0740d32
+      - req-e2d3a838-9cd2-44c6-a70a-65a0bc9678e9
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17072,27 +17072,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a43c8a8-e795-470c-9089-84e19bed00e6
+      - req-86e69f32-7192-4bc5-adcf-ce93f171bae3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9a43c8a8-e795-470c-9089-84e19bed00e6
+      - req-86e69f32-7192-4bc5-adcf-ce93f171bae3
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17107,27 +17107,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76188222-a78b-4e94-9524-a17925115ed5
+      - req-aa1132ad-efa3-4b88-9c39-ace8bb41f9aa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-76188222-a78b-4e94-9524-a17925115ed5
+      - req-aa1132ad-efa3-4b88-9c39-ace8bb41f9aa
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17142,27 +17142,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42eebf7f-13f6-4f25-9293-4ed15fa10153
+      - req-4f89928b-bb0d-4c96-8de2-2b63aa6b73a7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-42eebf7f-13f6-4f25-9293-4ed15fa10153
+      - req-4f89928b-bb0d-4c96-8de2-2b63aa6b73a7
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17177,22 +17177,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-74f89104-50ac-4428-ba97-62b91bddcbc1
+      - req-fbdcfc48-1600-40e2-99a6-0459ec7c2043
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-74f89104-50ac-4428-ba97-62b91bddcbc1
+      - req-fbdcfc48-1600-40e2-99a6-0459ec7c2043
       Date:
-      - Fri, 03 Aug 2018 19:34:22 GMT
+      - Mon, 06 Aug 2018 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17204,7 +17204,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17219,22 +17219,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a74c3fdd044d908a1609ab263649f6
+      - cd02b4b039874654a5cf39bb78e41848
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89767a20-5717-4584-9c51-58050008f4b2
+      - req-b41a97cb-7087-41e3-982a-b96323d1fa75
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-89767a20-5717-4584-9c51-58050008f4b2
+      - req-b41a97cb-7087-41e3-982a-b96323d1fa75
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17246,7 +17246,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17261,22 +17261,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1901fa9b-2d8b-48aa-b574-d8d348e89e8b
+      - req-22501124-4bbc-4ee6-ad1d-76b4f3c3ea9c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1901fa9b-2d8b-48aa-b574-d8d348e89e8b
+      - req-22501124-4bbc-4ee6-ad1d-76b4f3c3ea9c
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17288,7 +17288,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17303,22 +17303,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d33179864f3f4615a6be0c84486ed793
+      - 7a0874fc80964edc829f1d82639a36a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-17ec307d-3d8e-4808-bb3a-01593434ebe1
+      - req-1250d72f-6145-4eb0-8886-8fe11912f8a9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-17ec307d-3d8e-4808-bb3a-01593434ebe1
+      - req-1250d72f-6145-4eb0-8886-8fe11912f8a9
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17330,7 +17330,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17345,22 +17345,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a7b1857-a0a7-414e-ac73-81595a9f2729
+      - req-e5d6d34b-956d-4bfb-8b22-004f7a748ba2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0a7b1857-a0a7-414e-ac73-81595a9f2729
+      - req-e5d6d34b-956d-4bfb-8b22-004f7a748ba2
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17372,7 +17372,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17387,22 +17387,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1044e95492354d858308a40e6b63d1a7
+      - 1a39c26dfda042d9a2bc616fa21f5ab5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-30dcc902-436c-4b41-ba66-bcc46a5081f7
+      - req-3ba0d749-27f3-4ec0-a315-40ea52be59d3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-30dcc902-436c-4b41-ba66-bcc46a5081f7
+      - req-3ba0d749-27f3-4ec0-a315-40ea52be59d3
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17414,7 +17414,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17429,22 +17429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81001f47-fdcc-4c37-b7d7-4c681847b245
+      - req-107dfd0f-d3ad-405e-926c-41a35e13073f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-81001f47-fdcc-4c37-b7d7-4c681847b245
+      - req-107dfd0f-d3ad-405e-926c-41a35e13073f
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17456,7 +17456,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17471,22 +17471,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a651d029d14572a9ec0de5621a4f14
+      - 74975b8911e548af9490df36a6485b26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3dd4797e-74c5-4478-a6fe-3ab8f291159b
+      - req-1852f0a1-d90f-42fc-8394-29b416f1fd62
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3dd4797e-74c5-4478-a6fe-3ab8f291159b
+      - req-1852f0a1-d90f-42fc-8394-29b416f1fd62
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17498,7 +17498,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17516,13 +17516,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:23 GMT
+      - Mon, 06 Aug 2018 16:58:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-99dd87eb-a8e4-4141-be03-cd8c30228cec
+      - req-19885b70-f4bd-4f23-bd5b-e4c85841fa90
       Content-Length:
       - '4170'
       Connection:
@@ -17531,10 +17531,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:24.123850", "expires":
-        "2018-08-03T20:34:24Z", "id": "cd07b95f7ac6490a8a4f68123073dbca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:18.924647", "expires":
+        "2018-08-06T17:58:18Z", "id": "4e83aeed5d484917809eee610fcb7eb4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0u9CZg41Quyk736tfWYi1g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MKIbnPqIQ8KpkpbC3QSbzg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17579,7 +17579,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17597,13 +17597,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:24 GMT
+      - Mon, 06 Aug 2018 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d73610d-17f5-402f-bede-c4983a915922
+      - req-9f7e46b3-29ee-4ed0-8da3-f1b7707d1e6f
       Content-Length:
       - '4170'
       Connection:
@@ -17612,10 +17612,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:24.467023", "expires":
-        "2018-08-03T20:34:24Z", "id": "edb7a49b34d547359331123a8f3657ab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.312054", "expires":
+        "2018-08-06T17:58:19Z", "id": "1c5d03ccfb8f4ec7b349578773069908", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fTDqU8nXQ4KzgTavrUX6MQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["w1hRQQrbRky3TfBM6D2K-g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17660,7 +17660,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17678,13 +17678,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:24 GMT
+      - Mon, 06 Aug 2018 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbdb5a01-483e-4ab5-ab0a-61c7fb1bd772
+      - req-444287ea-2147-4266-a35b-b8e2bfa77745
       Content-Length:
       - '370'
       Connection:
@@ -17693,13 +17693,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:24.659396", "expires":
-        "2018-08-03T20:34:24Z", "id": "68273517ef9d4e7e8aaab3c1a3f42c61", "audit_ids":
-        ["c9ZiZ8PLRGitQzAC-_719w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.517058", "expires":
+        "2018-08-06T17:58:19Z", "id": "d6d8a76707c44fa1b74726c4cccb01a0", "audit_ids":
+        ["YpG1zWt9QCqHIPdId5eSZg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17714,20 +17714,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68273517ef9d4e7e8aaab3c1a3f42c61
+      - d6d8a76707c44fa1b74726c4cccb01a0
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:24 GMT
+      - Mon, 06 Aug 2018 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8bc3682a-0c9c-4a41-bb18-e8373a1b1b12
+      - req-04f5ee99-31e7-432c-b7d4-3b505553f7a6
       Content-Length:
       - '500'
       Connection:
@@ -17744,13 +17744,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"68273517ef9d4e7e8aaab3c1a3f42c61"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"d6d8a76707c44fa1b74726c4cccb01a0"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17762,13 +17762,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:24 GMT
+      - Mon, 06 Aug 2018 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-974afd80-51cd-44d2-b153-25bb8ae5b90b
+      - req-87b56b9b-e77e-473d-a4b8-5f732a73e948
       Content-Length:
       - '4143'
       Connection:
@@ -17777,11 +17777,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:25.107507", "expires":
-        "2018-08-03T20:34:24Z", "id": "252a33f6438e47de975368284008ff97", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.926574", "expires":
+        "2018-08-06T17:58:19Z", "id": "b069567866c94658af6d5ac91a486433", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["URbzK7KYRgyvNQskFarTpA",
-        "c9ZiZ8PLRGitQzAC-_719w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bKukrPWiSlCj57NyPPR7Kw",
+        "YpG1zWt9QCqHIPdId5eSZg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17825,7 +17825,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17840,20 +17840,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68273517ef9d4e7e8aaab3c1a3f42c61
+      - d6d8a76707c44fa1b74726c4cccb01a0
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:25 GMT
+      - Mon, 06 Aug 2018 16:58:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b257059f-8332-4742-b23a-de504f89107c
+      - req-d2c92e08-4e2b-48b2-8c40-fa1c4e7c6425
       Content-Length:
       - '500'
       Connection:
@@ -17870,7 +17870,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17888,13 +17888,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:25 GMT
+      - Mon, 06 Aug 2018 16:58:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d4944a51-6288-496d-ac82-d32c803062d9
+      - req-e18a7c45-e0f0-43bd-b344-b6e7fb0a32c0
       Content-Length:
       - '4117'
       Connection:
@@ -17903,10 +17903,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:25.629009", "expires":
-        "2018-08-03T20:34:25Z", "id": "2ef688219eef45e8912d4e4607eda5a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:20.394521", "expires":
+        "2018-08-06T17:58:20Z", "id": "978c29f254c4495a995dd0d27b436c66", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BiZu1nf4R1-5a8tvnZ5UKg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Z2NkwnjzQ4uW1tS24zK9FQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17950,7 +17950,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17968,13 +17968,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:25 GMT
+      - Mon, 06 Aug 2018 16:58:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c7193865-8ff2-4928-9c41-71b9c96cae44
+      - req-b9227d85-8ff6-4e7c-b7b5-51732c0a6462
       Content-Length:
       - '4131'
       Connection:
@@ -17983,10 +17983,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:25.931369", "expires":
-        "2018-08-03T20:34:25Z", "id": "53b7ad43e03346ef9cd11064b47819b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:20.753524", "expires":
+        "2018-08-06T17:58:20Z", "id": "4f942d6adf394d68b02a12836040f4cb", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["YOSVgJ4STu60uBKUCWGWNQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Z3yJM8GXQjCh0ozGte8KNA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18030,7 +18030,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18048,13 +18048,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:26 GMT
+      - Mon, 06 Aug 2018 16:58:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b5a30d40-38b8-4752-8ab5-94ac1a7599a6
+      - req-2b663e15-115d-4f19-9cc3-e4c31ed5dce7
       Content-Length:
       - '4118'
       Connection:
@@ -18063,10 +18063,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:26.250343", "expires":
-        "2018-08-03T20:34:26Z", "id": "4b2f6056c855499f886c212900465780", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:21.102500", "expires":
+        "2018-08-06T17:58:21Z", "id": "c12fa0d1909641b5804aa432e5698af0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Dj_pC22lRT669ah_NI2EsA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4LPFUHxcSAu1pKxKXv8BUg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18110,7 +18110,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18128,13 +18128,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:26 GMT
+      - Mon, 06 Aug 2018 16:58:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e86585c-a653-4fb9-94b6-7ea248464cbf
+      - req-94d7b89a-0dba-4465-ad52-aea4c915deac
       Content-Length:
       - '4117'
       Connection:
@@ -18143,10 +18143,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:26.538902", "expires":
-        "2018-08-03T20:34:26Z", "id": "6fa5694894b947768a98081e34c98bba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:21.446549", "expires":
+        "2018-08-06T17:58:21Z", "id": "255bc45c87f9432198831744313344ed", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["beNpGnCsQHyIaYBWrq2YUQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v4GZjI-dROaLpBwUC8Ndhw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18190,7 +18190,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18205,7 +18205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6fa5694894b947768a98081e34c98bba
+      - 255bc45c87f9432198831744313344ed
   response:
     status:
       code: 200
@@ -18234,15 +18234,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx914f5d3383a54b4e81514-005b64ae42
+      - txb1d1debe4f7343bb94b4a-005b687e2d
       Date:
-      - Fri, 03 Aug 2018 19:34:26 GMT
+      - Mon, 06 Aug 2018 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18257,7 +18257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6fa5694894b947768a98081e34c98bba
+      - 255bc45c87f9432198831744313344ed
   response:
     status:
       code: 200
@@ -18286,14 +18286,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx9158e552d5a24b4a94ccf-005b64ae43
+      - txf96d47e9135949dfb2ba2-005b687e2d
       Date:
-      - Fri, 03 Aug 2018 19:34:27 GMT
+      - Mon, 06 Aug 2018 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18311,13 +18311,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:27 GMT
+      - Mon, 06 Aug 2018 16:58:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1659d8c6-872e-4010-bec7-c4d461fcb84c
+      - req-b6c9a3e1-696e-4847-a09c-3e9ccfc8fdb8
       Content-Length:
       - '4131'
       Connection:
@@ -18326,10 +18326,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:27.561362", "expires":
-        "2018-08-03T20:34:27Z", "id": "48cbe0a21d2640d4913345ccdbc01925", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:22.237091", "expires":
+        "2018-08-06T17:58:22Z", "id": "caf2ec60224e44029b9f392214f467f9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["bqgTG3jbT9uenj_zfjaF-g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eqtwITeiRGeCanfuOM7q-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18373,7 +18373,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18388,7 +18388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48cbe0a21d2640d4913345ccdbc01925
+      - caf2ec60224e44029b9f392214f467f9
   response:
     status:
       code: 200
@@ -18401,22 +18401,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324867.93549'
+      - '1533574702.64951'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324867.93549'
+      - '1533574702.64951'
       X-Trans-Id:
-      - tx0cf3c88b6f7b48c2b4253-005b64ae43
+      - tx0463b7d5bad9471a99e91-005b687e2e
       Date:
-      - Fri, 03 Aug 2018 19:34:27 GMT
+      - Mon, 06 Aug 2018 16:58:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18431,7 +18431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edb7a49b34d547359331123a8f3657ab
+      - 1c5d03ccfb8f4ec7b349578773069908
   response:
     status:
       code: 200
@@ -18444,22 +18444,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324868.22345'
+      - '1533574703.24752'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324868.22345'
+      - '1533574703.24752'
       X-Trans-Id:
-      - tx49ce3ee0bdb54c098efe6-005b64ae44
+      - txa65ae97e8de745de872fe-005b687e2e
       Date:
-      - Fri, 03 Aug 2018 19:34:28 GMT
+      - Mon, 06 Aug 2018 16:58:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18477,13 +18477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:28 GMT
+      - Mon, 06 Aug 2018 16:58:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f4b2695-4ad1-4d55-ad5f-cb478bc09706
+      - req-5975d212-d5a4-40ff-a6b7-d3b87860d0cf
       Content-Length:
       - '4118'
       Connection:
@@ -18492,10 +18492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:28.458867", "expires":
-        "2018-08-03T20:34:28Z", "id": "6b93ee2d6be04d25b5b7c47e0e3ddd2b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:23.499014", "expires":
+        "2018-08-06T17:58:23Z", "id": "717776244bc6473dadc5ee0aa1fe13b5", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["uMZ9gZ5XSJSO1GCkVYpazw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F5NsyGexRr67qnNnc8e-6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18539,7 +18539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18554,7 +18554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b93ee2d6be04d25b5b7c47e0e3ddd2b
+      - 717776244bc6473dadc5ee0aa1fe13b5
   response:
     status:
       code: 200
@@ -18567,22 +18567,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324868.71545'
+      - '1533574703.79187'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324868.71545'
+      - '1533574703.79187'
       X-Trans-Id:
-      - tx6f1525eeebce4e009520d-005b64ae44
+      - tx90a8146c694442b2b8f10-005b687e2f
       Date:
-      - Fri, 03 Aug 2018 19:34:28 GMT
+      - Mon, 06 Aug 2018 16:58:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -18597,7 +18597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6fa5694894b947768a98081e34c98bba
+      - 255bc45c87f9432198831744313344ed
   response:
     status:
       code: 200
@@ -18618,9 +18618,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbc69e067d4324054b019c-005b64ae44
+      - txac612dbf88914edda6569-005b687e2f
       Date:
-      - Fri, 03 Aug 2018 19:34:28 GMT
+      - Mon, 06 Aug 2018 16:58:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -18630,7 +18630,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -18645,7 +18645,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6fa5694894b947768a98081e34c98bba
+      - 255bc45c87f9432198831744313344ed
   response:
     status:
       code: 200
@@ -18666,14 +18666,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd4d4204bf71546a1b1753-005b64ae44
+      - tx066b1504a6944a8fabb2d-005b687e2f
       Date:
-      - Fri, 03 Aug 2018 19:34:28 GMT
+      - Mon, 06 Aug 2018 16:58:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -18688,7 +18688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6fa5694894b947768a98081e34c98bba
+      - 255bc45c87f9432198831744313344ed
   response:
     status:
       code: 200
@@ -18709,12 +18709,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx311d935d4abf46a6a3efa-005b64ae44
+      - txa0a4ae1b98b34d5fadb43-005b687e30
       Date:
-      - Fri, 03 Aug 2018 19:34:29 GMT
+      - Mon, 06 Aug 2018 16:58:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:43 GMT
+      - Mon, 06 Aug 2018 16:58:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30655ee0-264d-41dc-9606-34c26e6e1456
+      - req-f5b2c7da-1c15-4b63-a8c7-1df4cb3abcb7
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:44.006057", "expires":
-        "2018-08-03T20:37:43Z", "id": "b004285efc644179b6c665cf492d3799", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:33.126068", "expires":
+        "2018-08-06T17:58:33Z", "id": "4ebf59a4fffa4e3ca02f9a5eee94c5c5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Xq93NxeUT2-8XvSzz2kidQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["6AR_kmuOSvq-LoLjYoHxKQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:44 GMT
+      - Mon, 06 Aug 2018 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-a538b81e-1a4d-42a2-89dd-e0d133433e61
+      - req-a692d5a2-e2e4-45fb-bc49-7b9106aa8319
       Date:
-      - Fri, 03 Aug 2018 19:37:44 GMT
+      - Mon, 06 Aug 2018 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:44 GMT
+      - Mon, 06 Aug 2018 16:58:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-39bb374b-0d7b-4c59-8404-b152fcb83565
+      - req-d824212a-47a1-417d-8fe0-d28bd12fbb8b
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:44.835440", "expires":
-        "2018-08-03T20:37:44Z", "id": "b7b538b91635497a8c930bc0a18d66e0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:33.730159", "expires":
+        "2018-08-06T17:58:33Z", "id": "96f1c6ea1b754c319f0e5f0d9c3a67bc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zy9X35ZhQIq7XB5m0P9E3w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["KFL_BUS0Tgih0RfuQa968g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63c7b594-dabe-42ae-b9e7-fd2e3c763a2f
+      - req-44f0a672-c3bc-4bc2-9ac9-bbb315a65e83
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-63c7b594-dabe-42ae-b9e7-fd2e3c763a2f
+      - req-44f0a672-c3bc-4bc2-9ac9-bbb315a65e83
       Date:
-      - Fri, 03 Aug 2018 19:37:45 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7e1773ce-6112-4971-85f4-1e4a1b65e8f2
+      - req-2a7a47a1-ca20-4561-8580-8c6153de7e30
       Date:
-      - Fri, 03 Aug 2018 19:37:45 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:37:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:58:30.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:37:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:37:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:58:32.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:37:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:37:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:58:30.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7bdf2ebb-901d-422a-8c85-fea9444ee24f
+      - req-94256caa-de1e-4743-8b7f-203943eab544
       Date:
-      - Fri, 03 Aug 2018 19:37:45 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:37:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:58:30.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:37:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:37:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:58:32.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:37:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:37:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:58:30.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-282ed381-584e-43a1-9b65-4ce301d031fe
+      - req-e86ee544-9393-45fa-a54e-b4a1cc970742
       Date:
-      - Fri, 03 Aug 2018 19:37:45 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-f9409dca-975d-4315-a712-f61de3561c17
+      - req-85aaa969-23f1-4194-88d5-c17e2040d35e
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-58bada84-0a20-4c5f-a418-b4b59fcea111
+      - req-482ab363-1bd1-4cfd-a7fb-2ac7165c4913
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-81ed0dcc-5a37-45f2-8d85-93db556f2b8e
+      - req-bca236f2-4f90-4b92-8a0f-5aaa7821b790
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c39afe4a-58e9-48e1-8bf7-de3fdcc8523c
+      - req-701fbe72-4ff6-481b-9270-6578cb47750c
       Content-Length:
       - '4170'
       Connection:
@@ -568,10 +568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:46.652992", "expires":
-        "2018-08-03T20:37:46Z", "id": "894267e3fa4c44ab8bd195a713ef16b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:35.198234", "expires":
+        "2018-08-06T17:58:35Z", "id": "0ecc31df08454f249f592dde69dfd5b4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rjRVCdtLTR6jvBioa49yGQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["8l2sttNeQ6K3YSs_RAXfuQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -616,7 +616,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -631,20 +631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 894267e3fa4c44ab8bd195a713ef16b7
+      - 0ecc31df08454f249f592dde69dfd5b4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f6b5501c-44fa-4afb-8980-ed11f11bca13
+      - req-34d16ea9-1ccc-4820-b1eb-24d3a3aed0bf
       Content-Length:
       - '500'
       Connection:
@@ -661,7 +661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -676,7 +676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -689,15 +689,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-1247c3dd-51bd-4188-bf1d-132c381d55c2
+      - req-7d65f6b9-065f-47d9-8ca7-2c28dde3e23c
       Date:
-      - Fri, 03 Aug 2018 19:37:46 GMT
+      - Mon, 06 Aug 2018 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -715,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:47 GMT
+      - Mon, 06 Aug 2018 16:58:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-016d7934-b637-42ec-88ee-2e4377c6ac00
+      - req-b5857e23-8905-47c5-99df-da9a58d20bb8
       Content-Length:
       - '4170'
       Connection:
@@ -730,10 +730,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:47.304632", "expires":
-        "2018-08-03T20:37:47Z", "id": "fb8f409f9cd64f3694e728358e9d9a76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:35.666608", "expires":
+        "2018-08-06T17:58:35Z", "id": "398b62f954a64f78ac12354c9159e6b6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["V-GfsjcCRD6ui7eTkl3MJQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zQ0HfZc3Rh2RZduDeihiRg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -778,7 +778,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -793,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb8f409f9cd64f3694e728358e9d9a76
+      - 398b62f954a64f78ac12354c9159e6b6
   response:
     status:
       code: 300
@@ -804,7 +804,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:37:47 GMT
+      - Mon, 06 Aug 2018 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -817,7 +817,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -832,7 +832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb8f409f9cd64f3694e728358e9d9a76
+      - 398b62f954a64f78ac12354c9159e6b6
   response:
     status:
       code: 200
@@ -843,14 +843,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6b778af6-6aaa-41c1-92fa-b73aeea8712a
+      - req-530dde98-1c3d-4c1b-a6c7-d81129600576
       Date:
-      - Fri, 03 Aug 2018 19:37:47 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -865,7 +865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb8f409f9cd64f3694e728358e9d9a76
+      - 398b62f954a64f78ac12354c9159e6b6
   response:
     status:
       code: 200
@@ -876,9 +876,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f73895d6-f4c1-41da-835d-154c8afd64f4
+      - req-68403965-35f3-4a18-9ef2-e6043ee1cf86
       Date:
-      - Fri, 03 Aug 2018 19:37:48 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -920,7 +920,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -935,7 +935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -948,9 +948,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-23a6c562-974a-4957-a918-6c232dbed8fa
+      - req-ab700580-706d-4ec0-a842-082b774deef7
       Date:
-      - Fri, 03 Aug 2018 19:37:48 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -960,7 +960,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -975,7 +975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -988,9 +988,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6d492f97-78e1-49f5-b546-5fd3c4f239d0
+      - req-14575cbc-fea9-4e6b-a9da-dbaac56dbaec
       Date:
-      - Fri, 03 Aug 2018 19:37:48 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1000,7 +1000,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +1018,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:48 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-095ba043-956a-4078-b838-51928b1b31ee
+      - req-0f6ee9c8-1210-4903-863a-72b5c6657f0f
       Content-Length:
       - '4170'
       Connection:
@@ -1033,10 +1033,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:48.789323", "expires":
-        "2018-08-03T20:37:48Z", "id": "cb4de28274b84bc08ad50d5ccf93f843", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:36.714201", "expires":
+        "2018-08-06T17:58:36Z", "id": "17fa0eb35a8b41b29043e32ec238b3f8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8oFeVwZ9TNWSG7SE-z0ezA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TvbWdRWtTKWhIc0awwlo4Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1081,7 +1081,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1099,13 +1099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:49 GMT
+      - Mon, 06 Aug 2018 16:58:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f33eead-0417-4b73-8e08-e96fa3c31780
+      - req-1fa26653-a854-43e6-9651-cd4afa9038d3
       Content-Length:
       - '370'
       Connection:
@@ -1114,13 +1114,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:49.243577", "expires":
-        "2018-08-03T20:37:49Z", "id": "300bc30796aa4422934cd4864bbc649b", "audit_ids":
-        ["LWMI3hxlQx6Jr68RHU8QMw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:36.909029", "expires":
+        "2018-08-06T17:58:36Z", "id": "fc712f2ffa1c4e02b91e577aa66701cd", "audit_ids":
+        ["2tviKPqCTYqbIPS9GqlAPg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1135,20 +1135,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 300bc30796aa4422934cd4864bbc649b
+      - fc712f2ffa1c4e02b91e577aa66701cd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:49 GMT
+      - Mon, 06 Aug 2018 16:58:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f4f81364-759b-4755-b33f-5141f8f23023
+      - req-b1ccb15f-c292-48d8-983b-529f9377b770
       Content-Length:
       - '500'
       Connection:
@@ -1165,13 +1165,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"300bc30796aa4422934cd4864bbc649b"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"fc712f2ffa1c4e02b91e577aa66701cd"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1183,13 +1183,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:49 GMT
+      - Mon, 06 Aug 2018 16:58:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-118aebf0-6bc2-4360-83ca-bb3613dfa972
+      - req-4c3cba92-dcf9-4d64-b7cc-e31bc72a7f29
       Content-Length:
       - '4143'
       Connection:
@@ -1198,11 +1198,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:49.801407", "expires":
-        "2018-08-03T20:37:49Z", "id": "1d09a3b6cc2244d3924dcac219dd0739", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:37.380434", "expires":
+        "2018-08-06T17:58:36Z", "id": "26def23b7455432c8e7bb476f18e8a13", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["oVhKlnLxRdqMPvUTvi1fKA",
-        "LWMI3hxlQx6Jr68RHU8QMw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["c7Lj2f7iRB-v3KNFDFDB2Q",
+        "2tviKPqCTYqbIPS9GqlAPg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1246,7 +1246,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1261,20 +1261,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 300bc30796aa4422934cd4864bbc649b
+      - fc712f2ffa1c4e02b91e577aa66701cd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:49 GMT
+      - Mon, 06 Aug 2018 16:58:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d75e39d-5a73-460d-8eb7-de60c287d592
+      - req-c009dd29-0ace-4fb8-a6e1-83f73deb6b2c
       Content-Length:
       - '500'
       Connection:
@@ -1291,7 +1291,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1309,13 +1309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:50 GMT
+      - Mon, 06 Aug 2018 16:58:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-903b4fa8-c498-4e24-a872-332840c56e93
+      - req-a500e178-e781-4e43-aeb4-43d9a3c1e815
       Content-Length:
       - '4117'
       Connection:
@@ -1324,10 +1324,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:50.354086", "expires":
-        "2018-08-03T20:37:50Z", "id": "2ede52f562ca459fa872c998f4a29e10", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:37.802699", "expires":
+        "2018-08-06T17:58:37Z", "id": "d94f732ed99e452d84cafd89d277cc7e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Nmk12d9hQGesTRV6mAR_zg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HxQJEVq1QMmQ9aQkgPx-6w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1371,7 +1371,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1386,7 +1386,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ede52f562ca459fa872c998f4a29e10
+      - d94f732ed99e452d84cafd89d277cc7e
   response:
     status:
       code: 200
@@ -1397,7 +1397,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:50 GMT
+      - Mon, 06 Aug 2018 16:58:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1406,7 +1406,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1424,13 +1424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:50 GMT
+      - Mon, 06 Aug 2018 16:58:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d62690cc-846a-4699-b4a3-dc4a351e349a
+      - req-a6fa9713-b6f8-4633-abb5-4e6c314e4c1b
       Content-Length:
       - '4131'
       Connection:
@@ -1439,10 +1439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:50.742918", "expires":
-        "2018-08-03T20:37:50Z", "id": "c316da1acb344344b13a3c5c27c0928e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.155229", "expires":
+        "2018-08-06T17:58:38Z", "id": "806c4413c2914055ba268043ff4a1557", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VGuzJpYJSQyAxwvV7svKxw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VJkXqGhkQUKAHpsr9OvBoQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1486,7 +1486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1501,7 +1501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c316da1acb344344b13a3c5c27c0928e
+      - 806c4413c2914055ba268043ff4a1557
   response:
     status:
       code: 200
@@ -1512,7 +1512,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:50 GMT
+      - Mon, 06 Aug 2018 16:58:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1521,7 +1521,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1539,13 +1539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:50 GMT
+      - Mon, 06 Aug 2018 16:58:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29340f01-c075-4d03-85f0-916f501fc095
+      - req-6c89109d-0c52-4c48-963f-8511dd57c5f9
       Content-Length:
       - '4118'
       Connection:
@@ -1554,10 +1554,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:51.172045", "expires":
-        "2018-08-03T20:37:51Z", "id": "ecbca8974e1e4a25805a89206f115594", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.431903", "expires":
+        "2018-08-06T17:58:38Z", "id": "6368f71d4447459794e46941aa627e9b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dUvQ-g2MSJuiw_tps-uB6g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oPMv8WD-T8aUX1roARUPSw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1601,7 +1601,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1616,7 +1616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecbca8974e1e4a25805a89206f115594
+      - 6368f71d4447459794e46941aa627e9b
   response:
     status:
       code: 200
@@ -1627,7 +1627,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:51 GMT
+      - Mon, 06 Aug 2018 16:58:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1636,7 +1636,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1654,13 +1654,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:51 GMT
+      - Mon, 06 Aug 2018 16:58:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cab73c0e-e9ec-473a-9b51-efd4be1e1747
+      - req-a5faf062-4881-484f-9ff2-09c51d021048
       Content-Length:
       - '4117'
       Connection:
@@ -1669,10 +1669,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:51.579576", "expires":
-        "2018-08-03T20:37:51Z", "id": "5765ac05b4a54ccbb582b680a62ee7d4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.709932", "expires":
+        "2018-08-06T17:58:38Z", "id": "ab4d6f43c6b1486cb45ce4d6a2a88ca4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yJKQIeZsQ1qDH_J-r5_LLQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vcoRmKV4Truer8J_2X3FhQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1716,7 +1716,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1731,7 +1731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -1742,9 +1742,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-15d67abd-26b0-41d3-8189-afc0cc329283
+      - req-08d8fe75-e74c-4f5e-ba5d-9d6906bd1b6c
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1778,7 +1778,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1793,7 +1793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -1804,14 +1804,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bb72bc1b-9ba8-4bf3-8823-98f5de93752c
+      - req-98962cdd-72c9-4455-8435-93065aff6168
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1829,13 +1829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d58c8e71-6f6a-4921-968d-7a594a23595f
+      - req-79c6983c-aa3d-43fb-8b66-f2e6ad52e86f
       Content-Length:
       - '4131'
       Connection:
@@ -1844,10 +1844,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:52.327139", "expires":
-        "2018-08-03T20:37:52Z", "id": "c7a06a8054bb47dfa0cd315c9fb5a86a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:39.409333", "expires":
+        "2018-08-06T17:58:39Z", "id": "6f6088c4cc17498b86d60a4e1ad03903", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["L2yZoC_0SxaVrwqUOu1zNA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["e6hLLJceQhGWbLyzoq1pjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1891,7 +1891,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1906,7 +1906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7a06a8054bb47dfa0cd315c9fb5a86a
+      - 6f6088c4cc17498b86d60a4e1ad03903
   response:
     status:
       code: 200
@@ -1917,14 +1917,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7428caf5-ed0d-4e59-ae26-1b2b806335f9
+      - req-acf19525-6a13-4c08-9a43-afa30858e545
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1939,7 +1939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb4de28274b84bc08ad50d5ccf93f843
+      - 17fa0eb35a8b41b29043e32ec238b3f8
   response:
     status:
       code: 200
@@ -1950,14 +1950,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-19e8e581-2597-4a8a-80ad-36a053d06bdd
+      - req-d2f80e33-fca2-4db0-b5ca-e5f079217a89
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1975,13 +1975,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:52 GMT
+      - Mon, 06 Aug 2018 16:58:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51b982ed-672c-45b8-92e1-16f4c99a829f
+      - req-54cb2fc6-268d-45df-b2f3-42ff4ec2cbeb
       Content-Length:
       - '4118'
       Connection:
@@ -1990,10 +1990,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:53.045544", "expires":
-        "2018-08-03T20:37:53Z", "id": "7a232e7e5e0d440bad435313b1c38579", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:40.464906", "expires":
+        "2018-08-06T17:58:40Z", "id": "5404da4d73394d6b82bf6bd8489d7bd0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["D8p7KFA-TH-CSsFK00yTqw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jfRjnGYGTRy8Jtzsff12Wg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2037,7 +2037,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2052,7 +2052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a232e7e5e0d440bad435313b1c38579
+      - 5404da4d73394d6b82bf6bd8489d7bd0
   response:
     status:
       code: 200
@@ -2063,14 +2063,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-42a6b9b1-68d2-4148-a1a1-d802beec898f
+      - req-12d5c0ff-03bc-4e39-83b4-6c74f2abc743
       Date:
-      - Fri, 03 Aug 2018 19:37:53 GMT
+      - Mon, 06 Aug 2018 16:58:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2085,7 +2085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2096,9 +2096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a94fe170-42ff-4672-9e62-8acafb7e7d6d
+      - req-fa6c6c76-5ea1-4bb5-886f-07e936a0d9dd
       Date:
-      - Fri, 03 Aug 2018 19:37:54 GMT
+      - Mon, 06 Aug 2018 16:58:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2125,7 +2125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2140,7 +2140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2151,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3ada7cbb-5a10-4c0e-9945-970a03ec4733
+      - req-d3b0d8fa-e556-4dff-83e3-92a66e208b88
       Date:
-      - Fri, 03 Aug 2018 19:37:54 GMT
+      - Mon, 06 Aug 2018 16:58:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2180,7 +2180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2206,9 +2206,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8ac2f459-0533-48d9-9330-26aa222de594
+      - req-1a88e110-9e8b-4977-8433-1c7f01d20487
       Date:
-      - Fri, 03 Aug 2018 19:37:55 GMT
+      - Mon, 06 Aug 2018 16:58:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2235,7 +2235,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -2250,7 +2250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2261,9 +2261,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-6a83f22b-b462-4439-9162-b8120b281384
+      - req-98607303-7f9d-40fa-9f51-3a9ead529dff
       Date:
-      - Fri, 03 Aug 2018 19:37:55 GMT
+      - Mon, 06 Aug 2018 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2319,7 +2319,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -2334,7 +2334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2345,9 +2345,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5c7e9c18-b61d-4321-bfd2-7adfe6fba6ff
+      - req-57f4e030-91ff-4fb1-9171-852c16ab867e
       Date:
-      - Fri, 03 Aug 2018 19:37:55 GMT
+      - Mon, 06 Aug 2018 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2359,7 +2359,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -2374,7 +2374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2387,9 +2387,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-b39e5ed9-1483-4a53-be9f-3e865bee14c9
+      - req-2ffccbd9-6d2d-45a6-82d0-56f457554484
       Date:
-      - Fri, 03 Aug 2018 19:37:55 GMT
+      - Mon, 06 Aug 2018 16:58:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -2435,7 +2435,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -2450,7 +2450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2463,9 +2463,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-ad4a4d57-939d-4e75-b937-7b4d1c7140cf
+      - req-b5406ec7-d39a-4df6-a3b6-c3c2e46d1c3c
       Date:
-      - Fri, 03 Aug 2018 19:37:56 GMT
+      - Mon, 06 Aug 2018 16:58:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -2511,7 +2511,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -2526,7 +2526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2539,9 +2539,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-98154853-1a4c-4903-ba0e-89d962119f3c
+      - req-91ff243b-17ec-493b-bc8f-29d0abcc1a04
       Date:
-      - Fri, 03 Aug 2018 19:37:56 GMT
+      - Mon, 06 Aug 2018 16:58:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -2589,7 +2589,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -2604,7 +2604,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2617,9 +2617,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-6e64df64-c745-42ca-8805-a05803470e1b
+      - req-a7c0be9e-f8a1-433f-920f-670f4c9129a2
       Date:
-      - Fri, 03 Aug 2018 19:37:57 GMT
+      - Mon, 06 Aug 2018 16:58:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2661,7 +2661,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2689,9 +2689,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-5ef51b7d-79bc-4555-a8ce-7dbf93c24cbd
+      - req-31021216-5abd-40d9-8c6d-a8eb3b70cd2c
       Date:
-      - Fri, 03 Aug 2018 19:37:57 GMT
+      - Mon, 06 Aug 2018 16:58:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2714,7 +2714,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2729,7 +2729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2740,9 +2740,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-18442afb-ec49-4a23-b0a0-8acc726831d5
+      - req-018b455a-f638-4b4d-8897-928b6e15cdae
       Date:
-      - Fri, 03 Aug 2018 19:37:58 GMT
+      - Mon, 06 Aug 2018 16:58:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2798,7 +2798,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2813,7 +2813,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2824,9 +2824,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d5e951f5-54d7-4594-86fb-c6ad84925b8d
+      - req-23d1f76c-f90d-4264-b33f-e6d3d08bb8dd
       Date:
-      - Fri, 03 Aug 2018 19:37:58 GMT
+      - Mon, 06 Aug 2018 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2838,7 +2838,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2853,7 +2853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2864,9 +2864,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-97e1d427-de15-4f55-92c5-24547734dba1
+      - req-c7f51efe-365d-4256-8ebb-c974ca819f92
       Date:
-      - Fri, 03 Aug 2018 19:37:58 GMT
+      - Mon, 06 Aug 2018 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2922,7 +2922,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2937,7 +2937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5765ac05b4a54ccbb582b680a62ee7d4
+      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
   response:
     status:
       code: 200
@@ -2948,9 +2948,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f258da2f-5a47-4c54-984f-1cdf3e4fd149
+      - req-6e2da3fc-399f-485c-bec5-20e25cd86aa3
       Date:
-      - Fri, 03 Aug 2018 19:37:58 GMT
+      - Mon, 06 Aug 2018 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2962,7 +2962,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2977,7 +2977,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ede52f562ca459fa872c998f4a29e10
+      - d94f732ed99e452d84cafd89d277cc7e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2990,9 +2990,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5ed20be4-1e93-4896-a297-f10db99c9412
+      - req-297f7f4d-d03a-43d6-ba62-900a7aa15134
       Date:
-      - Fri, 03 Aug 2018 19:37:59 GMT
+      - Mon, 06 Aug 2018 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3001,7 +3001,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3016,7 +3016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c316da1acb344344b13a3c5c27c0928e
+      - 806c4413c2914055ba268043ff4a1557
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3029,9 +3029,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bbf70229-7ee4-4c7c-a0ea-e0e292b4bc1d
+      - req-909333e7-66cd-4213-b765-84a42c36b41d
       Date:
-      - Fri, 03 Aug 2018 19:37:59 GMT
+      - Mon, 06 Aug 2018 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3040,7 +3040,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3055,7 +3055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-376a95f6-17fc-41cc-8ac9-c44e8a752162
+      - req-bc08aea2-5fa1-4187-b57a-0cd7ea4e15ae
       Date:
-      - Fri, 03 Aug 2018 19:37:59 GMT
+      - Mon, 06 Aug 2018 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3079,7 +3079,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3094,7 +3094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecbca8974e1e4a25805a89206f115594
+      - 6368f71d4447459794e46941aa627e9b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3107,9 +3107,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9befc23b-c1ed-485d-ba1e-3d5ae0b21765
+      - req-473e4e27-34ce-43f9-86de-b8dba254b407
       Date:
-      - Fri, 03 Aug 2018 19:37:59 GMT
+      - Mon, 06 Aug 2018 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3118,7 +3118,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3136,13 +3136,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:05 GMT
+      - Mon, 06 Aug 2018 16:58:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-afcd68c6-2baf-4163-ab2e-142ffee560f8
+      - req-4f0dee00-e397-42da-ab76-79e3ad9955c2
       Content-Length:
       - '4117'
       Connection:
@@ -3151,10 +3151,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:05.498081", "expires":
-        "2018-08-03T20:38:05Z", "id": "28aeb043c2ef461a84fd4c3d3ce7cec2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:51.009285", "expires":
+        "2018-08-06T17:58:50Z", "id": "77b554ddb3f342fe99724e6c38144fe7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OCiX7Z6jRwOf_dtMhIpRpQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lcz6SD24SV-DJCkikhPszA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3198,7 +3198,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3213,22 +3213,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28aeb043c2ef461a84fd4c3d3ce7cec2
+      - 77b554ddb3f342fe99724e6c38144fe7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5dc7f879-5027-4061-9d2b-617939b1420e
+      - req-f72f05a9-21a6-449e-bf84-e0bd344ba712
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5dc7f879-5027-4061-9d2b-617939b1420e
+      - req-f72f05a9-21a6-449e-bf84-e0bd344ba712
       Date:
-      - Fri, 03 Aug 2018 19:38:06 GMT
+      - Mon, 06 Aug 2018 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3238,7 +3238,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3256,13 +3256,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:06 GMT
+      - Mon, 06 Aug 2018 16:58:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbb04483-ac75-400f-b1b7-734895db2d7b
+      - req-8e3ccd07-c07f-4e4a-b616-7ebe82f5b4aa
       Content-Length:
       - '4131'
       Connection:
@@ -3271,10 +3271,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:06.687035", "expires":
-        "2018-08-03T20:38:06Z", "id": "4b8194cde9fc40ef9817d434d8beafa3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:51.977023", "expires":
+        "2018-08-06T17:58:51Z", "id": "9e07ad07d60f434c83cd7e7f2cc5d8d9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TFhBDOldQqu01r8HOdf02w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fbYQ9fJcQ-6RU5QZ2glWWA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3318,7 +3318,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3333,22 +3333,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b8194cde9fc40ef9817d434d8beafa3
+      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c618e04-c3a3-4ee8-be47-069c672060c0
+      - req-b3a6f278-2c4a-4442-be7b-3caaf77a754c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7c618e04-c3a3-4ee8-be47-069c672060c0
+      - req-b3a6f278-2c4a-4442-be7b-3caaf77a754c
       Date:
-      - Fri, 03 Aug 2018 19:38:07 GMT
+      - Mon, 06 Aug 2018 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3358,7 +3358,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3373,22 +3373,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7440dab1-3715-426e-ac85-cf9cc2faffd5
+      - req-f80540a3-4fda-4e15-99df-1970bfe9809b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7440dab1-3715-426e-ac85-cf9cc2faffd5
+      - req-f80540a3-4fda-4e15-99df-1970bfe9809b
       Date:
-      - Fri, 03 Aug 2018 19:38:08 GMT
+      - Mon, 06 Aug 2018 16:58:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3398,7 +3398,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3416,13 +3416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:08 GMT
+      - Mon, 06 Aug 2018 16:58:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-66326e16-ad4c-4272-97ab-d3135cf1f486
+      - req-ce9a84e7-0d31-4382-8748-cce59d859749
       Content-Length:
       - '4118'
       Connection:
@@ -3431,10 +3431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:08.444946", "expires":
-        "2018-08-03T20:38:08Z", "id": "33bc0f061745485cab687191f8a7ea9c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:53.656459", "expires":
+        "2018-08-06T17:58:53Z", "id": "95e5eaf00df847018b63061319e4692e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8uDGMnRKQSWPIcMNJvT2Hg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["L8oPrFSKQUK1WmJeA2v_3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3478,7 +3478,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3493,22 +3493,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33bc0f061745485cab687191f8a7ea9c
+      - 95e5eaf00df847018b63061319e4692e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f4592bb-71fa-4566-9430-807f9e123dee
+      - req-bfc46660-5ed0-47a8-81d5-db8fb68d8b1d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4f4592bb-71fa-4566-9430-807f9e123dee
+      - req-bfc46660-5ed0-47a8-81d5-db8fb68d8b1d
       Date:
-      - Fri, 03 Aug 2018 19:38:08 GMT
+      - Mon, 06 Aug 2018 16:58:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3518,7 +3518,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3536,13 +3536,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:09 GMT
+      - Mon, 06 Aug 2018 16:58:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9021cb11-0824-4eb8-b7a8-28ad0c2038bd
+      - req-e661159d-0cc6-4995-b7e3-569ba53c0381
       Content-Length:
       - '4170'
       Connection:
@@ -3551,10 +3551,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:09.331717", "expires":
-        "2018-08-03T20:38:09Z", "id": "48a2dcb5b85044fb95a2235c2a3b257f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:54.262536", "expires":
+        "2018-08-06T17:58:54Z", "id": "7ee81ffd642c430d8e0c71a95d33d4a5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7T3kGjJJS7W_yzCLSm4iGg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gmWS0SZTS_-0bUWTbUKH4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3599,7 +3599,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48a2dcb5b85044fb95a2235c2a3b257f
+      - 7ee81ffd642c430d8e0c71a95d33d4a5
   response:
     status:
       code: 200
@@ -3625,13 +3625,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:38:09 GMT
+      - Mon, 06 Aug 2018 16:58:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3649,13 +3649,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:09 GMT
+      - Mon, 06 Aug 2018 16:58:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8bf1fb58-1da6-415e-8256-3bb9953a973b
+      - req-eef1fd29-f45a-4f2c-9fd5-8895cacd00fa
       Content-Length:
       - '4117'
       Connection:
@@ -3664,10 +3664,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:09.727927", "expires":
-        "2018-08-03T20:38:09Z", "id": "9d1894a69a80464d94d6b7dd3b2fcc8e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:54.615199", "expires":
+        "2018-08-06T17:58:54Z", "id": "38da0b87d3a942648c7a4025c404b6b8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zIuyZVv_THaRUtxQ5EOv7w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UqJF3FGPSQixOpYBTFmOWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3711,7 +3711,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3726,7 +3726,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d1894a69a80464d94d6b7dd3b2fcc8e
+      - 38da0b87d3a942648c7a4025c404b6b8
   response:
     status:
       code: 200
@@ -3737,16 +3737,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2db74485-e683-45f4-a490-08d465259aaa
+      - req-aa98e46c-c5ae-40b9-a49d-8da3388f7068
       Date:
-      - Fri, 03 Aug 2018 19:38:10 GMT
+      - Mon, 06 Aug 2018 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3764,13 +3764,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:10 GMT
+      - Mon, 06 Aug 2018 16:58:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-19022221-3585-4248-9d32-d9985300b6a9
+      - req-c8577b90-895c-43f4-a95f-f88320f9afea
       Content-Length:
       - '4131'
       Connection:
@@ -3779,10 +3779,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:10.379367", "expires":
-        "2018-08-03T20:38:10Z", "id": "4c7f900c855e4e5bb56bc54529085c31", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:55.301614", "expires":
+        "2018-08-06T17:58:55Z", "id": "2a9f4bbc74214ddcaa5922e314b3df65", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8tDmTfsDQOuN-6_3rr_OOw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_hzbLx34QcGFUNiYp0gOGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3826,7 +3826,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3841,7 +3841,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c7f900c855e4e5bb56bc54529085c31
+      - 2a9f4bbc74214ddcaa5922e314b3df65
   response:
     status:
       code: 200
@@ -3852,16 +3852,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8bd31d46-51de-4801-8cfe-7a3c43b28a75
+      - req-e63d685d-1020-4235-aad6-c99d6b73886c
       Date:
-      - Fri, 03 Aug 2018 19:38:10 GMT
+      - Mon, 06 Aug 2018 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48a2dcb5b85044fb95a2235c2a3b257f
+      - 7ee81ffd642c430d8e0c71a95d33d4a5
   response:
     status:
       code: 200
@@ -3887,16 +3887,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2a0a22f9-64c4-4339-958f-24198639c456
+      - req-711f94b9-6e1b-4557-a4e2-ac6f770fea7a
       Date:
-      - Fri, 03 Aug 2018 19:38:10 GMT
+      - Mon, 06 Aug 2018 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3914,13 +3914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:10 GMT
+      - Mon, 06 Aug 2018 16:58:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2dfae6d5-0fde-4e87-9b27-0a41f68903c7
+      - req-5038bbf7-ce15-4c47-a28e-c9820d703f9f
       Content-Length:
       - '4118'
       Connection:
@@ -3929,10 +3929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:10.943894", "expires":
-        "2018-08-03T20:38:10Z", "id": "fe741402e27a43ac9ef6acb37cf4acac", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:55.906452", "expires":
+        "2018-08-06T17:58:55Z", "id": "1832ac46f9b34119a75798c23592396e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0e1AtJopS3KLAsi7rAogRg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4ytxlz_oRhGVP0ONr0HkgA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3976,7 +3976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3991,7 +3991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe741402e27a43ac9ef6acb37cf4acac
+      - 1832ac46f9b34119a75798c23592396e
   response:
     status:
       code: 200
@@ -4002,16 +4002,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e4f6ddf8-8fe7-4448-90b0-984b7fdf6418
+      - req-e07c7cab-4a86-4435-ac23-727665b9b8ab
       Date:
-      - Fri, 03 Aug 2018 19:38:11 GMT
+      - Mon, 06 Aug 2018 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4026,7 +4026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4039,14 +4039,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5baa649e-70cc-4dfb-8e95-d523a2609804
+      - req-8223844e-cfad-4320-ab86-3d594620e09f
       Date:
-      - Fri, 03 Aug 2018 19:38:11 GMT
+      - Mon, 06 Aug 2018 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4061,7 +4061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4074,14 +4074,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-9a0024b5-153a-4d3f-8e5c-bb1712e6fb19
+      - req-a596199c-fc3f-4373-972f-fcf0898055fb
       Date:
-      - Fri, 03 Aug 2018 19:38:11 GMT
+      - Mon, 06 Aug 2018 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4096,7 +4096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4109,14 +4109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-82875666-08fe-483e-8a11-c052b723926f
+      - req-5f8cf60b-1767-4017-91e9-60d2185954a2
       Date:
-      - Fri, 03 Aug 2018 19:38:11 GMT
+      - Mon, 06 Aug 2018 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4131,7 +4131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4144,14 +4144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-beb515a9-5829-4d85-b9ed-dc7b86da59ed
+      - req-bf8ed835-04f8-4ce3-8e44-8732ecdefa97
       Date:
-      - Fri, 03 Aug 2018 19:38:11 GMT
+      - Mon, 06 Aug 2018 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4166,7 +4166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4179,14 +4179,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0e67be8d-7c14-4fc8-8818-e45cc820cdb9
+      - req-275ce610-2346-4252-b828-3ce08baa77c7
       Date:
-      - Fri, 03 Aug 2018 19:38:12 GMT
+      - Mon, 06 Aug 2018 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4201,7 +4201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4214,15 +4214,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-0eaf0726-f51a-4dbb-89aa-d1d5b4bbda49
+      - req-450385bc-db21-4ed7-80bd-db08035f2053
       Date:
-      - Fri, 03 Aug 2018 19:38:12 GMT
+      - Mon, 06 Aug 2018 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4237,7 +4237,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4250,14 +4250,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-820433fa-f561-44a7-a9fa-58d4b2be1d9d
+      - req-cc6c784c-494a-4181-b032-df3f272a6b36
       Date:
-      - Fri, 03 Aug 2018 19:38:12 GMT
+      - Mon, 06 Aug 2018 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4272,7 +4272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4285,15 +4285,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-a4cb19fc-71c1-46df-ace6-e6abf4e11e8c
+      - req-31e59294-cee0-455d-ad8c-d3367fed85c1
       Date:
-      - Fri, 03 Aug 2018 19:38:12 GMT
+      - Mon, 06 Aug 2018 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4308,7 +4308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4321,14 +4321,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2130d049-93e4-4447-ab51-ba7333d9a6c7
+      - req-278af330-f069-4052-9a56-72dcdfd75904
       Date:
-      - Fri, 03 Aug 2018 19:38:13 GMT
+      - Mon, 06 Aug 2018 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4343,7 +4343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4356,14 +4356,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7a54eac8-c8a2-4274-bda5-4052243eb32a
+      - req-c6c74b82-b217-4673-960d-9c897a13b2e1
       Date:
-      - Fri, 03 Aug 2018 19:38:13 GMT
+      - Mon, 06 Aug 2018 16:58:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4378,7 +4378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4391,14 +4391,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-4efa942b-f9d6-4d70-b4ad-2d7ad79f940b
+      - req-d572d166-b3da-459e-99c3-0aa2bcd00ca3
       Date:
-      - Fri, 03 Aug 2018 19:38:13 GMT
+      - Mon, 06 Aug 2018 16:58:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4416,13 +4416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:13 GMT
+      - Mon, 06 Aug 2018 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3d02b65-d6d9-421c-91b8-9cf8e433a73e
+      - req-45a2d339-8c64-41d2-936b-e49c28bd7255
       Content-Length:
       - '4170'
       Connection:
@@ -4431,10 +4431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:14.085144", "expires":
-        "2018-08-03T20:38:14Z", "id": "958fb5e620a3489f95b8ca897ac2e654", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:59.685828", "expires":
+        "2018-08-06T17:58:59Z", "id": "5b9979a656354175a8944e75b4c721a2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["M1mDAPFbTKefjQXn8fn2wQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XmpvPFh0TYKPlaM4nDqHRg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4479,13 +4479,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"958fb5e620a3489f95b8ca897ac2e654"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"5b9979a656354175a8944e75b4c721a2"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4497,13 +4497,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:14 GMT
+      - Mon, 06 Aug 2018 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-efcc2f6e-dca3-4dfe-b920-101784637897
+      - req-7473b01d-834b-49d4-a6ca-d2770964c403
       Content-Length:
       - '4196'
       Connection:
@@ -4512,10 +4512,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:14.369551", "expires":
-        "2018-08-03T20:38:14Z", "id": "3c8f70e4b7724a61a3874335a3da041d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:59.960016", "expires":
+        "2018-08-06T17:58:59Z", "id": "3ab6ff526e4945a48512b17da807f3c7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nistkNp0R_O52s7ruNvGhg", "M1mDAPFbTKefjQXn8fn2wQ"]},
+        "name": "admin"}, "audit_ids": ["vr8D-kavSYW8mbp9ZpdH_w", "XmpvPFh0TYKPlaM4nDqHRg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4560,7 +4560,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4578,13 +4578,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:14 GMT
+      - Mon, 06 Aug 2018 16:59:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a6369f3-04e7-459b-8ae4-08789e2beea4
+      - req-e80ab592-956f-47d5-9d39-f96c17fc4c94
       Content-Length:
       - '4170'
       Connection:
@@ -4593,10 +4593,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:14.710400", "expires":
-        "2018-08-03T20:38:14Z", "id": "a2000aa408284ed4885b364aa285cac2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:00.284181", "expires":
+        "2018-08-06T17:59:00Z", "id": "689b88e98f714916b428e9641d8590d9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["a0ge-gEZSwipoa8a3oag4w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tRn94WlZQEWDOeRvlRPS2g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4641,13 +4641,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"a2000aa408284ed4885b364aa285cac2"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"689b88e98f714916b428e9641d8590d9"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4659,13 +4659,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:14 GMT
+      - Mon, 06 Aug 2018 16:59:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b061319e-cca1-42d7-b634-c51eef923897
+      - req-0e771898-6a41-4307-b6eb-d9c2ee127999
       Content-Length:
       - '4196'
       Connection:
@@ -4674,10 +4674,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:15.000129", "expires":
-        "2018-08-03T20:38:14Z", "id": "33b124f4b4fa4b7590360bc75553f9a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:00.551782", "expires":
+        "2018-08-06T17:59:00Z", "id": "cffb230b3b81487a99965bb87844f7f0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HxQy3GeyTeelJgI1eTZQDA", "a0ge-gEZSwipoa8a3oag4w"]},
+        "name": "admin"}, "audit_ids": ["gLXDtMj8RXe_tA5fNC-jqQ", "tRn94WlZQEWDOeRvlRPS2g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4722,7 +4722,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -4737,7 +4737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b004285efc644179b6c665cf492d3799
+      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4750,14 +4750,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-0cdd0e3f-ff25-4a5a-a0f9-41a2b1533a04
+      - req-78934f53-6ae1-4925-ac19-33516ef8f355
       Date:
-      - Fri, 03 Aug 2018 19:38:15 GMT
+      - Mon, 06 Aug 2018 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -4772,22 +4772,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f594091e-1dd2-4c6b-8916-703ced7d9ec1
+      - req-0f39e440-8db4-4e1e-b5f7-ddac71bca834
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-f594091e-1dd2-4c6b-8916-703ced7d9ec1
+      - req-0f39e440-8db4-4e1e-b5f7-ddac71bca834
       Date:
-      - Fri, 03 Aug 2018 19:38:15 GMT
+      - Mon, 06 Aug 2018 16:59:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4820,7 +4820,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4835,22 +4835,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a1aece4-e00f-44e3-9af0-2acda4e0fa44
+      - req-c635d002-553a-4cfb-a107-58098137d8a4
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-8a1aece4-e00f-44e3-9af0-2acda4e0fa44
+      - req-c635d002-553a-4cfb-a107-58098137d8a4
       Date:
-      - Fri, 03 Aug 2018 19:38:16 GMT
+      - Mon, 06 Aug 2018 16:59:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4867,7 +4867,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -4882,22 +4882,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28aeb043c2ef461a84fd4c3d3ce7cec2
+      - 77b554ddb3f342fe99724e6c38144fe7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8d77597-aa7b-4ae7-b892-060b61ab26c2
+      - req-ad4640ed-5f12-4787-a83e-3241742d6af6
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b8d77597-aa7b-4ae7-b892-060b61ab26c2
+      - req-ad4640ed-5f12-4787-a83e-3241742d6af6
       Date:
-      - Fri, 03 Aug 2018 19:38:16 GMT
+      - Mon, 06 Aug 2018 16:59:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4912,7 +4912,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -4927,22 +4927,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28aeb043c2ef461a84fd4c3d3ce7cec2
+      - 77b554ddb3f342fe99724e6c38144fe7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-412f5f17-1567-4360-9ccc-e26d6a1eab48
+      - req-0605e2ba-e44d-4327-ab84-0bd9f483872d
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-412f5f17-1567-4360-9ccc-e26d6a1eab48
+      - req-0605e2ba-e44d-4327-ab84-0bd9f483872d
       Date:
-      - Fri, 03 Aug 2018 19:38:16 GMT
+      - Mon, 06 Aug 2018 16:59:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4957,7 +4957,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -4972,27 +4972,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b8194cde9fc40ef9817d434d8beafa3
+      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab62fa4b-8c2e-4e16-b245-84d76bcfad05
+      - req-5fd8bbf5-5136-4ac2-b62d-fa10e085a833
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ab62fa4b-8c2e-4e16-b245-84d76bcfad05
+      - req-5fd8bbf5-5136-4ac2-b62d-fa10e085a833
       Date:
-      - Fri, 03 Aug 2018 19:38:16 GMT
+      - Mon, 06 Aug 2018 16:59:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5007,27 +5007,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b8194cde9fc40ef9817d434d8beafa3
+      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a74112ff-0f0b-4337-8354-d482d671b9a0
+      - req-83cbcefe-0380-4d13-bc34-f136c748d5e9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a74112ff-0f0b-4337-8354-d482d671b9a0
+      - req-83cbcefe-0380-4d13-bc34-f136c748d5e9
       Date:
-      - Fri, 03 Aug 2018 19:38:17 GMT
+      - Mon, 06 Aug 2018 16:59:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5042,27 +5042,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c9774fb7-aaca-4fc2-a666-8e2b65f9bd45
+      - req-534398db-bf34-4748-97a2-722e34f31e8c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c9774fb7-aaca-4fc2-a666-8e2b65f9bd45
+      - req-534398db-bf34-4748-97a2-722e34f31e8c
       Date:
-      - Fri, 03 Aug 2018 19:38:17 GMT
+      - Mon, 06 Aug 2018 16:59:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5077,27 +5077,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de3a3c74-6cbf-4693-8993-8a898e7de7ce
+      - req-16082d46-187b-4e75-9720-0cbde3a01c48
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-de3a3c74-6cbf-4693-8993-8a898e7de7ce
+      - req-16082d46-187b-4e75-9720-0cbde3a01c48
       Date:
-      - Fri, 03 Aug 2018 19:38:17 GMT
+      - Mon, 06 Aug 2018 16:59:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5112,27 +5112,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33bc0f061745485cab687191f8a7ea9c
+      - 95e5eaf00df847018b63061319e4692e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffea61ed-efd7-44d5-9c15-9053ac609977
+      - req-fe6a8362-50aa-4873-9a96-eb52c37a69bb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ffea61ed-efd7-44d5-9c15-9053ac609977
+      - req-fe6a8362-50aa-4873-9a96-eb52c37a69bb
       Date:
-      - Fri, 03 Aug 2018 19:38:17 GMT
+      - Mon, 06 Aug 2018 16:59:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5147,27 +5147,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33bc0f061745485cab687191f8a7ea9c
+      - 95e5eaf00df847018b63061319e4692e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91ecae83-81ee-4a84-bf37-d14b1684ee9d
+      - req-11db1ee4-15b8-4f65-956d-15fe81ecc915
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-91ecae83-81ee-4a84-bf37-d14b1684ee9d
+      - req-11db1ee4-15b8-4f65-956d-15fe81ecc915
       Date:
-      - Fri, 03 Aug 2018 19:38:17 GMT
+      - Mon, 06 Aug 2018 16:59:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -5182,22 +5182,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e684092-0f2d-4c3c-b6c5-dbf8cc079210
+      - req-7eec5d2c-93aa-42fb-a8d2-1e3d997dff4c
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-0e684092-0f2d-4c3c-b6c5-dbf8cc079210
+      - req-7eec5d2c-93aa-42fb-a8d2-1e3d997dff4c
       Date:
-      - Fri, 03 Aug 2018 19:38:18 GMT
+      - Mon, 06 Aug 2018 16:59:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5230,7 +5230,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5245,22 +5245,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc7ba85c-13b9-4702-9a22-c76128ac2b60
+      - req-4b9ed9b8-a42f-4c21-aec6-9dc702979d63
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-cc7ba85c-13b9-4702-9a22-c76128ac2b60
+      - req-4b9ed9b8-a42f-4c21-aec6-9dc702979d63
       Date:
-      - Fri, 03 Aug 2018 19:38:18 GMT
+      - Mon, 06 Aug 2018 16:59:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5301,7 +5301,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5316,22 +5316,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac8b1fa4-5676-450e-8cbe-07ab30ba1c46
+      - req-46bcad44-adae-4873-a302-4bde916710bb
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-ac8b1fa4-5676-450e-8cbe-07ab30ba1c46
+      - req-46bcad44-adae-4873-a302-4bde916710bb
       Date:
-      - Fri, 03 Aug 2018 19:38:18 GMT
+      - Mon, 06 Aug 2018 16:59:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5365,7 +5365,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5380,27 +5380,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b538b91635497a8c930bc0a18d66e0
+      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-09f066c0-6861-4df1-99df-60d3d211a233
+      - req-913e1a7d-a4a8-40e4-876d-b1d7c6b2de68
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-09f066c0-6861-4df1-99df-60d3d211a233
+      - req-913e1a7d-a4a8-40e4-876d-b1d7c6b2de68
       Date:
-      - Fri, 03 Aug 2018 19:38:18 GMT
+      - Mon, 06 Aug 2018 16:59:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5418,13 +5418,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:19 GMT
+      - Mon, 06 Aug 2018 16:59:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a98fb967-3df9-4a34-a3a5-b2fe0ca4c225
+      - req-70ee66a7-13ce-4e33-bb63-c6ecd372bf84
       Content-Length:
       - '4170'
       Connection:
@@ -5433,10 +5433,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:19.653553", "expires":
-        "2018-08-03T20:38:19Z", "id": "59daef6b8d9248bfab4460ba8f7cc0eb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:05.912611", "expires":
+        "2018-08-06T17:59:05Z", "id": "05ea1c5ee3fd4982880ce1af52f8e708", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4pSO9760QkqWMLoiQzSvng"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HvQr3QeMTgSpxXYLW_Xwlw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5481,7 +5481,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5499,13 +5499,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:19 GMT
+      - Mon, 06 Aug 2018 16:59:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cfa90b3-656a-46e7-a092-19a8ce98f61f
+      - req-d35beef9-1bb4-4aa0-b786-3b4ef5973214
       Content-Length:
       - '4170'
       Connection:
@@ -5514,10 +5514,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:19.884744", "expires":
-        "2018-08-03T20:38:19Z", "id": "e208967d90ce41b6bcbab7f7994f0881", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:06.209749", "expires":
+        "2018-08-06T17:59:06Z", "id": "d88b45aa6a6545f2ba07d009de85ad0a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fNuMZ5FySVSAaltAh1NIjQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["-yGtszqXRXuxfCsel5AhWg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5562,7 +5562,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5577,7 +5577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -5588,42 +5588,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-5d1df0db-93c0-4384-b22a-d5dbecb848cf
+      - req-dbceb32f-4c7d-4934-a100-5d894216f5cf
       Date:
-      - Fri, 03 Aug 2018 19:38:20 GMT
+      - Mon, 06 Aug 2018 16:59:06 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -5653,14 +5628,39 @@ http_interactions:
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5678,13 +5678,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:20 GMT
+      - Mon, 06 Aug 2018 16:59:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9e61c2b-1a79-4ad2-9016-51244b65bdd6
+      - req-2750b74a-d301-43c5-a17b-2a20d92fec50
       Content-Length:
       - '4170'
       Connection:
@@ -5693,10 +5693,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:20.409994", "expires":
-        "2018-08-03T20:38:20Z", "id": "a558647309604e49be2a50f2db1da8a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:06.958661", "expires":
+        "2018-08-06T17:59:06Z", "id": "99e22869e52a463b88b8ad2ada2a135c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CQTX5qnvR4Oc9h7JdBKgvA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HCXjm0e8Q8ymPkYsNEcRDA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5741,7 +5741,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5759,13 +5759,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:20 GMT
+      - Mon, 06 Aug 2018 16:59:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fb4f234e-680b-4cda-8852-7ec4193ae756
+      - req-93cca87a-5cdf-4f2e-b8c3-9e4bd0c85947
       Content-Length:
       - '370'
       Connection:
@@ -5774,13 +5774,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:20.648154", "expires":
-        "2018-08-03T20:38:20Z", "id": "9ace06ddeaea41d68c658705bf7a600b", "audit_ids":
-        ["jvgaXEqyR8ei2w47LZfq6w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:07.176896", "expires":
+        "2018-08-06T17:59:07Z", "id": "aabfcda393194d40bdaef290f2cf7a57", "audit_ids":
+        ["6lvZIaEASG6YMzuT0tlTHw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5795,20 +5795,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ace06ddeaea41d68c658705bf7a600b
+      - aabfcda393194d40bdaef290f2cf7a57
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:20 GMT
+      - Mon, 06 Aug 2018 16:59:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3df9b048-34e9-4797-b58d-34917014c203
+      - req-a9c3761d-7b1d-4eb7-8b7f-7d54b64b0e75
       Content-Length:
       - '500'
       Connection:
@@ -5825,13 +5825,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9ace06ddeaea41d68c658705bf7a600b"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"aabfcda393194d40bdaef290f2cf7a57"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5843,13 +5843,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:20 GMT
+      - Mon, 06 Aug 2018 16:59:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ac039e5d-01c0-4170-b81c-676c3ad74ef3
+      - req-c87fc29f-6f85-4ad8-816a-b3c86c2feb12
       Content-Length:
       - '4143'
       Connection:
@@ -5858,11 +5858,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:21.093612", "expires":
-        "2018-08-03T20:38:20Z", "id": "b649fbd1703c473f8a5486dccbddce43", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:07.626019", "expires":
+        "2018-08-06T17:59:07Z", "id": "8b695835c438498b85a4e8c5da2e15a0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2sMiF-i7QIup3xr9qhUhwQ",
-        "jvgaXEqyR8ei2w47LZfq6w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YhzDYicFSkGzH3xNSWXR3w",
+        "6lvZIaEASG6YMzuT0tlTHw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5906,7 +5906,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5921,20 +5921,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ace06ddeaea41d68c658705bf7a600b
+      - aabfcda393194d40bdaef290f2cf7a57
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:21 GMT
+      - Mon, 06 Aug 2018 16:59:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-393ed12a-e0fa-403f-83eb-c747d289bdbc
+      - req-67ba66de-55df-4a4e-a297-d83180bf6518
       Content-Length:
       - '500'
       Connection:
@@ -5951,7 +5951,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5969,13 +5969,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:21 GMT
+      - Mon, 06 Aug 2018 16:59:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-23ba5955-badc-4368-8aa9-77cfa226cf09
+      - req-86ac1d73-a0c0-46db-9832-1e649d2c8442
       Content-Length:
       - '4117'
       Connection:
@@ -5984,10 +5984,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:21.532561", "expires":
-        "2018-08-03T20:38:21Z", "id": "4cc17c6695f242a6a1f6336b871f355a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.120802", "expires":
+        "2018-08-06T17:59:08Z", "id": "b52e0fa29a63447fb953a79df4eeeeb8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dPf9cNMARGqz-rE48uQDzA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wJ0MGL_pTc-RgUmEVXGihg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6031,7 +6031,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6049,13 +6049,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:21 GMT
+      - Mon, 06 Aug 2018 16:59:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-01caa854-9c5f-4bcc-9d0f-1b4d8c685bdb
+      - req-f32424e3-485a-49c8-95fd-bdf207967cf3
       Content-Length:
       - '4131'
       Connection:
@@ -6064,10 +6064,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:21.732679", "expires":
-        "2018-08-03T20:38:21Z", "id": "fb894e951d5144d7a3457f27f6219c06", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.400015", "expires":
+        "2018-08-06T17:59:08Z", "id": "2b9f6b5374844cf78a125ef661fdd920", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mIUXb8ozRIWBNTebQVsW-A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CTNHElIaStaJMe8_ytwUTA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6111,7 +6111,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6129,13 +6129,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:21 GMT
+      - Mon, 06 Aug 2018 16:59:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-57ee8ab4-f57f-44d1-bad9-9758f1b0c95f
+      - req-4a09be9d-fa82-4f1d-8036-3a974a99e22e
       Content-Length:
       - '4118'
       Connection:
@@ -6144,10 +6144,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:21.979353", "expires":
-        "2018-08-03T20:38:21Z", "id": "bcf7393f33ec4f4a9e10e2c3bad10bd0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.829533", "expires":
+        "2018-08-06T17:59:08Z", "id": "4d3c4ed36d044774a54710c7ea5325da", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Sr3nWmqvRzadx5L8583XLA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["54_4E5OqQMiQX4KFJaJ-_g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6191,7 +6191,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6209,13 +6209,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:22 GMT
+      - Mon, 06 Aug 2018 16:59:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-094bb052-635b-4f14-a462-c68ab56aa9f8
+      - req-856e1f58-5d59-47f9-aae2-28a4dc8e1ba5
       Content-Length:
       - '4117'
       Connection:
@@ -6224,10 +6224,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:22.271932", "expires":
-        "2018-08-03T20:38:22Z", "id": "ba53dc73ba8b4f93899211724bbde022", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:09.060886", "expires":
+        "2018-08-06T17:59:09Z", "id": "b8f8e61a54d04baf8d56bcb75a06acf4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PLzaqOASSYm_qEaeZshM9Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["d9HTSY4vRkaW9vmedAvJAg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6271,7 +6271,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6286,7 +6286,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6297,9 +6297,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-16a63c49-b978-487b-9f3c-c3439f75317e
+      - req-fd770d44-3d66-4acd-b830-b9196ac601aa
       Date:
-      - Fri, 03 Aug 2018 19:38:22 GMT
+      - Mon, 06 Aug 2018 16:59:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6333,7 +6333,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6348,7 +6348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6359,14 +6359,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-eeb2e836-c8e9-43a1-a5c2-194fca8af73e
+      - req-cf325328-8db8-4bbf-a7b2-a3367a56a8d8
       Date:
-      - Fri, 03 Aug 2018 19:38:22 GMT
+      - Mon, 06 Aug 2018 16:59:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6384,13 +6384,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:23 GMT
+      - Mon, 06 Aug 2018 16:59:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-af4c4dad-9cfe-421f-a2cd-939220b76089
+      - req-06e124c3-00ab-4ae9-b237-46c2ff016a1d
       Content-Length:
       - '4131'
       Connection:
@@ -6399,10 +6399,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:23.240854", "expires":
-        "2018-08-03T20:38:23Z", "id": "c6b8650dcabe434b955ea2d000ae241e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:09.604954", "expires":
+        "2018-08-06T17:59:09Z", "id": "b36a8fdb3fc548569bda57e164ea3d7d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ZZT4fKXpRZKg5lrWyIDyJw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jjS6mdYzSnCopwC4widLoQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6446,7 +6446,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6461,7 +6461,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6b8650dcabe434b955ea2d000ae241e
+      - b36a8fdb3fc548569bda57e164ea3d7d
   response:
     status:
       code: 200
@@ -6472,14 +6472,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-894b25d3-7b4d-43e3-911f-4051b0aebedf
+      - req-b0f29f1c-c70d-4cec-a587-4e1f3e8b3442
       Date:
-      - Fri, 03 Aug 2018 19:38:24 GMT
+      - Mon, 06 Aug 2018 16:59:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6494,7 +6494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a558647309604e49be2a50f2db1da8a2
+      - 99e22869e52a463b88b8ad2ada2a135c
   response:
     status:
       code: 200
@@ -6505,14 +6505,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9572e95b-7600-40cd-8df9-6c67856d74b7
+      - req-c533be79-d372-4155-bf05-a01e0c6335b1
       Date:
-      - Fri, 03 Aug 2018 19:38:24 GMT
+      - Mon, 06 Aug 2018 16:59:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6530,13 +6530,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:25 GMT
+      - Mon, 06 Aug 2018 16:59:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-18f80251-cabd-4e73-a066-a57cdf00e12e
+      - req-d827df86-a25c-4337-a59c-6358726a3c2e
       Content-Length:
       - '4118'
       Connection:
@@ -6545,10 +6545,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:25.208062", "expires":
-        "2018-08-03T20:38:25Z", "id": "88ef2263ca61401caa700a7c9a2e6b25", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:10.257641", "expires":
+        "2018-08-06T17:59:10Z", "id": "f57be5a86efb4599882eed22efcb34ca", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tdWG-cxMR4a7PyljwQmr9g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xnTEXAR9RgKYbrpLUCN91w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6592,7 +6592,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6607,7 +6607,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88ef2263ca61401caa700a7c9a2e6b25
+      - f57be5a86efb4599882eed22efcb34ca
   response:
     status:
       code: 200
@@ -6618,14 +6618,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-fc98c833-7507-40e3-b169-07b525d3f34c
+      - req-93009c5e-b294-4e3b-ac0f-9457d14ac6a3
       Date:
-      - Fri, 03 Aug 2018 19:38:25 GMT
+      - Mon, 06 Aug 2018 16:59:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6640,7 +6640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6651,9 +6651,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e7e55607-32b9-4c6a-9cb4-33c3b8be45f9
+      - req-4b6c1c9a-a38f-4978-b9f9-3f073df38856
       Date:
-      - Fri, 03 Aug 2018 19:38:26 GMT
+      - Mon, 06 Aug 2018 16:59:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6680,7 +6680,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6695,7 +6695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6706,9 +6706,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d9f881e7-89f6-4fdc-bcf7-8442d17ae0da
+      - req-73a7d2ec-8530-46e0-80d7-04c76cfc3a4a
       Date:
-      - Fri, 03 Aug 2018 19:38:27 GMT
+      - Mon, 06 Aug 2018 16:59:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6735,7 +6735,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6750,7 +6750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6761,9 +6761,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-da897f00-a752-4acf-9aa5-28eb7c7000e9
+      - req-fbd10a2c-f20b-4f6e-99fa-c0910179874c
       Date:
-      - Fri, 03 Aug 2018 19:38:28 GMT
+      - Mon, 06 Aug 2018 16:59:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6790,7 +6790,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -6805,7 +6805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6816,9 +6816,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3b7c0d11-8f7a-4022-adb1-95bbd70abc43
+      - req-ccfeecc6-bbcc-476d-acab-62abf73e3567
       Date:
-      - Fri, 03 Aug 2018 19:38:28 GMT
+      - Mon, 06 Aug 2018 16:59:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6830,7 +6830,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -6845,7 +6845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6856,9 +6856,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9e18e4cf-002f-41ba-93e7-8cc0529280e1
+      - req-cd257390-e97b-44a2-a446-b447e34b912c
       Date:
-      - Fri, 03 Aug 2018 19:38:28 GMT
+      - Mon, 06 Aug 2018 16:59:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6870,7 +6870,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -6885,7 +6885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba53dc73ba8b4f93899211724bbde022
+      - b8f8e61a54d04baf8d56bcb75a06acf4
   response:
     status:
       code: 200
@@ -6896,9 +6896,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a4a6a768-f641-4bda-ad6e-21d848930d9f
+      - req-58eaec86-2003-425c-be5c-a02ab3f49c44
       Date:
-      - Fri, 03 Aug 2018 19:38:28 GMT
+      - Mon, 06 Aug 2018 16:59:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6910,7 +6910,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -6925,7 +6925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -6936,42 +6936,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-07a9754b-11a9-49e4-a268-4dc38d13d972
+      - req-05e645b3-28b9-4886-b07b-1b9925cd2d8f
       Date:
-      - Fri, 03 Aug 2018 19:38:29 GMT
+      - Mon, 06 Aug 2018 16:59:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -7018,6 +6988,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -7029,6 +7005,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -7042,7 +7042,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7057,7 +7057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -7068,42 +7068,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1761c385-fb2f-46c5-9ab7-f6d5cc81630e
+      - req-c5638a6a-d0f8-4626-a94d-ae3166d70386
       Date:
-      - Fri, 03 Aug 2018 19:38:29 GMT
+      - Mon, 06 Aug 2018 16:59:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -7150,6 +7120,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -7161,6 +7137,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -7174,7 +7174,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -7189,7 +7189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -7200,9 +7200,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2889ba08-f1ae-49f6-a846-b6a338c4d7e3
+      - req-1781f3dc-52e7-4709-80f8-02ac3c82651d
       Date:
-      - Fri, 03 Aug 2018 19:38:29 GMT
+      - Mon, 06 Aug 2018 16:59:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7244,7 +7244,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -7259,7 +7259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -7270,9 +7270,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6565d9a2-48a1-4797-9cce-af9095828fc2
+      - req-579c4440-4546-4d33-8406-e902d8a0be41
       Date:
-      - Fri, 03 Aug 2018 19:38:29 GMT
+      - Mon, 06 Aug 2018 16:59:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7314,7 +7314,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -7329,7 +7329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -7340,9 +7340,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-e8656d70-b475-48b9-b877-627afae7418e
+      - req-7864e2db-d530-4eb8-b1c7-2a2880d9d058
       Date:
-      - Fri, 03 Aug 2018 19:38:29 GMT
+      - Mon, 06 Aug 2018 16:59:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7745,7 +7745,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -7760,7 +7760,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -7771,9 +7771,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9bdb7c6d-717e-403f-b05f-293366e30973
+      - req-5beac863-6721-426b-a595-6d789d926105
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8176,7 +8176,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8191,7 +8191,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8202,9 +8202,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-246e8b43-371a-4c1c-9b35-a3b95dbfb600
+      - req-d9409d0f-a41e-402b-bdde-d64fdd97470c
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8236,7 +8236,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -8251,7 +8251,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8262,9 +8262,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a3a835e4-d6da-47fc-b524-04feaaed73f2
+      - req-f3de9f74-27ac-4139-a5c0-3d782ee98750
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8296,7 +8296,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -8311,7 +8311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8322,9 +8322,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-1b76961f-245e-4105-967e-8877ace89f76
+      - req-40846e1d-8375-4d70-b544-2a297ad2603c
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -8366,7 +8366,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -8381,7 +8381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8392,9 +8392,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-1d08b3de-f98f-41bf-990f-3b77a65c71d2
+      - req-43a02090-5e05-41dd-b260-018d6a878b19
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -8437,7 +8437,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -8452,7 +8452,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8463,9 +8463,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-d771cd35-8047-4757-9513-87a66b813231
+      - req-6e250d2e-3fa8-40b9-9a2e-f856bcf55496
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -8500,7 +8500,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -8515,7 +8515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e208967d90ce41b6bcbab7f7994f0881
+      - d88b45aa6a6545f2ba07d009de85ad0a
   response:
     status:
       code: 200
@@ -8526,9 +8526,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-86462032-0bad-4bf3-8130-fac711c6053d
+      - req-ad66afa1-6721-4c23-a746-51198e8e3ad7
       Date:
-      - Fri, 03 Aug 2018 19:38:30 GMT
+      - Mon, 06 Aug 2018 16:59:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -8615,7 +8615,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8633,13 +8633,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:31 GMT
+      - Mon, 06 Aug 2018 16:59:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-43da1577-71d4-48d0-807a-f5192b9b0ceb
+      - req-4e9bfa65-42b2-4ce4-b22c-507111905e1c
       Content-Length:
       - '4170'
       Connection:
@@ -8648,10 +8648,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:31.482485", "expires":
-        "2018-08-03T20:38:31Z", "id": "88736d005f9b4b26a7deb390da8db8aa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.519386", "expires":
+        "2018-08-06T17:59:19Z", "id": "68b742dc9c1e450fb199eb9ec23ffdce", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4m3V_EK4TpeIaPQFa0aYkg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ykZULkUJRUG_kZzabtsAxw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8696,7 +8696,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8714,13 +8714,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:31 GMT
+      - Mon, 06 Aug 2018 16:59:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52ae908b-72b0-4736-ad70-d041bfa458a2
+      - req-ee2d54ec-8e25-4580-a023-26a045846c7f
       Content-Length:
       - '4170'
       Connection:
@@ -8729,10 +8729,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:31.683869", "expires":
-        "2018-08-03T20:38:31Z", "id": "af92be87043749dd8bd0b248ceb6027b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.767325", "expires":
+        "2018-08-06T17:59:19Z", "id": "be1b0e4a3b094df8899c595fde3b3191", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["UNyYjNSZQM2VNYB4DqoA9g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ffPYt2dXRje0GxKSyXTuqQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8777,7 +8777,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8795,13 +8795,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:31 GMT
+      - Mon, 06 Aug 2018 16:59:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5ff66ae7-4abb-4c64-9b07-ed64fef0f46c
+      - req-438dbed8-9fa5-4dfc-9505-39adec04e289
       Content-Length:
       - '370'
       Connection:
@@ -8810,13 +8810,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:31.834987", "expires":
-        "2018-08-03T20:38:31Z", "id": "038bdb711bfb4ca6912578cb13af917a", "audit_ids":
-        ["zBzBwApyQHaPMmfzmz9YaQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.916954", "expires":
+        "2018-08-06T17:59:19Z", "id": "19c7b0653dc54a1fb9cfc82c7098e272", "audit_ids":
+        ["ZVmiBOYtS0urU8XTrim-3w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8831,20 +8831,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '038bdb711bfb4ca6912578cb13af917a'
+      - 19c7b0653dc54a1fb9cfc82c7098e272
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:31 GMT
+      - Mon, 06 Aug 2018 16:59:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fad3111f-c539-45e9-9c92-abc60a248c26
+      - req-d2f7ea21-769e-4ae7-82cc-d4717cfd3f60
       Content-Length:
       - '500'
       Connection:
@@ -8861,13 +8861,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"038bdb711bfb4ca6912578cb13af917a"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"19c7b0653dc54a1fb9cfc82c7098e272"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8879,13 +8879,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:32 GMT
+      - Mon, 06 Aug 2018 16:59:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d636f723-f935-436e-a96d-6570e8fd5548
+      - req-91c0b0a8-e9a4-4d3c-a7fb-e5ede13a624f
       Content-Length:
       - '4143'
       Connection:
@@ -8894,11 +8894,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:32.242008", "expires":
-        "2018-08-03T20:38:31Z", "id": "f26954de92cf45bea195f9dc31ba0c7b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:20.223429", "expires":
+        "2018-08-06T17:59:19Z", "id": "8584c37590f84628a374e22d249e8307", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_Rg8b_4GRM2gF0FqxaRI6g",
-        "zBzBwApyQHaPMmfzmz9YaQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5ajzjj_vQBqfuMGjPFaHvw",
+        "ZVmiBOYtS0urU8XTrim-3w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8942,7 +8942,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8957,20 +8957,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '038bdb711bfb4ca6912578cb13af917a'
+      - 19c7b0653dc54a1fb9cfc82c7098e272
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:32 GMT
+      - Mon, 06 Aug 2018 16:59:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69847994-e70a-44bc-b76c-9487b4b437f7
+      - req-e7320054-920c-447b-8899-a84602e51ea6
       Content-Length:
       - '500'
       Connection:
@@ -8987,7 +8987,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9005,13 +9005,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:32 GMT
+      - Mon, 06 Aug 2018 16:59:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a28c7867-2172-4c1a-a420-d83a92ecb229
+      - req-545dbe38-b07b-49f1-9309-c9faab1ae392
       Content-Length:
       - '4117'
       Connection:
@@ -9020,10 +9020,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:32.623726", "expires":
-        "2018-08-03T20:38:32Z", "id": "0cbc9a394f0d4f39a7b1addccd21c6fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:20.641306", "expires":
+        "2018-08-06T17:59:20Z", "id": "d2da814bd13c47cb9d8436089a51dd2b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["o2p11ZFHSxyXjscXdAeFOQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jHrnXa4DTSG5xvHHISdKVA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9067,7 +9067,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9085,13 +9085,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:32 GMT
+      - Mon, 06 Aug 2018 16:59:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-09233f02-b080-47a9-83b6-db2015ed8fea
+      - req-04d7d6e7-fc96-438e-80ad-4a490929d58f
       Content-Length:
       - '4131'
       Connection:
@@ -9100,10 +9100,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:32.831053", "expires":
-        "2018-08-03T20:38:32Z", "id": "6c9df58d6bff4bb8bf466b49b6c992aa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.020195", "expires":
+        "2018-08-06T17:59:20Z", "id": "e2de1187c0184808a29675d57710ac8f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qiL-u9ieQAOKtU9iBprXFQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PXy2QaNUR3-lOUCJbxNVEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9147,7 +9147,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9165,13 +9165,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:32 GMT
+      - Mon, 06 Aug 2018 16:59:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-848b7b5b-30b9-4110-8e71-31c3a56b496c
+      - req-9058a710-9e07-4c54-b516-e0bae9b8f26f
       Content-Length:
       - '4118'
       Connection:
@@ -9180,10 +9180,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:33.144969", "expires":
-        "2018-08-03T20:38:33Z", "id": "a1c87683871440f18fc1ea98abf5b40c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.317147", "expires":
+        "2018-08-06T17:59:21Z", "id": "061e7aaa56e942ddbb7fdb1b1531f3fe", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LQRm9QAtQYaq6rRbzVDQWw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MN72ZUc_Q8O5z4tEDxpgEg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9227,7 +9227,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9245,13 +9245,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:33 GMT
+      - Mon, 06 Aug 2018 16:59:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df86be0d-b011-4a84-9f79-db7a5511bb8e
+      - req-30d54df0-e1dd-4d1e-82b1-0feb6c8310a5
       Content-Length:
       - '4117'
       Connection:
@@ -9260,10 +9260,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:33.479037", "expires":
-        "2018-08-03T20:38:33Z", "id": "d894af4e204249d5991ffe22a3fb14b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.587395", "expires":
+        "2018-08-06T17:59:21Z", "id": "5f0d46b46ad04e69903dc564100ec9a1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZalKc1n-TPaX4yMdC_quvA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LF82K4J2RKmm6h6vkM-2KQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9307,7 +9307,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -9322,22 +9322,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d731f63d-d21a-4061-b88a-916f34ffc474
+      - req-4301b9c6-1ed2-43e9-9185-8263d5f5088b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-d731f63d-d21a-4061-b88a-916f34ffc474
+      - req-4301b9c6-1ed2-43e9-9185-8263d5f5088b
       Date:
-      - Fri, 03 Aug 2018 19:38:33 GMT
+      - Mon, 06 Aug 2018 16:59:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -9370,7 +9370,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -9385,22 +9385,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af5455c7-a014-4004-94ca-9618fe45fa44
+      - req-62e652d2-ab56-4aca-9641-2bb06704b66c
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-af5455c7-a014-4004-94ca-9618fe45fa44
+      - req-62e652d2-ab56-4aca-9641-2bb06704b66c
       Date:
-      - Fri, 03 Aug 2018 19:38:34 GMT
+      - Mon, 06 Aug 2018 16:59:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -9441,7 +9441,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -9456,22 +9456,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-361f6d20-a763-4899-9dc5-c5daf19cc7be
+      - req-76c99b70-1eab-4b30-b959-b504432956f7
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-361f6d20-a763-4899-9dc5-c5daf19cc7be
+      - req-76c99b70-1eab-4b30-b959-b504432956f7
       Date:
-      - Fri, 03 Aug 2018 19:38:34 GMT
+      - Mon, 06 Aug 2018 16:59:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -9505,7 +9505,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -9520,27 +9520,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b235ef57-9832-4d2a-95e3-223200ca8754
+      - req-c345ce99-c83f-4f96-ad6b-90c5f9dcaec2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b235ef57-9832-4d2a-95e3-223200ca8754
+      - req-c345ce99-c83f-4f96-ad6b-90c5f9dcaec2
       Date:
-      - Fri, 03 Aug 2018 19:38:35 GMT
+      - Mon, 06 Aug 2018 16:59:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9558,13 +9558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:35 GMT
+      - Mon, 06 Aug 2018 16:59:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-913ba0bf-4d19-4ed0-b2b8-b9fa0e35c236
+      - req-5558ea28-4c00-484d-b379-c73734f5cac0
       Content-Length:
       - '4131'
       Connection:
@@ -9573,10 +9573,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:35.413001", "expires":
-        "2018-08-03T20:38:35Z", "id": "80b3ffeea5c843ee993ff23fc0da15b0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:23.526106", "expires":
+        "2018-08-06T17:59:23Z", "id": "c7c4928b6d44499e8d874dbad8b15386", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0wVWYPxnTkSdH7rZuN-5qQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["YufTPl9qSt6G17x1sRpgMQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9620,7 +9620,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -9635,27 +9635,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a87779f3-fefb-4dc9-a61f-69eac7bb5de1
+      - req-c9eede0b-edef-47ae-b78f-2a1c1cacff04
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a87779f3-fefb-4dc9-a61f-69eac7bb5de1
+      - req-c9eede0b-edef-47ae-b78f-2a1c1cacff04
       Date:
-      - Fri, 03 Aug 2018 19:38:35 GMT
+      - Mon, 06 Aug 2018 16:59:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -9670,27 +9670,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9e39a0bb-2853-4ab3-b95e-004f46fcb723
+      - req-f9246ebd-c085-4427-b6f8-000d45d9f8bb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9e39a0bb-2853-4ab3-b95e-004f46fcb723
+      - req-f9246ebd-c085-4427-b6f8-000d45d9f8bb
       Date:
-      - Fri, 03 Aug 2018 19:38:36 GMT
+      - Mon, 06 Aug 2018 16:59:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9708,13 +9708,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:36 GMT
+      - Mon, 06 Aug 2018 16:59:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5e029419-be43-4a21-b1f6-53828dd5c473
+      - req-92b3cc63-c0b1-43ef-a233-e209ae439544
       Content-Length:
       - '4118'
       Connection:
@@ -9723,10 +9723,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:36.284233", "expires":
-        "2018-08-03T20:38:36Z", "id": "ea305ae7c3c84c66b420938e09123ab8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:24.754751", "expires":
+        "2018-08-06T17:59:24Z", "id": "bec5445947df455a8e17059515395e53", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zrqxrZvlRdixIoAuY9Zg7g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KbRJItYbSTmFXXCLo3zJBQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9770,7 +9770,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -9785,27 +9785,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b54d4bda-f359-47c4-ad75-06093910c47b
+      - req-9fa47910-ff90-43d8-990b-f6e031c0d292
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b54d4bda-f359-47c4-ad75-06093910c47b
+      - req-9fa47910-ff90-43d8-990b-f6e031c0d292
       Date:
-      - Fri, 03 Aug 2018 19:38:36 GMT
+      - Mon, 06 Aug 2018 16:59:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -9820,22 +9820,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e04de06-2de8-452c-8fb3-d6cd7106da25
+      - req-c65d8a5d-42f0-4258-8963-9a5e7eebb102
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7e04de06-2de8-452c-8fb3-d6cd7106da25
+      - req-c65d8a5d-42f0-4258-8963-9a5e7eebb102
       Date:
-      - Fri, 03 Aug 2018 19:38:36 GMT
+      - Mon, 06 Aug 2018 16:59:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9850,7 +9850,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -9865,22 +9865,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-086b577a-ff9b-4606-95f1-2bbdeff54f91
+      - req-dbc6c9c7-650f-41da-8a9d-c6cfc0fe0d76
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-086b577a-ff9b-4606-95f1-2bbdeff54f91
+      - req-dbc6c9c7-650f-41da-8a9d-c6cfc0fe0d76
       Date:
-      - Fri, 03 Aug 2018 19:38:36 GMT
+      - Mon, 06 Aug 2018 16:59:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9895,7 +9895,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -9910,27 +9910,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aef1d02b-7e66-43a8-af76-137bcd5a8b71
+      - req-5012f771-29ea-4868-ab83-09d3486092ef
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-aef1d02b-7e66-43a8-af76-137bcd5a8b71
+      - req-5012f771-29ea-4868-ab83-09d3486092ef
       Date:
-      - Fri, 03 Aug 2018 19:38:37 GMT
+      - Mon, 06 Aug 2018 16:59:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -9945,27 +9945,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cf4da52-df8f-4d04-98da-f39a3d60d392
+      - req-e845be26-9dab-43ad-bd92-7fcf7fb1af86
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4cf4da52-df8f-4d04-98da-f39a3d60d392
+      - req-e845be26-9dab-43ad-bd92-7fcf7fb1af86
       Date:
-      - Fri, 03 Aug 2018 19:38:37 GMT
+      - Mon, 06 Aug 2018 16:59:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -9980,27 +9980,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-efd24565-674a-4ac6-8e92-2e6ab9e2cfa3
+      - req-b2bc7a47-7fe1-4b16-bd04-50f7a8e344b2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-efd24565-674a-4ac6-8e92-2e6ab9e2cfa3
+      - req-b2bc7a47-7fe1-4b16-bd04-50f7a8e344b2
       Date:
-      - Fri, 03 Aug 2018 19:38:37 GMT
+      - Mon, 06 Aug 2018 16:59:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -10015,27 +10015,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-556b3b51-f131-4aa1-93b3-17083cd15151
+      - req-398f8111-9eae-43a5-a36c-eae81928f143
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-556b3b51-f131-4aa1-93b3-17083cd15151
+      - req-398f8111-9eae-43a5-a36c-eae81928f143
       Date:
-      - Fri, 03 Aug 2018 19:38:37 GMT
+      - Mon, 06 Aug 2018 16:59:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -10050,27 +10050,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12abdb8b-4fa6-4055-8e66-ded5d4bcb271
+      - req-1eb08e3d-a431-4de1-9738-32912ea6a8ed
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-12abdb8b-4fa6-4055-8e66-ded5d4bcb271
+      - req-1eb08e3d-a431-4de1-9738-32912ea6a8ed
       Date:
-      - Fri, 03 Aug 2018 19:38:37 GMT
+      - Mon, 06 Aug 2018 16:59:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -10085,27 +10085,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c5c0f12-8553-4250-836c-303def10e669
+      - req-bf5df789-c985-4cdd-8475-401692a6624d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4c5c0f12-8553-4250-836c-303def10e669
+      - req-bf5df789-c985-4cdd-8475-401692a6624d
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -10120,27 +10120,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-def44139-294e-414e-a83a-ed281a9c858e
+      - req-ef163e07-329c-4d87-8878-5f9e73a94637
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-def44139-294e-414e-a83a-ed281a9c858e
+      - req-ef163e07-329c-4d87-8878-5f9e73a94637
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -10155,27 +10155,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29d6adde-bfca-481b-90a1-804d269dedfe
+      - req-7ecb97b6-9236-4864-a639-1161d5828b33
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-29d6adde-bfca-481b-90a1-804d269dedfe
+      - req-7ecb97b6-9236-4864-a639-1161d5828b33
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -10190,27 +10190,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39ee2f97-8b9c-46f6-afad-41584446921f
+      - req-0f65a5e7-f525-474d-81a4-8d8892b7f056
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-39ee2f97-8b9c-46f6-afad-41584446921f
+      - req-0f65a5e7-f525-474d-81a4-8d8892b7f056
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -10225,27 +10225,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9148a8c-6bbd-4010-8026-f82a3541f16b
+      - req-e3a24031-234b-43c3-bb1d-f46ad4707409
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a9148a8c-6bbd-4010-8026-f82a3541f16b
+      - req-e3a24031-234b-43c3-bb1d-f46ad4707409
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -10260,27 +10260,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91b35baa-0c19-43c4-ac6b-3eaf0b329692
+      - req-d5fbfc35-773a-497e-9c87-d28b1e7ced99
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91b35baa-0c19-43c4-ac6b-3eaf0b329692
+      - req-d5fbfc35-773a-497e-9c87-d28b1e7ced99
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -10295,27 +10295,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37241cf9-bf68-4000-a8cc-c8822226af77
+      - req-f2e783e4-486b-4b27-8e1c-30761ce133ab
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-37241cf9-bf68-4000-a8cc-c8822226af77
+      - req-f2e783e4-486b-4b27-8e1c-30761ce133ab
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -10330,27 +10330,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-55bb000d-6122-4dc6-88c1-b3587727b674
+      - req-b3d58a50-6510-4aac-be18-a7662385c0fd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-55bb000d-6122-4dc6-88c1-b3587727b674
+      - req-b3d58a50-6510-4aac-be18-a7662385c0fd
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -10365,27 +10365,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6dd9e9f9-1187-48a4-898a-d45cdc2b4b30
+      - req-e641a975-6fee-4709-809d-4af89f07cfa7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6dd9e9f9-1187-48a4-898a-d45cdc2b4b30
+      - req-e641a975-6fee-4709-809d-4af89f07cfa7
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -10400,22 +10400,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02c9d4b3-39b0-419b-afb7-3ad1c63db908
+      - req-d30e0c7e-0c59-41f7-be20-13ccbcf19559
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-02c9d4b3-39b0-419b-afb7-3ad1c63db908
+      - req-d30e0c7e-0c59-41f7-be20-13ccbcf19559
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10427,7 +10427,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10442,22 +10442,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d894af4e204249d5991ffe22a3fb14b5
+      - 5f0d46b46ad04e69903dc564100ec9a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89fcfa9f-883f-4343-9269-e4b6d3370674
+      - req-1ae576ea-57d6-4336-80c9-780d546c10e7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-89fcfa9f-883f-4343-9269-e4b6d3370674
+      - req-1ae576ea-57d6-4336-80c9-780d546c10e7
       Date:
-      - Fri, 03 Aug 2018 19:38:38 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10469,7 +10469,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -10484,22 +10484,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23255452-93e8-444b-b0ad-789380a7b4c1
+      - req-fd373a9a-bdfe-4643-8183-1644d7e1459b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-23255452-93e8-444b-b0ad-789380a7b4c1
+      - req-fd373a9a-bdfe-4643-8183-1644d7e1459b
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10511,7 +10511,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10526,22 +10526,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b3ffeea5c843ee993ff23fc0da15b0
+      - c7c4928b6d44499e8d874dbad8b15386
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee2a3a4f-4487-4a8c-a8c8-28ecdd96a892
+      - req-f48eeed2-27b3-4979-bee4-4cc8f9840efe
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ee2a3a4f-4487-4a8c-a8c8-28ecdd96a892
+      - req-f48eeed2-27b3-4979-bee4-4cc8f9840efe
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10553,7 +10553,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -10568,22 +10568,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48b0d5bc-557f-4b35-8803-a36cb79a05c6
+      - req-ce621c95-198d-4b11-a33e-bced0ecae254
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-48b0d5bc-557f-4b35-8803-a36cb79a05c6
+      - req-ce621c95-198d-4b11-a33e-bced0ecae254
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10595,7 +10595,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10610,22 +10610,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af92be87043749dd8bd0b248ceb6027b
+      - be1b0e4a3b094df8899c595fde3b3191
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae97594f-66a7-4dfd-96f1-5f0181d2aeaf
+      - req-5eb2659a-61d1-4a17-8ec6-7d2e18ebaee8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ae97594f-66a7-4dfd-96f1-5f0181d2aeaf
+      - req-5eb2659a-61d1-4a17-8ec6-7d2e18ebaee8
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10637,7 +10637,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -10652,22 +10652,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1aa96307-e8f9-411b-a774-e7d30b0d7101
+      - req-b8f1afd8-c9b9-44ca-b55b-dda3961662a7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1aa96307-e8f9-411b-a774-e7d30b0d7101
+      - req-b8f1afd8-c9b9-44ca-b55b-dda3961662a7
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10679,7 +10679,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10694,22 +10694,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea305ae7c3c84c66b420938e09123ab8
+      - bec5445947df455a8e17059515395e53
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ca87db7-d36d-4d5c-8853-4d9f85f7cd1e
+      - req-f1efd27c-de4c-429f-8220-56514b2a40a7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5ca87db7-d36d-4d5c-8853-4d9f85f7cd1e
+      - req-f1efd27c-de4c-429f-8220-56514b2a40a7
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10721,7 +10721,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10739,13 +10739,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:39 GMT
+      - Mon, 06 Aug 2018 16:59:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f348067-03d5-4186-a400-1c71064b0c1d
+      - req-e7e6b45e-9382-4ca1-9935-1b0c5693b8a5
       Content-Length:
       - '4170'
       Connection:
@@ -10754,10 +10754,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:40.118799", "expires":
-        "2018-08-03T20:38:40Z", "id": "ba12e3c495bf4ad49c0b0b14431c1d68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:29.580676", "expires":
+        "2018-08-06T17:59:29Z", "id": "3a61c4d7b6f74774a0d2ad933e1c6435", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["lcVbhHDlSJmF0Qxue4y50g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FVSdFB0LQFG0tpAbWFrKxw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10802,7 +10802,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10820,13 +10820,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:40 GMT
+      - Mon, 06 Aug 2018 16:59:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51000079-89f1-4089-8211-1a776ed636b6
+      - req-753614ef-fd42-48b9-be80-b820f53d2ee1
       Content-Length:
       - '4170'
       Connection:
@@ -10835,10 +10835,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:40.468649", "expires":
-        "2018-08-03T20:38:40Z", "id": "0ce14a518fa443f3bcd757ab59e8d4f7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:29.896937", "expires":
+        "2018-08-06T17:59:29Z", "id": "5748222f76a742bf9150654229b08b2d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["r_aDSj4XRAGccRqqS_Rqug"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["LQtXciQZQW23W35IseCs5Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10883,7 +10883,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10901,13 +10901,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:40 GMT
+      - Mon, 06 Aug 2018 16:59:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-77d2ebbf-4a91-408f-8a6b-651a713c864a
+      - req-ad5cb464-5dba-42e3-9020-375ddfac2e66
       Content-Length:
       - '370'
       Connection:
@@ -10916,13 +10916,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:40.655374", "expires":
-        "2018-08-03T20:38:40Z", "id": "97ba1f314f1f43a9981afbb82356476c", "audit_ids":
-        ["_snj5e0BSXG0Huk9Bi--aw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:30.089513", "expires":
+        "2018-08-06T17:59:30Z", "id": "1bc2e95a2abf4cf5a354fa2f41f184ac", "audit_ids":
+        ["fhIFJA40SDaJzOAyaaJL4Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10937,20 +10937,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ba1f314f1f43a9981afbb82356476c
+      - 1bc2e95a2abf4cf5a354fa2f41f184ac
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:40 GMT
+      - Mon, 06 Aug 2018 16:59:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b95baff9-c64d-4053-8615-6e2d327f4919
+      - req-e395ab02-bb10-4df8-936a-939118fbc315
       Content-Length:
       - '500'
       Connection:
@@ -10967,13 +10967,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"97ba1f314f1f43a9981afbb82356476c"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"1bc2e95a2abf4cf5a354fa2f41f184ac"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10985,13 +10985,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:41 GMT
+      - Mon, 06 Aug 2018 16:59:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-96563cab-aa33-4276-82bb-b395eb660042
+      - req-db6acb8d-bf71-493d-97cc-22575807f2f1
       Content-Length:
       - '4143'
       Connection:
@@ -11000,11 +11000,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:41.427990", "expires":
-        "2018-08-03T20:38:40Z", "id": "3e36a4d4fd5c499ea9461b29065f639a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:30.561806", "expires":
+        "2018-08-06T17:59:30Z", "id": "c5a93a05339a46978a244b0e9571c75f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qtOsQvnzTkiqsg_0xrJk4Q",
-        "_snj5e0BSXG0Huk9Bi--aw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YqZek5xyRxygtja9Yvx-vQ",
+        "fhIFJA40SDaJzOAyaaJL4Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11048,7 +11048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -11063,20 +11063,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ba1f314f1f43a9981afbb82356476c
+      - 1bc2e95a2abf4cf5a354fa2f41f184ac
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:41 GMT
+      - Mon, 06 Aug 2018 16:59:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-982a616c-248e-49f5-a72c-6f11fc057ea8
+      - req-a08017d1-d686-44ce-8b38-845626c80c67
       Content-Length:
       - '500'
       Connection:
@@ -11093,7 +11093,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11111,13 +11111,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:41 GMT
+      - Mon, 06 Aug 2018 16:59:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9c26aaa9-7f93-4b5b-8df3-cc8da639232f
+      - req-cbd5973a-8dbd-4ea1-a5eb-552e4e71dbd8
       Content-Length:
       - '4117'
       Connection:
@@ -11126,10 +11126,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:41.891958", "expires":
-        "2018-08-03T20:38:41Z", "id": "c92ed35bf36647e59d03508c7d3701fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.231944", "expires":
+        "2018-08-06T17:59:31Z", "id": "63528c43735f4c589a3e70a98f6541e7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["J70Q8kUvTRqXAsGvEqBg5w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CgTO8Y4CQk-cUD3tGGxHAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11173,7 +11173,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11191,13 +11191,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:42 GMT
+      - Mon, 06 Aug 2018 16:59:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cd415476-cc7e-4a8f-95e6-20621872b0c1
+      - req-f5b10ea4-3780-4443-9989-0aadde0f2469
       Content-Length:
       - '4131'
       Connection:
@@ -11206,10 +11206,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:42.120140", "expires":
-        "2018-08-03T20:38:42Z", "id": "1089e9fb7d1e401ca72df6a2113e8cf3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.555502", "expires":
+        "2018-08-06T17:59:31Z", "id": "fa8ab7986f6844c297d1c2e2b73b3539", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lhMlupP0QwOu95obVoRqYA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dQqIMiOoQziN_C_1YCqOxg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11253,7 +11253,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11271,13 +11271,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:42 GMT
+      - Mon, 06 Aug 2018 16:59:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2c2d10d5-2b0a-427d-a728-81a9797d613c
+      - req-dd18a0c6-e290-4366-bdd8-64d41221d440
       Content-Length:
       - '4118'
       Connection:
@@ -11286,10 +11286,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:42.354651", "expires":
-        "2018-08-03T20:38:42Z", "id": "21c7be639e62431896910641a97234c4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.862409", "expires":
+        "2018-08-06T17:59:31Z", "id": "c86dd302cb8845bbac3f0684152e4d89", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4JJIqFpmSOurLJw_KPCrcQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NoogcbC_Tk-T3oGgW2kREg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11333,7 +11333,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11351,13 +11351,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:42 GMT
+      - Mon, 06 Aug 2018 16:59:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b3d7de04-7ca8-47d7-8a65-00c65507c920
+      - req-283ccace-faf0-402f-a09c-b07cc6950acd
       Content-Length:
       - '4117'
       Connection:
@@ -11366,10 +11366,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:42.562758", "expires":
-        "2018-08-03T20:38:42Z", "id": "027509c70b5347b5b84a8761e621a8ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:32.160678", "expires":
+        "2018-08-06T17:59:32Z", "id": "76f8237daac748dc9cb8c9d27b7b67b3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wNW2W5oSQeKyHkwGiUiA6Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SkdWdT86TueNkWOcpkwtcg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11413,7 +11413,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -11428,7 +11428,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '027509c70b5347b5b84a8761e621a8ce'
+      - 76f8237daac748dc9cb8c9d27b7b67b3
   response:
     status:
       code: 200
@@ -11457,15 +11457,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txcc7cd320d37f494487b71-005b64af42
+      - tx9643b989eac64731b10d6-005b687e74
       Date:
-      - Fri, 03 Aug 2018 19:38:42 GMT
+      - Mon, 06 Aug 2018 16:59:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -11480,7 +11480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '027509c70b5347b5b84a8761e621a8ce'
+      - 76f8237daac748dc9cb8c9d27b7b67b3
   response:
     status:
       code: 200
@@ -11509,14 +11509,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb043289e990a4916a5331-005b64af42
+      - tx6dc66264a7eb4cb4be8b2-005b687e74
       Date:
-      - Fri, 03 Aug 2018 19:38:42 GMT
+      - Mon, 06 Aug 2018 16:59:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11534,13 +11534,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:43 GMT
+      - Mon, 06 Aug 2018 16:59:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cbff410-a1b9-4069-a582-5ed568e6b17a
+      - req-0e298d04-c7a5-40ef-b845-2a3075c92857
       Content-Length:
       - '4131'
       Connection:
@@ -11549,10 +11549,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:43.111420", "expires":
-        "2018-08-03T20:38:43Z", "id": "855a47df5bd04619844082332bfb4e2c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:33.292117", "expires":
+        "2018-08-06T17:59:33Z", "id": "bfbc6b562b5b48bc99ec85e9ac03a374", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["s9Qg-e_cRjC2BlROU5XOBQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0YnI4vF_S-WRr9NoGitb8Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11596,7 +11596,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -11611,7 +11611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 855a47df5bd04619844082332bfb4e2c
+      - bfbc6b562b5b48bc99ec85e9ac03a374
   response:
     status:
       code: 200
@@ -11624,22 +11624,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325123.42609'
+      - '1533574773.62254'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325123.42609'
+      - '1533574773.62254'
       X-Trans-Id:
-      - tx8e2224a41ffe476fbdf97-005b64af43
+      - txb56db25c175b4c588b6de-005b687e75
       Date:
-      - Fri, 03 Aug 2018 19:38:43 GMT
+      - Mon, 06 Aug 2018 16:59:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -11654,7 +11654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce14a518fa443f3bcd757ab59e8d4f7
+      - 5748222f76a742bf9150654229b08b2d
   response:
     status:
       code: 200
@@ -11667,22 +11667,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325123.78880'
+      - '1533574773.91746'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325123.78880'
+      - '1533574773.91746'
       X-Trans-Id:
-      - tx09b60fd1c1624b578f56a-005b64af43
+      - tx50080720bb4d4c599567e-005b687e75
       Date:
-      - Fri, 03 Aug 2018 19:38:43 GMT
+      - Mon, 06 Aug 2018 16:59:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11700,13 +11700,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:43 GMT
+      - Mon, 06 Aug 2018 16:59:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50a23cdb-6a00-4a81-92a2-7f09dfa27992
+      - req-b82742e4-cd6e-4a9d-b838-0e76e035f813
       Content-Length:
       - '4118'
       Connection:
@@ -11715,10 +11715,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:38:44.088201", "expires":
-        "2018-08-03T20:38:44Z", "id": "b0e0065f82654614b79a8b8d0bb688a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:34.170978", "expires":
+        "2018-08-06T17:59:34Z", "id": "29c4288d22c6477d8606395d7168e29b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UAyAz6XaRVq-kCWN-Dunzg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DMZ5PglkRgOUnO6gwWSC6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11762,7 +11762,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -11777,7 +11777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0e0065f82654614b79a8b8d0bb688a5
+      - 29c4288d22c6477d8606395d7168e29b
   response:
     status:
       code: 200
@@ -11790,22 +11790,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325124.39686'
+      - '1533574774.48208'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325124.39686'
+      - '1533574774.48208'
       X-Trans-Id:
-      - tx9390ea74b7a44fcfa6178-005b64af44
+      - txae0ccf6d94084d878d830-005b687e76
       Date:
-      - Fri, 03 Aug 2018 19:38:44 GMT
+      - Mon, 06 Aug 2018 16:59:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -11820,7 +11820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '027509c70b5347b5b84a8761e621a8ce'
+      - 76f8237daac748dc9cb8c9d27b7b67b3
   response:
     status:
       code: 200
@@ -11841,9 +11841,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txc4823db802c948ff8fb19-005b64af44
+      - tx266458fd1be741b6bf80b-005b687e76
       Date:
-      - Fri, 03 Aug 2018 19:38:44 GMT
+      - Mon, 06 Aug 2018 16:59:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -11853,7 +11853,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -11868,7 +11868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '027509c70b5347b5b84a8761e621a8ce'
+      - 76f8237daac748dc9cb8c9d27b7b67b3
   response:
     status:
       code: 200
@@ -11889,14 +11889,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7b5558736f104f4686a20-005b64af44
+      - tx8bd1b193b4b1456186b0c-005b687e76
       Date:
-      - Fri, 03 Aug 2018 19:38:44 GMT
+      - Mon, 06 Aug 2018 16:59:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -11911,7 +11911,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '027509c70b5347b5b84a8761e621a8ce'
+      - 76f8237daac748dc9cb8c9d27b7b67b3
   response:
     status:
       code: 200
@@ -11932,12 +11932,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx46b756e3ddd24a039a851-005b64af44
+      - tx1cb9c4f3c1fa434494a5a-005b687e76
       Date:
-      - Fri, 03 Aug 2018 19:38:44 GMT
+      - Mon, 06 Aug 2018 16:59:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:48 GMT
+      - Mon, 06 Aug 2018 16:52:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0f0bd54b-a539-4b48-812d-4cca676f8257
+      - req-1d07290e-74fc-4125-9896-97a0cce49a42
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:38:49.213564Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:38.589467Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bVKcGRG-S6WsuDCtMwK6Zw"],
-        "issued_at": "2018-08-03T19:38:49.213642Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h-O1Nd7XRwSIUswx3BAs7A"],
+        "issued_at": "2018-08-06T16:52:38.589550Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:49 GMT
+      - Mon, 06 Aug 2018 16:52:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-02d67680-5c26-4b8e-be00-a552c488d985
+      - req-fb672a8d-2084-41a9-ade9-76b8755d543f
       Date:
-      - Fri, 03 Aug 2018 19:38:49 GMT
+      - Mon, 06 Aug 2018 16:52:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:49 GMT
+      - Mon, 06 Aug 2018 16:52:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e091898a-735d-4bac-bd0a-90fc949ed171
+      - req-b2f75fbb-606d-4372-8582-8410620157ea
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:38:49.874302Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:39.286345Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P6uLnxHASX6PMgqaa6q8ew"],
-        "issued_at": "2018-08-03T19:38:49.874374Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIDlV7bER0yyZIl10S-LJg"],
+        "issued_at": "2018-08-06T16:52:39.286412Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e986bbf8-1335-4870-b7f3-afbd484639c8
+      - req-15bbc64f-b0ad-4382-96af-61ef4970a63b
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-e986bbf8-1335-4870-b7f3-afbd484639c8
+      - req-15bbc64f-b0ad-4382-96af-61ef4970a63b
       Date:
-      - Fri, 03 Aug 2018 19:38:50 GMT
+      - Mon, 06 Aug 2018 16:52:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:50 GMT
+      - Mon, 06 Aug 2018 16:52:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 498b49754b804633bc6b54b8c593f50a
+      - c8f530ab110446e093f91a8bf1479483
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-412f5121-b092-473f-913d-4f0a65080cb9
+      - req-bb43493f-95d4-4d3a-b15d-ebc1f77f7776
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +381,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:38:50.650286Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:39.735964Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rMGEk9VHSzOWzAGfmyFXag"],
-        "issued_at": "2018-08-03T19:38:50.650346Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fr_uUYXIShWj4W3M5GqfCA"],
+        "issued_at": "2018-08-06T16:52:39.736062Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -401,20 +401,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 498b49754b804633bc6b54b8c593f50a
+      - c8f530ab110446e093f91a8bf1479483
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:50 GMT
+      - Mon, 06 Aug 2018 16:52:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d3ffeb68-13af-4b56-818f-51539ba1bd2b
+      - req-e007cad8-3988-4626-82fb-d05accaeeed5
       Content-Length:
       - '2457'
       Connection:
@@ -447,13 +447,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"498b49754b804633bc6b54b8c593f50a"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"c8f530ab110446e093f91a8bf1479483"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -465,15 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:50 GMT
+      - Mon, 06 Aug 2018 16:52:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 882a1947f769463199d5a2ea9d3723c8
+      - a80481f2ddef491b88f7655e54259581
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-05e74351-ce34-4b1b-9e98-7c50068b050d
+      - req-da1cc156-4549-4a0c-9acc-132131c48361
       Content-Length:
       - '7313'
       Connection:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:50.650286Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:39.735964Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KWkbT_TfTz-e1SYb-DYO7g",
-        "rMGEk9VHSzOWzAGfmyFXag"], "issued_at": "2018-08-03T19:38:51.250893Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xlSadgQyQtqW0_JK_SDCdw",
+        "fr_uUYXIShWj4W3M5GqfCA"], "issued_at": "2018-08-06T16:52:40.185016Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -582,20 +582,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 882a1947f769463199d5a2ea9d3723c8
+      - a80481f2ddef491b88f7655e54259581
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:51 GMT
+      - Mon, 06 Aug 2018 16:52:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2922f2d3-6912-41c8-a9e2-15db6920513b
+      - req-bed535d6-eaf4-4f13-813b-41e55cfca355
       Content-Length:
       - '2179'
       Connection:
@@ -628,7 +628,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -646,15 +646,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:51 GMT
+      - Mon, 06 Aug 2018 16:52:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d8b001c3-73a3-422c-b841-293309f8a889
+      - req-ecdcb143-d1c1-4144-80b0-ae549111e99e
       Content-Length:
       - '7278'
       Connection:
@@ -666,7 +666,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:51.718541Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:40.767860Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -745,10 +745,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BUVtPTbTQCCArMcJ__AbBQ"],
-        "issued_at": "2018-08-03T19:38:51.718606Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L3y3ssfvQ32RFO4JaggdeA"],
+        "issued_at": "2018-08-06T16:52:40.767942Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:51 GMT
+      - Mon, 06 Aug 2018 16:52:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -801,15 +801,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:51 GMT
+      - Mon, 06 Aug 2018 16:52:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3fb9bfbd-d833-43b9-bca9-4618e3504a43
+      - req-dfbb0c31-fcc6-49df-999b-e5d5e4cd60d5
       Content-Length:
       - '7278'
       Connection:
@@ -821,7 +821,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:52.131827Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:41.184434Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -900,10 +900,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S6bjXl4nRxu7E1cZ4nkaEw"],
-        "issued_at": "2018-08-03T19:38:52.131906Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["89HDEpJkST2OV_rFJbB04w"],
+        "issued_at": "2018-08-06T16:52:41.184523Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -918,7 +918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
   response:
     status:
       code: 200
@@ -929,7 +929,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:52 GMT
+      - Mon, 06 Aug 2018 16:52:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -938,7 +938,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -956,15 +956,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:52 GMT
+      - Mon, 06 Aug 2018 16:52:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-63542c09-fd21-43b8-89d0-2b349900250f
+      - req-31b5a559-8352-4482-a4e6-054ae7517a9b
       Content-Length:
       - '7264'
       Connection:
@@ -976,7 +976,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:52.538933Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:41.602988Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1055,10 +1055,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1DHlKujCTX-wnjQAVxwUmg"],
-        "issued_at": "2018-08-03T19:38:52.538998Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LNYmP48kR82cleIMmIAcJg"],
+        "issued_at": "2018-08-06T16:52:41.603090Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
   response:
     status:
       code: 200
@@ -1084,7 +1084,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:52 GMT
+      - Mon, 06 Aug 2018 16:52:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1093,7 +1093,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1111,15 +1111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:52 GMT
+      - Mon, 06 Aug 2018 16:52:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6d491d60-4a25-4c8a-9119-50eb526caa46
+      - req-3a424a15-4d95-4713-9ba5-142a29df2bdc
       Content-Length:
       - '7278'
       Connection:
@@ -1131,7 +1131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:52.951418Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:42.275227Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1210,10 +1210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GDf2aWbVT36__XNi_BRviQ"],
-        "issued_at": "2018-08-03T19:38:52.951495Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I3PV587YR-SmY53Q8D0A8w"],
+        "issued_at": "2018-08-06T16:52:42.275298Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1228,7 +1228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
   response:
     status:
       code: 200
@@ -1239,7 +1239,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:53 GMT
+      - Mon, 06 Aug 2018 16:52:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1248,7 +1248,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1266,15 +1266,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:53 GMT
+      - Mon, 06 Aug 2018 16:52:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9bf02fb-a549-4f63-99f6-b858e506e81c
+      - req-e109d28b-d06b-4199-9789-b0f7a688d3a6
       Content-Length:
       - '7265'
       Connection:
@@ -1286,7 +1286,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:53.418339Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:42.811365Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1365,10 +1365,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EwTX4OdtRAumcQclPZWCGg"],
-        "issued_at": "2018-08-03T19:38:53.418407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vLQdIbquQCaYiRMEEW_MbA"],
+        "issued_at": "2018-08-06T16:52:42.811445Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1383,7 +1383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
   response:
     status:
       code: 200
@@ -1394,7 +1394,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:53 GMT
+      - Mon, 06 Aug 2018 16:52:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1403,7 +1403,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1421,15 +1421,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:53 GMT
+      - Mon, 06 Aug 2018 16:52:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-843c6b6f-9f5e-4904-b812-ec2ea2d20cc2
+      - req-773d374e-def9-456c-811f-bb0bd144f96d
       Content-Length:
       - '7278'
       Connection:
@@ -1441,7 +1441,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:53.827900Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:43.205474Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1520,10 +1520,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lmQ3Xdu8QuCnpHzJy8PxJw"],
-        "issued_at": "2018-08-03T19:38:53.827964Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jwqa7qe3TQaozli8tB7_Fg"],
+        "issued_at": "2018-08-06T16:52:43.205538Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1538,7 +1538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
   response:
     status:
       code: 200
@@ -1549,7 +1549,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:38:53 GMT
+      - Mon, 06 Aug 2018 16:52:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1558,7 +1558,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1573,7 +1573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1586,26 +1586,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-31e4d92c-ab91-4ed9-90c2-6a879cf06365
+      - req-cc998ef2-c624-4651-b834-7d7493c267ff
       Date:
-      - Fri, 03 Aug 2018 19:38:54 GMT
+      - Mon, 06 Aug 2018 16:52:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1620,7 +1620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1633,26 +1633,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0fc185ce-be38-4260-a8c9-00540b4f8f5c
+      - req-36251c9d-c533-4cb3-8ab9-85e19e97b07a
       Date:
-      - Fri, 03 Aug 2018 19:38:54 GMT
+      - Mon, 06 Aug 2018 16:52:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1667,7 +1667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1680,26 +1680,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-454f7a1d-ba47-4bf0-b23a-ce71ec7dade4
+      - req-f1fe8dce-532e-416e-940b-493ddca98fb5
       Date:
-      - Fri, 03 Aug 2018 19:38:54 GMT
+      - Mon, 06 Aug 2018 16:52:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1714,7 +1714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1727,26 +1727,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-412499af-1223-4f82-b174-d8aa5ccb2e4a
+      - req-29faa091-0e58-4f46-b867-e6a557a92ef8
       Date:
-      - Fri, 03 Aug 2018 19:38:54 GMT
+      - Mon, 06 Aug 2018 16:52:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1761,7 +1761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1774,26 +1774,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e94c8444-302e-4540-b9a2-d27e9be7be41
+      - req-cd54d602-d3d8-48e7-af72-b9af56c80101
       Date:
-      - Fri, 03 Aug 2018 19:38:54 GMT
+      - Mon, 06 Aug 2018 16:52:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1808,7 +1808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1821,26 +1821,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-25e39dac-84ff-4d27-a5f7-89715d1bcfe2
+      - req-af286552-37d5-4e9c-a403-af307066390f
       Date:
-      - Fri, 03 Aug 2018 19:38:55 GMT
+      - Mon, 06 Aug 2018 16:52:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1855,7 +1855,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1868,26 +1868,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b3ce1a64-7b4b-4cdb-8015-734aa282062e
+      - req-e29f7485-86e8-4a10-bacb-e9007d0d023e
       Date:
-      - Fri, 03 Aug 2018 19:38:55 GMT
+      - Mon, 06 Aug 2018 16:52:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1902,7 +1902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1915,26 +1915,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7942ecd1-0418-4f05-8f59-8f17233d77de
+      - req-e244a05a-2f19-458c-9a80-48083a5e233e
       Date:
-      - Fri, 03 Aug 2018 19:38:55 GMT
+      - Mon, 06 Aug 2018 16:52:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1949,7 +1949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1962,26 +1962,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f8ba5d75-dd18-494d-b5a5-90e9c4745013
+      - req-3b411cf7-98c7-49db-9332-03ea788bfa75
       Date:
-      - Fri, 03 Aug 2018 19:38:55 GMT
+      - Mon, 06 Aug 2018 16:52:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1996,7 +1996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2009,26 +2009,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b2f84916-f54d-4a42-9e6c-18cb9f858c53
+      - req-3caa2b22-ed52-471c-9fb0-889344e67cc8
       Date:
-      - Fri, 03 Aug 2018 19:38:56 GMT
+      - Mon, 06 Aug 2018 16:52:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -2043,7 +2043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2056,26 +2056,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d523cc37-30c0-4ddb-809e-4d1ec3100cf5
+      - req-ef9b404c-59f0-41d8-a333-63a89e1eb4e8
       Date:
-      - Fri, 03 Aug 2018 19:38:56 GMT
+      - Mon, 06 Aug 2018 16:52:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -2090,7 +2090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2103,26 +2103,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-4d61860a-49da-470a-b0f9-0cf5db082ed6
+      - req-d1519d20-d6fe-4066-8fb6-09065f103091
       Date:
-      - Fri, 03 Aug 2018 19:38:57 GMT
+      - Mon, 06 Aug 2018 16:52:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -2137,7 +2137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2150,26 +2150,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b6e2d117-4bcc-43bd-b8a4-2863fc3dbcda
+      - req-68e40470-d95c-4a2f-86bb-722a89fd711e
       Date:
-      - Fri, 03 Aug 2018 19:38:57 GMT
+      - Mon, 06 Aug 2018 16:52:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2184,7 +2184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2197,26 +2197,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7047bc06-ed3f-4ea9-82d7-26d3ad27e6e7
+      - req-a97ca6b5-230d-4884-911a-827a68bd27fa
       Date:
-      - Fri, 03 Aug 2018 19:38:57 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:38:53.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:38:48.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:38:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:38:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:38:53.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2231,7 +2231,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2244,9 +2244,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-be24468f-61a6-4bb3-89a9-50b2859cefd9
+      - req-6fccb537-61f1-4ced-acad-e8fb660b4dad
       Date:
-      - Fri, 03 Aug 2018 19:38:58 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2260,7 +2260,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-dbeb8677-5988-45f2-887f-5651cd728567
+      - req-3674c6e8-5545-4cb4-861d-42825c0df93a
       Date:
-      - Fri, 03 Aug 2018 19:38:58 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2304,7 +2304,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2319,7 +2319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2332,9 +2332,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-9e31120d-3d75-4e9e-a5a5-418a36d048a0
+      - req-4ae770a9-8287-45b8-81d7-9d6ef8e1b0f9
       Date:
-      - Fri, 03 Aug 2018 19:38:58 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2349,7 +2349,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2364,7 +2364,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2377,9 +2377,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-2bfc32b6-debe-4e9a-b7e3-0c0475ffdd98
+      - req-723fb82e-289c-4a05-b65e-388f3415dd27
       Date:
-      - Fri, 03 Aug 2018 19:38:58 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2389,7 +2389,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2404,7 +2404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2417,15 +2417,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-ad1b58fc-e0fa-44d4-ad4d-78ca0ae553b9
+      - req-9bf655a5-6e50-48b9-bbe4-e4036812b847
       Date:
-      - Fri, 03 Aug 2018 19:38:59 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2443,15 +2443,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:59 GMT
+      - Mon, 06 Aug 2018 16:52:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 87569325524a4472a77fe55308a62dc8
+      - e0255fc0aa294babb280279aca329cbf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f65c61cb-acc1-4553-907e-6227e6bd2f0d
+      - req-a9f01416-29cb-4579-ac16-29b8cfbc6415
       Content-Length:
       - '7311'
       Connection:
@@ -2463,7 +2463,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:38:59.375619Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:47.116655Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2542,10 +2542,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R5vCOCdKSkKnwQYMt6FHOg"],
-        "issued_at": "2018-08-03T19:38:59.375680Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y6nKBSC2Rk2EwEpbR0A6Bw"],
+        "issued_at": "2018-08-06T16:52:47.116727Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -2560,7 +2560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87569325524a4472a77fe55308a62dc8
+      - e0255fc0aa294babb280279aca329cbf
   response:
     status:
       code: 300
@@ -2571,7 +2571,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:38:59 GMT
+      - Mon, 06 Aug 2018 16:52:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -2584,7 +2584,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2602,15 +2602,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:38:59 GMT
+      - Mon, 06 Aug 2018 16:52:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b713dc20d59d43938c559e78436df23d
+      - 6b2a80456bc941eaaae5cf6e479b6010
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2842051d-62f2-4b16-a21c-0f904bbdb95f
+      - req-fa9582a3-99af-4f5d-8392-0d7ab05cc2dc
       Content-Length:
       - '7278'
       Connection:
@@ -2622,7 +2622,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:38:59.795008Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:47.524291Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2701,10 +2701,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NHrblLXWQ2ycOW7ux50D5w"],
-        "issued_at": "2018-08-03T19:38:59.795076Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zEvt1LvlT6epY86Y_YroGQ"],
+        "issued_at": "2018-08-06T16:52:47.524355Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:38:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2719,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b713dc20d59d43938c559e78436df23d
+      - 6b2a80456bc941eaaae5cf6e479b6010
   response:
     status:
       code: 200
@@ -2730,9 +2730,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-482fa27c-bf86-4aca-82dd-5952ebd537a8
+      - req-565e993e-bcae-4595-b868-34f47d4e14f7
       Date:
-      - Fri, 03 Aug 2018 19:39:00 GMT
+      - Mon, 06 Aug 2018 16:52:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2774,7 +2774,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -2789,7 +2789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b713dc20d59d43938c559e78436df23d
+      - 6b2a80456bc941eaaae5cf6e479b6010
   response:
     status:
       code: 200
@@ -2800,14 +2800,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d295426d-8589-4df0-b935-343199794a66
+      - req-547cbf1c-a3c3-4faa-9d58-b918c62742b7
       Date:
-      - Fri, 03 Aug 2018 19:39:00 GMT
+      - Mon, 06 Aug 2018 16:52:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2825,15 +2825,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:00 GMT
+      - Mon, 06 Aug 2018 16:52:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c9a715a26d249ef8c401b94665ef2e8
+      - e08c7d86bb46470fb21d8583bcc1c547
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9565a958-8e10-40e4-88b6-f11ea16114e5
+      - req-1493b0b2-45d2-489e-93aa-c019742d4f36
       Content-Length:
       - '7278'
       Connection:
@@ -2845,7 +2845,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:00.711805Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:48.357818Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2924,10 +2924,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YEh9GqqvQyqS92CxPDh5_w"],
-        "issued_at": "2018-08-03T19:39:00.711876Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q5r3DhCaRqm907y0zS7O-w"],
+        "issued_at": "2018-08-06T16:52:48.357889Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2942,7 +2942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a715a26d249ef8c401b94665ef2e8
+      - e08c7d86bb46470fb21d8583bcc1c547
   response:
     status:
       code: 200
@@ -2953,9 +2953,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7ef2ac78-3fe7-4ab8-8c7e-23fb468bc3ee
+      - req-a18a56f4-031b-458f-bb49-1315bbb53df7
       Date:
-      - Fri, 03 Aug 2018 19:39:01 GMT
+      - Mon, 06 Aug 2018 16:52:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2997,7 +2997,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3012,7 +3012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c9a715a26d249ef8c401b94665ef2e8
+      - e08c7d86bb46470fb21d8583bcc1c547
   response:
     status:
       code: 200
@@ -3023,14 +3023,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-672801ba-d991-4fb5-801d-5331883c86ae
+      - req-2a99b798-6070-4892-90f0-9f13994260bb
       Date:
-      - Fri, 03 Aug 2018 19:39:01 GMT
+      - Mon, 06 Aug 2018 16:52:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3048,15 +3048,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:01 GMT
+      - Mon, 06 Aug 2018 16:52:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 99cfc69c9fc14f1da72d8460b723fb8b
+      - d94d85ae28f345c6a4abdc0a79aa5f29
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-475c9152-49d1-4740-8c20-82cb03d07012
+      - req-6539bf3f-b8e3-43ff-9671-21d9157cc0d4
       Content-Length:
       - '7264'
       Connection:
@@ -3068,7 +3068,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:01.507466Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:49.264408Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3147,10 +3147,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VHzgiA3GRfap2NFZyDo5DA"],
-        "issued_at": "2018-08-03T19:39:01.507536Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0-jmVHbQTl2Dxd3DBrgwUw"],
+        "issued_at": "2018-08-06T16:52:49.264480Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3165,7 +3165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99cfc69c9fc14f1da72d8460b723fb8b
+      - d94d85ae28f345c6a4abdc0a79aa5f29
   response:
     status:
       code: 200
@@ -3176,9 +3176,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e088840c-be87-4c17-962e-bea66affb3f5
+      - req-be63f8e4-e004-4d5c-81a0-d3426dff792a
       Date:
-      - Fri, 03 Aug 2018 19:39:01 GMT
+      - Mon, 06 Aug 2018 16:52:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3220,7 +3220,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3235,7 +3235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99cfc69c9fc14f1da72d8460b723fb8b
+      - d94d85ae28f345c6a4abdc0a79aa5f29
   response:
     status:
       code: 200
@@ -3246,14 +3246,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ece8d9fa-7628-4af9-9ec6-7404fab1039e
+      - req-c5b1faa0-99f0-42ef-b6a7-1fb0bdde029f
       Date:
-      - Fri, 03 Aug 2018 19:39:02 GMT
+      - Mon, 06 Aug 2018 16:52:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3271,15 +3271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:02 GMT
+      - Mon, 06 Aug 2018 16:52:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 051b58db40a14d6aa324c63c0c45c2ae
+      - 63828c7f088e450fbb3a18a495f6d723
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cca1c290-e21e-45c0-9668-564c32be3029
+      - req-a004f139-a355-435c-80d2-f155ec3354e4
       Content-Length:
       - '7278'
       Connection:
@@ -3291,7 +3291,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:02.489203Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:50.082257Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3370,10 +3370,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7fWjUB5ATuyY2X-73nQpCg"],
-        "issued_at": "2018-08-03T19:39:02.489309Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5yJ8qLbQSMCYFeTyPyYGbQ"],
+        "issued_at": "2018-08-06T16:52:50.082320Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3388,7 +3388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 051b58db40a14d6aa324c63c0c45c2ae
+      - 63828c7f088e450fbb3a18a495f6d723
   response:
     status:
       code: 200
@@ -3399,9 +3399,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3cd1c29c-1e34-46b8-bfee-b16f5881bbc0
+      - req-8d3b761a-91c5-4a5f-8aa2-259e5f1481c5
       Date:
-      - Fri, 03 Aug 2018 19:39:02 GMT
+      - Mon, 06 Aug 2018 16:52:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3443,7 +3443,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3458,7 +3458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 051b58db40a14d6aa324c63c0c45c2ae
+      - 63828c7f088e450fbb3a18a495f6d723
   response:
     status:
       code: 200
@@ -3469,14 +3469,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4b31af30-0bba-42a0-afbb-af816f345d32
+      - req-09484f92-d968-4d79-a28f-1e551c7d1b49
       Date:
-      - Fri, 03 Aug 2018 19:39:03 GMT
+      - Mon, 06 Aug 2018 16:52:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3491,7 +3491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87569325524a4472a77fe55308a62dc8
+      - e0255fc0aa294babb280279aca329cbf
   response:
     status:
       code: 200
@@ -3502,9 +3502,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6a3ef059-bc4e-4dce-81e8-6832fae0ee97
+      - req-3966a763-f1ed-48ee-b938-4b90d6e9699f
       Date:
-      - Fri, 03 Aug 2018 19:39:03 GMT
+      - Mon, 06 Aug 2018 16:52:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3546,7 +3546,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3561,7 +3561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87569325524a4472a77fe55308a62dc8
+      - e0255fc0aa294babb280279aca329cbf
   response:
     status:
       code: 200
@@ -3572,14 +3572,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1d90fb02-c084-46b4-8e02-d6fa067d64f6
+      - req-1e29afd5-5d64-4405-8003-bbb0be355a55
       Date:
-      - Fri, 03 Aug 2018 19:39:03 GMT
+      - Mon, 06 Aug 2018 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3597,15 +3597,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:03 GMT
+      - Mon, 06 Aug 2018 16:52:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b95e57ae46d740719af6adee7e26d3fc
+      - d242693e8d344bc4a3b968d514136dc8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40979878-143e-400d-b3e0-4c1bed1c09cf
+      - req-4b971a73-0069-4f59-a844-cf11d26a9e18
       Content-Length:
       - '7265'
       Connection:
@@ -3617,7 +3617,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:04.039580Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:51.348687Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3696,10 +3696,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q3iWc654S2qtVWw88dradg"],
-        "issued_at": "2018-08-03T19:39:04.039647Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rqYl1q4PQ2OZUUW6rH2LfA"],
+        "issued_at": "2018-08-06T16:52:51.348758Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3714,7 +3714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b95e57ae46d740719af6adee7e26d3fc
+      - d242693e8d344bc4a3b968d514136dc8
   response:
     status:
       code: 200
@@ -3725,9 +3725,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7aaad96f-9632-44cd-811b-5628a0c6c9f6
+      - req-a0db113a-7616-424a-8689-fe740d6a307b
       Date:
-      - Fri, 03 Aug 2018 19:39:04 GMT
+      - Mon, 06 Aug 2018 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3769,7 +3769,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3784,7 +3784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b95e57ae46d740719af6adee7e26d3fc
+      - d242693e8d344bc4a3b968d514136dc8
   response:
     status:
       code: 200
@@ -3795,14 +3795,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d8ebbde3-ee8c-4703-9561-8e5a09f7dde2
+      - req-c2ca3315-bc11-4535-8f61-7128c3c2da78
       Date:
-      - Fri, 03 Aug 2018 19:39:04 GMT
+      - Mon, 06 Aug 2018 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3820,15 +3820,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:04 GMT
+      - Mon, 06 Aug 2018 16:52:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7afdacb062ed440e83df732dc6940d80
+      - 3fd8d08be5694ed6971260dab1201cdf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-acd11f43-f7dc-4198-988d-75ce3629c93a
+      - req-e5b2f3b8-0421-4c8a-b405-21f219edb778
       Content-Length:
       - '7278'
       Connection:
@@ -3840,7 +3840,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:04.786777Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:52.244069Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3919,10 +3919,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5-b-_JPfQ_ewVGwO2_mNFw"],
-        "issued_at": "2018-08-03T19:39:04.786835Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mavmut0ATNGNNRc5nyMOSg"],
+        "issued_at": "2018-08-06T16:52:52.244184Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3937,7 +3937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7afdacb062ed440e83df732dc6940d80
+      - 3fd8d08be5694ed6971260dab1201cdf
   response:
     status:
       code: 200
@@ -3948,9 +3948,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-060bb942-be3e-44d5-9b84-118dd52518c2
+      - req-ebf99b7c-6c55-4140-8473-897bc4401b9b
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3992,7 +3992,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4007,7 +4007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7afdacb062ed440e83df732dc6940d80
+      - 3fd8d08be5694ed6971260dab1201cdf
   response:
     status:
       code: 200
@@ -4018,14 +4018,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-dd3cff7c-74da-47a6-b94a-2dba5d4073dd
+      - req-0cf4518c-d633-4815-a9a9-2a0c1023514d
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -4040,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4053,9 +4053,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-8e22f3f2-6a30-4f6d-b634-912f66f07170
+      - req-ff2ad657-8787-4537-b18b-4c73af28d9ee
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4065,7 +4065,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4080,7 +4080,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4093,9 +4093,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ae53404d-f373-4f96-941e-348c26474092
+      - req-9c69e1fe-4cd4-43b5-a731-0d78b9c0991e
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4105,7 +4105,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -4120,7 +4120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4133,9 +4133,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-dd8fe16e-9365-4b58-9b47-5daa4400a616
+      - req-c6aed6d9-41ef-4993-be29-c21fdbcf0b40
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4145,7 +4145,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4160,7 +4160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4173,9 +4173,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ed2d861e-ef60-4fe8-9e3c-c77b34466532
+      - req-eaacafc8-01eb-4dd7-9081-8364b9584525
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4185,7 +4185,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -4200,7 +4200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4213,9 +4213,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-46d84358-9ea9-43b8-ab29-48cf095cd40b
+      - req-126938d7-0f15-4249-b0fe-3decfaf7199b
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4225,7 +4225,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4240,7 +4240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4253,9 +4253,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f79ef2ab-edc5-4144-acdd-987ef71227b7
+      - req-c14edb40-8d0c-49e4-8f88-8d0e58984613
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4265,7 +4265,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4280,7 +4280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4293,9 +4293,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-7ef8e8a2-36ed-461a-8550-a7dab7590026
+      - req-d11a6e65-1099-4225-8f9c-e2986229fe57
       Date:
-      - Fri, 03 Aug 2018 19:39:05 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4305,7 +4305,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4320,7 +4320,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4333,9 +4333,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-4a19ecf2-d267-4c91-acf5-1aeb08cfe434
+      - req-87682d57-d6bd-4f74-9793-58f52ff14644
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4345,7 +4345,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4360,7 +4360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4373,9 +4373,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-003accd5-9412-446b-90a5-5a35692e6a11
+      - req-b50e9765-7a37-4fb1-a50a-bdf201c7e1db
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4385,7 +4385,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4400,7 +4400,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4413,9 +4413,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-526e7ec1-ddd2-4fc0-9f7f-a20b285b4f79
+      - req-5149f29f-470a-4950-a3e9-3e35dcf3289a
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4425,7 +4425,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4440,7 +4440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4453,9 +4453,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-58d3f9c5-27a1-4788-823b-a4d43114a0ea
+      - req-eea393d7-4972-4f81-ae8c-0428bc617f89
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4465,7 +4465,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4480,7 +4480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4493,9 +4493,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-6f125afe-d8c2-4e8c-979c-34688fc05804
+      - req-42e07569-08b9-4fc1-8673-181894d8459b
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4505,7 +4505,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4520,7 +4520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4533,9 +4533,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-20ddb34e-e9ea-4802-8361-bdd574dbaa11
+      - req-63c1abd7-0dd8-4a92-9e70-28304374cf84
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4545,7 +4545,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4560,7 +4560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4573,9 +4573,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-5af0c472-3591-41a6-9d88-ae83d00a3192
+      - req-da49120e-d605-4b64-9658-ce362a6093cb
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4585,7 +4585,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4603,15 +4603,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:06 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1aabfff5bbbb429b90771f35d6526c8e
+      - 5c2978f9f41d4f4092f5b157f5bc9559
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad5b2e72-369d-47fb-b283-c5927cbf170f
+      - req-00412d16-d80a-4c86-9257-d349505d59b7
       Content-Length:
       - '7311'
       Connection:
@@ -4623,7 +4623,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:07.044885Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:54.785531Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4702,10 +4702,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mVhCb1w_SvOtuEh9OEexWA"],
-        "issued_at": "2018-08-03T19:39:07.044967Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7OLy8fs2Q-WAzNP50kM_tw"],
+        "issued_at": "2018-08-06T16:52:54.785606Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4723,15 +4723,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:07 GMT
+      - Mon, 06 Aug 2018 16:52:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ad38db12c0b848c69091e58126871ec1
+      - d0c452aad88e4242bf637b03a2904903
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a8c24e9f-2816-40a8-90cb-2011cda2426c
+      - req-ddbaf8f9-cdd9-43b0-bd97-878b27b54a70
       Content-Length:
       - '7278'
       Connection:
@@ -4743,7 +4743,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:07.404468Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:55.121719Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4822,10 +4822,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cHf5na6zS5GdkvMSsS2Tnw"],
-        "issued_at": "2018-08-03T19:39:07.404548Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2EaUwMHBSZyW98IXrm4ylA"],
+        "issued_at": "2018-08-06T16:52:55.121789Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -4840,7 +4840,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad38db12c0b848c69091e58126871ec1
+      - d0c452aad88e4242bf637b03a2904903
   response:
     status:
       code: 200
@@ -4851,14 +4851,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ddebbca3-f633-458c-97a7-ff829d352f67
+      - req-34ade597-9452-42b6-b912-9802c85a3ae8
       Date:
-      - Fri, 03 Aug 2018 19:39:08 GMT
+      - Mon, 06 Aug 2018 16:52:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4876,15 +4876,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:08 GMT
+      - Mon, 06 Aug 2018 16:52:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7c5985f18c8f4e988841d99169678cf8
+      - 31a0d57a36ca4c02898433445435548a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-42b8e987-ee1c-43a6-90ea-2baa84484d89
+      - req-1308f761-0258-4abe-a952-0b02dc22b381
       Content-Length:
       - '7278'
       Connection:
@@ -4896,7 +4896,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:08.461086Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:55.673026Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4975,10 +4975,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Q59zqu1Rlmbv1TJKAXVlg"],
-        "issued_at": "2018-08-03T19:39:08.461207Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jo2kK6nlT9y2xn4UaTbExA"],
+        "issued_at": "2018-08-06T16:52:55.673095Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -4993,7 +4993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c5985f18c8f4e988841d99169678cf8
+      - 31a0d57a36ca4c02898433445435548a
   response:
     status:
       code: 200
@@ -5004,14 +5004,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2ae6a38c-7043-47fa-b9e6-0de63b36d4f4
+      - req-2bd0c15a-37a3-479d-9da7-4167b25d2570
       Date:
-      - Fri, 03 Aug 2018 19:39:08 GMT
+      - Mon, 06 Aug 2018 16:52:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5029,15 +5029,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:08 GMT
+      - Mon, 06 Aug 2018 16:52:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6aca612-8cb8-43b2-aaa1-16f49fa30f96
+      - req-480a9782-4a4f-4eba-8ef5-86a228cdf3ea
       Content-Length:
       - '7264'
       Connection:
@@ -5049,7 +5049,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:09.096225Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:56.227459Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5128,10 +5128,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TlKjKJCzTs2S_bpSfvly7A"],
-        "issued_at": "2018-08-03T19:39:09.096342Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k2wkQZqLQ8-en49fVRWB5w"],
+        "issued_at": "2018-08-06T16:52:56.227526Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5146,7 +5146,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5157,9 +5157,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-9843b3db-b173-4797-b110-3edc5b3492ca
+      - req-41b143e8-6cfc-414c-a350-b60e3b7d4382
       Date:
-      - Fri, 03 Aug 2018 19:39:09 GMT
+      - Mon, 06 Aug 2018 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5193,7 +5193,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5208,7 +5208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5219,14 +5219,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4dcc4dfa-9df2-4a0c-bc10-0fb2263a7ef1
+      - req-3b104c59-5fc8-40e7-939e-d80bedc323d5
       Date:
-      - Fri, 03 Aug 2018 19:39:09 GMT
+      - Mon, 06 Aug 2018 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5244,15 +5244,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:09 GMT
+      - Mon, 06 Aug 2018 16:52:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 865106683be84939a90c12b4df7deae0
+      - dee8366863ab435a968168c9c439234e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad6e8f41-4a0c-49b3-abdd-a0895d0fe60e
+      - req-da5d954b-097d-4618-ab95-ac15a5cb506c
       Content-Length:
       - '7278'
       Connection:
@@ -5264,7 +5264,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:09.868536Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:57.141571Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5343,10 +5343,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g0IyLq5GRFywlmOoWZ_U-g"],
-        "issued_at": "2018-08-03T19:39:09.868602Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RiWr8L3CQzGYrPTGpZ75Yw"],
+        "issued_at": "2018-08-06T16:52:57.141653Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5361,7 +5361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865106683be84939a90c12b4df7deae0
+      - dee8366863ab435a968168c9c439234e
   response:
     status:
       code: 200
@@ -5372,14 +5372,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a882e9ec-91eb-47aa-9240-e58bb2b7533f
+      - req-d6e8ba25-506e-4504-bbbb-eaff5a08bebb
       Date:
-      - Fri, 03 Aug 2018 19:39:10 GMT
+      - Mon, 06 Aug 2018 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5394,7 +5394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1aabfff5bbbb429b90771f35d6526c8e
+      - 5c2978f9f41d4f4092f5b157f5bc9559
   response:
     status:
       code: 200
@@ -5405,14 +5405,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a94bfff3-aec8-4a19-8bf2-3dc036b7bf71
+      - req-8dc48d3e-db9d-468a-b94c-913dd0906247
       Date:
-      - Fri, 03 Aug 2018 19:39:10 GMT
+      - Mon, 06 Aug 2018 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5430,15 +5430,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:10 GMT
+      - Mon, 06 Aug 2018 16:52:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 18e5663f21b34324991607d13360f998
+      - 109146320f07436d9ba2e121784cd817
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1196e50b-771f-41ce-ab11-7bbcaa6bdc23
+      - req-909ecce8-5582-4db5-b784-ee59e4f50d7c
       Content-Length:
       - '7265'
       Connection:
@@ -5450,7 +5450,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:10.626199Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:57.901678Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5529,10 +5529,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["af4OJTt2Rnq6Y9CXxXOPLw"],
-        "issued_at": "2018-08-03T19:39:10.626284Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tVSntgbjR4mVhEjXCFguxw"],
+        "issued_at": "2018-08-06T16:52:57.901749Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5547,7 +5547,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18e5663f21b34324991607d13360f998
+      - 109146320f07436d9ba2e121784cd817
   response:
     status:
       code: 200
@@ -5558,14 +5558,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-102dd84f-7861-4783-8793-a983db98207c
+      - req-99d56488-9c04-4dbe-a871-391d1d414276
       Date:
-      - Fri, 03 Aug 2018 19:39:10 GMT
+      - Mon, 06 Aug 2018 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5583,15 +5583,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:10 GMT
+      - Mon, 06 Aug 2018 16:52:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '01985ea664d14b0caabf3bb5014b9aa3'
+      - b1e177b7e02d4dddb686d3f0c566f620
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aafc0cbf-2db1-47b8-8f0c-8b1e0c87c19f
+      - req-01f89233-4aab-48b0-832e-cd4757922a56
       Content-Length:
       - '7278'
       Connection:
@@ -5603,7 +5603,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:11.248357Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:58.544698Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5682,10 +5682,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["roEPft2CSvqacP58o1l3zQ"],
-        "issued_at": "2018-08-03T19:39:11.248425Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kVrvmzwvRX2o33nT1__3dg"],
+        "issued_at": "2018-08-06T16:52:58.544798Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5700,7 +5700,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01985ea664d14b0caabf3bb5014b9aa3'
+      - b1e177b7e02d4dddb686d3f0c566f620
   response:
     status:
       code: 200
@@ -5711,14 +5711,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f5f5317c-8a5b-4ba7-969d-4d49c5778f34
+      - req-38a43eda-b696-42f8-9bca-84fbdc6bff2a
       Date:
-      - Fri, 03 Aug 2018 19:39:11 GMT
+      - Mon, 06 Aug 2018 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5733,7 +5733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5744,9 +5744,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1e7ddba0-d32d-48cd-8c62-499232088957
+      - req-d8a28338-cb30-4099-be84-bab7a824d61a
       Date:
-      - Fri, 03 Aug 2018 19:39:16 GMT
+      - Mon, 06 Aug 2018 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5773,7 +5773,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5788,7 +5788,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5799,9 +5799,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3a82db77-75d1-4dcf-82a5-da952aeed168
+      - req-cd758996-b86d-4d4f-9dbb-9865e0d72bf3
       Date:
-      - Fri, 03 Aug 2018 19:39:17 GMT
+      - Mon, 06 Aug 2018 16:53:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5828,7 +5828,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5843,7 +5843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5854,9 +5854,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-26ddb45d-2d53-465b-8741-20dfc2b51f8d
+      - req-c1748a00-f9e7-4952-abc4-2b5ee6782b09
       Date:
-      - Fri, 03 Aug 2018 19:39:18 GMT
+      - Mon, 06 Aug 2018 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5883,7 +5883,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5898,7 +5898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5909,9 +5909,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-832cb526-3daf-4a7c-b204-9e2b6ddb6f03
+      - req-057dce27-9c52-423e-aba9-307352a93ba8
       Date:
-      - Fri, 03 Aug 2018 19:39:18 GMT
+      - Mon, 06 Aug 2018 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5967,7 +5967,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5982,7 +5982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -5993,9 +5993,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fa2738ec-031f-4566-8bf9-feb58af31664
+      - req-3e7b5de9-7a72-4c8f-92c7-230ae7cca305
       Date:
-      - Fri, 03 Aug 2018 19:39:18 GMT
+      - Mon, 06 Aug 2018 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6007,7 +6007,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -6022,7 +6022,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6035,14 +6035,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-57e6e74a-bb8b-443c-b32c-33f37d979097
+      - req-be00c2f7-0b85-453a-8159-e3f4f0ef1be4
       Date:
-      - Fri, 03 Aug 2018 19:39:18 GMT
+      - Mon, 06 Aug 2018 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -6057,7 +6057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6070,14 +6070,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-f871964e-7eb7-4d84-9382-3f1b9c0d2524
+      - req-ff48b394-7e7f-40b6-88d5-65bccabc4438
       Date:
-      - Fri, 03 Aug 2018 19:39:18 GMT
+      - Mon, 06 Aug 2018 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -6092,7 +6092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6105,9 +6105,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-e419d56c-c890-4e22-bd55-dd0d066bae09
+      - req-f4292a65-29ca-40e0-9ebd-d4dda74b550e
       Date:
-      - Fri, 03 Aug 2018 19:39:19 GMT
+      - Mon, 06 Aug 2018 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6153,7 +6153,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6168,7 +6168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6181,9 +6181,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-12236974-260d-470e-b977-dbb1e1a91922
+      - req-9f59117b-b80e-4c8e-bfcf-c0cdb5cfbe46
       Date:
-      - Fri, 03 Aug 2018 19:39:20 GMT
+      - Mon, 06 Aug 2018 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6229,7 +6229,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6244,7 +6244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6257,9 +6257,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-fc6ce426-e1c3-4a25-9cdc-bc1155131227
+      - req-ad3a735f-b51d-4fd4-b9f6-69eb8573f6c9
       Date:
-      - Fri, 03 Aug 2018 19:39:20 GMT
+      - Mon, 06 Aug 2018 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6307,7 +6307,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6322,7 +6322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6335,9 +6335,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-227b967e-9908-4108-9c13-d7f13f4b1175
+      - req-c17c8f25-08ad-4120-aec0-84e6d31c5c67
       Date:
-      - Fri, 03 Aug 2018 19:39:21 GMT
+      - Mon, 06 Aug 2018 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6379,7 +6379,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6394,7 +6394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6407,9 +6407,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-ed388f0d-39da-4729-80e6-33f947afe1b3
+      - req-b8be4714-a8d9-4956-91d4-2012ff42a891
       Date:
-      - Fri, 03 Aug 2018 19:39:21 GMT
+      - Mon, 06 Aug 2018 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6432,7 +6432,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6447,7 +6447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6460,14 +6460,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-0efeddde-f91d-46e6-ac24-9474b2fbb5b7
+      - req-b73ad868-377c-4bbe-b18d-68fb4793f542
       Date:
-      - Fri, 03 Aug 2018 19:39:22 GMT
+      - Mon, 06 Aug 2018 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6482,7 +6482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6495,14 +6495,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-f08e5111-b403-4011-b40c-bb6317f46b9c
+      - req-46866397-24fa-4198-a165-77dc4f18c559
       Date:
-      - Fri, 03 Aug 2018 19:39:22 GMT
+      - Mon, 06 Aug 2018 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6517,7 +6517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6530,14 +6530,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-bef66247-6f51-42b5-a614-71ae0065d56e
+      - req-16010f25-282a-4d58-9878-d645d7bea724
       Date:
-      - Fri, 03 Aug 2018 19:39:22 GMT
+      - Mon, 06 Aug 2018 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6552,7 +6552,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6565,14 +6565,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-2d81efd9-484d-49e7-bb72-4f2fbc9376b6
+      - req-a6fb132f-bdde-4fcf-87ad-1b4f0a1433b8
       Date:
-      - Fri, 03 Aug 2018 19:39:22 GMT
+      - Mon, 06 Aug 2018 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6587,7 +6587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -6598,9 +6598,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d73dd9f0-0ba4-48ce-a92f-e8185f4b4175
+      - req-cce2ea96-be76-425a-93bb-1226f74928e9
       Date:
-      - Fri, 03 Aug 2018 19:39:22 GMT
+      - Mon, 06 Aug 2018 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6656,7 +6656,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6671,7 +6671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -6682,9 +6682,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-22e820bb-150e-4add-a248-8b832574f921
+      - req-a53cfa1b-56fd-4a7e-a304-3a19b97019dd
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6696,7 +6696,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6711,7 +6711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -6722,9 +6722,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9d50b0a4-36e3-43d4-9cec-07444eb5fd98
+      - req-489899d2-1308-43d4-8b65-c85362e9bdbd
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6780,7 +6780,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6795,7 +6795,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d6c3ec801584c09bdb55980c776fe90
+      - b77edbdc5ef544b2aea248f2c2aaa45e
   response:
     status:
       code: 200
@@ -6806,9 +6806,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9cae945e-7cb4-4bb2-83a9-aefde1a6ef87
+      - req-e97d5726-1f49-4d77-af9d-598ba7a74f0f
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6820,7 +6820,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6835,7 +6835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 774c9e1f235144c7a614e1eb509e166d
+      - a42803d75e874942aad55838bcdbdb57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6848,9 +6848,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-31e80b00-7634-4031-a3e4-f8f4d6e8c775
+      - req-253aca03-644b-4bb1-b7e8-16cae6274f8a
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6859,7 +6859,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6874,7 +6874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cea41597a01437aa870cd1d0d96967a
+      - f6261347ce294158801fcd7ae46c28b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6887,9 +6887,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f0fc3175-4a71-4fc7-8a7f-d137971e1a1b
+      - req-759f0075-f3c0-4515-859e-07c910e3741c
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6898,7 +6898,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6913,7 +6913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6926,9 +6926,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c79800a9-f81f-4c68-b8e6-dbfcd549cc72
+      - req-2a5ca4c7-8b71-4d49-9bac-a5eab66e0935
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6937,7 +6937,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6952,7 +6952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5540fed231e74292a0e9be3c5bbc8c81
+      - 9e467dc0da3a488fa7febc7960ef0c57
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6965,9 +6965,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a4ed087f-70dc-4de7-a92a-e93d61efaeb8
+      - req-3df399bb-2178-4d8a-b5f2-70a0e8a8faf0
       Date:
-      - Fri, 03 Aug 2018 19:39:23 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6976,7 +6976,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6991,7 +6991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7004,9 +7004,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9db7cbf7-5287-4f8c-b03d-6d5a1b22beac
+      - req-120c4d26-c41e-457c-be6b-ade3e9389cc6
       Date:
-      - Fri, 03 Aug 2018 19:39:24 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7015,7 +7015,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7030,7 +7030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d28efc6d74ed49b1bb2b87312f4d31a3
+      - 886f1fde8f83488597be3fad95c8cb04
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7043,9 +7043,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3e2e2974-82c9-4f84-bd40-9176d254bafb
+      - req-d497a84f-3c82-4b19-9d7f-5c214434c148
       Date:
-      - Fri, 03 Aug 2018 19:39:24 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7054,7 +7054,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7069,7 +7069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4784dbfb83cf40799a2556ab921b5cf1
+      - 154f676ec5da4c0da8039638bb2147fa
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7082,9 +7082,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c0b84630-2f4e-4f11-8e9a-bddf182e8de8
+      - req-698a31bc-cfe4-46c8-983d-cc7e7fd7f53b
       Date:
-      - Fri, 03 Aug 2018 19:39:24 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7093,7 +7093,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7111,15 +7111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:24 GMT
+      - Mon, 06 Aug 2018 16:53:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7bf00775-1c1c-4bfd-a481-73be692e79ab
+      - req-10c3fa80-f773-4542-958c-93278e3071d7
       Content-Length:
       - '7278'
       Connection:
@@ -7131,7 +7131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:24.510546Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:07.983736Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7210,10 +7210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sygLAkPRQmiLLnU6cKiymA"],
-        "issued_at": "2018-08-03T19:39:24.510606Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2x2sJPqnT2GhKKJ4L0QabA"],
+        "issued_at": "2018-08-06T16:53:07.983802Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7228,22 +7228,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-db2d937d-c8dd-47ac-bc63-dc6d2e687b11
+      - req-a9dd3364-99ba-46bd-bffe-a0167b256954
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-db2d937d-c8dd-47ac-bc63-dc6d2e687b11
+      - req-a9dd3364-99ba-46bd-bffe-a0167b256954
       Date:
-      - Fri, 03 Aug 2018 19:39:25 GMT
+      - Mon, 06 Aug 2018 16:53:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7253,7 +7253,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7271,15 +7271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:25 GMT
+      - Mon, 06 Aug 2018 16:53:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-691478b2-f9e5-4a73-9e7c-ce7059a48e3d
+      - req-9a0dea54-28bc-428f-9e3f-9d9453f4353e
       Content-Length:
       - '7278'
       Connection:
@@ -7291,7 +7291,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:25.687765Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:09.144330Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7370,10 +7370,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fRTqXGeiSSa1WaJHMS7w6g"],
-        "issued_at": "2018-08-03T19:39:25.687819Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RxKnFFoXST6xgSfQmskNpA"],
+        "issued_at": "2018-08-06T16:53:09.144394Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7388,22 +7388,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-30d4bd7e-3e35-4ed8-8d2b-64c4a4f38227
+      - req-5f99b9f8-6f9f-4f2c-af82-d146da142a9e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-30d4bd7e-3e35-4ed8-8d2b-64c4a4f38227
+      - req-5f99b9f8-6f9f-4f2c-af82-d146da142a9e
       Date:
-      - Fri, 03 Aug 2018 19:39:26 GMT
+      - Mon, 06 Aug 2018 16:53:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7413,7 +7413,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7431,15 +7431,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:26 GMT
+      - Mon, 06 Aug 2018 16:53:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7d84616-6611-4192-bd9e-d375be457804
+      - req-bdb2279f-74a5-45ee-9d68-055ed553c446
       Content-Length:
       - '7264'
       Connection:
@@ -7451,7 +7451,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:26.506937Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:10.138274Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7530,10 +7530,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FOunOfBJRzqNVsRq5QemJw"],
-        "issued_at": "2018-08-03T19:39:26.507011Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eSPzD5EJSXm8yNaWgz6ZPg"],
+        "issued_at": "2018-08-06T16:53:10.138335Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7548,22 +7548,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e62a285-b54d-4a92-86ca-29c141717e1b
+      - req-3ec23f8a-de59-432b-bc1e-164f2674fa67
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-2e62a285-b54d-4a92-86ca-29c141717e1b
+      - req-3ec23f8a-de59-432b-bc1e-164f2674fa67
       Date:
-      - Fri, 03 Aug 2018 19:39:27 GMT
+      - Mon, 06 Aug 2018 16:53:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7573,7 +7573,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7591,15 +7591,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:27 GMT
+      - Mon, 06 Aug 2018 16:53:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-58bff9db-64c6-4aa8-bb0d-9ccc5134ad60
+      - req-837a9be6-204b-4f32-93df-70312a52d396
       Content-Length:
       - '7278'
       Connection:
@@ -7611,7 +7611,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:27.613806Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:11.601170Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7690,10 +7690,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JIBdgORpQy6pFxYFZcWbjg"],
-        "issued_at": "2018-08-03T19:39:27.613960Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BX8VJcd3R3u1HgmeO12_6w"],
+        "issued_at": "2018-08-06T16:53:11.601264Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7708,22 +7708,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70079662-5f3d-42dd-906b-2c16d7fab4d9
+      - req-28bb3ccb-3750-41bb-9a19-6acca26ac7cd
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-70079662-5f3d-42dd-906b-2c16d7fab4d9
+      - req-28bb3ccb-3750-41bb-9a19-6acca26ac7cd
       Date:
-      - Fri, 03 Aug 2018 19:39:28 GMT
+      - Mon, 06 Aug 2018 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7733,7 +7733,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7748,22 +7748,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41aa7692-eb68-4afa-a6cb-488d1fe1a82e
+      - req-4a9d45a0-a7e5-4a92-a6c4-7ae050e9e886
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-41aa7692-eb68-4afa-a6cb-488d1fe1a82e
+      - req-4a9d45a0-a7e5-4a92-a6c4-7ae050e9e886
       Date:
-      - Fri, 03 Aug 2018 19:39:28 GMT
+      - Mon, 06 Aug 2018 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7773,7 +7773,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7791,15 +7791,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:29 GMT
+      - Mon, 06 Aug 2018 16:53:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6616dde-67e5-449c-9112-fc6c4f7cb208
+      - req-3b353f8c-825a-460a-b1b3-491fdbed20cb
       Content-Length:
       - '7265'
       Connection:
@@ -7811,7 +7811,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:29.332035Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:13.356387Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7890,10 +7890,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["alOQOtMxT76BMUI7Oc8dWA"],
-        "issued_at": "2018-08-03T19:39:29.332147Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SYTLohBGSmS82TyWiRzLsA"],
+        "issued_at": "2018-08-06T16:53:13.356467Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7908,22 +7908,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df85d2f8-7659-45ca-8cc5-6f54235718f4
+      - req-eede0dbf-af71-4d46-83b7-3902df976e29
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-df85d2f8-7659-45ca-8cc5-6f54235718f4
+      - req-eede0dbf-af71-4d46-83b7-3902df976e29
       Date:
-      - Fri, 03 Aug 2018 19:39:30 GMT
+      - Mon, 06 Aug 2018 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7933,7 +7933,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7951,15 +7951,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:30 GMT
+      - Mon, 06 Aug 2018 16:53:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5de192af-d771-408d-988e-158c9fb0a416
+      - req-d898bb8f-94bc-42aa-a067-a443bf0c208a
       Content-Length:
       - '7278'
       Connection:
@@ -7971,7 +7971,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:30.352975Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:14.390387Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8050,10 +8050,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k5738TB5S8-qhrCd-SxoHQ"],
-        "issued_at": "2018-08-03T19:39:30.353048Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8YSikr7gQxKCDs-jYUU8bg"],
+        "issued_at": "2018-08-06T16:53:14.390459Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8068,22 +8068,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe3c5c65-893f-4b51-b714-6f00141f473e
+      - req-cd6f7a95-9c48-4350-8081-63376fc7bc89
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-fe3c5c65-893f-4b51-b714-6f00141f473e
+      - req-cd6f7a95-9c48-4350-8081-63376fc7bc89
       Date:
-      - Fri, 03 Aug 2018 19:39:31 GMT
+      - Mon, 06 Aug 2018 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8093,7 +8093,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8111,15 +8111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:31 GMT
+      - Mon, 06 Aug 2018 16:53:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c6a88e044f1f4d25851e0290c1665b14
+      - 944acba135024d6f8eb679f2d946af56
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dcaa910f-5cb2-4a79-b7a7-7db4626df81c
+      - req-aaaeb321-19ee-43ca-b34e-ce8cd5a67d25
       Content-Length:
       - '7311'
       Connection:
@@ -8131,7 +8131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:31.527487Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:15.517537Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8210,10 +8210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A_rsudOfSNC2fBJeLIPyLg"],
-        "issued_at": "2018-08-03T19:39:31.527555Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tfw_PlAXTSOz5_pT8Rw9UQ"],
+        "issued_at": "2018-08-06T16:53:15.517608Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -8228,7 +8228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6a88e044f1f4d25851e0290c1665b14
+      - 944acba135024d6f8eb679f2d946af56
   response:
     status:
       code: 200
@@ -8239,13 +8239,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:39:31 GMT
+      - Mon, 06 Aug 2018 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8263,15 +8263,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:31 GMT
+      - Mon, 06 Aug 2018 16:53:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b8ed776d0d4f4bf5ac9ab3de4d70aa3a
+      - 3bf5dc7f7adb4ed289ad2f74458950c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ccba559-858e-41b9-a5d4-5eae6ed71beb
+      - req-7b9a48df-67da-422f-aa69-6765dcbae093
       Content-Length:
       - '7278'
       Connection:
@@ -8283,7 +8283,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:31.929612Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:15.936815Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8362,10 +8362,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qtnx_YgATpeH8rrXkURUMA"],
-        "issued_at": "2018-08-03T19:39:31.929693Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WkEuT58ZRISQvsdkbySrvw"],
+        "issued_at": "2018-08-06T16:53:15.936890Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8380,7 +8380,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8ed776d0d4f4bf5ac9ab3de4d70aa3a
+      - 3bf5dc7f7adb4ed289ad2f74458950c8
   response:
     status:
       code: 200
@@ -8391,16 +8391,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0765fb70-4afb-4aa7-b8f0-d1297052b68b
+      - req-ec24816d-0e85-4369-83e9-b1ef20ebd89b
       Date:
-      - Fri, 03 Aug 2018 19:39:32 GMT
+      - Mon, 06 Aug 2018 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8418,15 +8418,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:32 GMT
+      - Mon, 06 Aug 2018 16:53:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2fc6cc2a95214162a3a25516846bd8de
+      - 856aaaf296064fc6826f403b17c34f57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2e89529c-a9f0-4f26-bbe3-5deceeb51fc0
+      - req-bf36ca02-84c6-417a-8fbe-32ee41ccea84
       Content-Length:
       - '7278'
       Connection:
@@ -8438,7 +8438,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:32.459598Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:16.463642Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8517,10 +8517,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JrjURChbTBWtTqQ_p2Igew"],
-        "issued_at": "2018-08-03T19:39:32.459670Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eFbMPaMaT8yNa_On5n2B4A"],
+        "issued_at": "2018-08-06T16:53:16.463722Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8535,7 +8535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc6cc2a95214162a3a25516846bd8de
+      - 856aaaf296064fc6826f403b17c34f57
   response:
     status:
       code: 200
@@ -8546,16 +8546,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d204b3a7-4eb0-4f21-a899-5c2467d731de
+      - req-8809fdc0-46cb-49cc-85a9-a377fa4375a1
       Date:
-      - Fri, 03 Aug 2018 19:39:32 GMT
+      - Mon, 06 Aug 2018 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8573,15 +8573,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:32 GMT
+      - Mon, 06 Aug 2018 16:53:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6a686f7fdd364b72ad6feb5babb198d6
+      - c4eda03ea411482a988386f7fa45daf1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb09383c-dabc-49c9-8577-e0d2074a4b4b
+      - req-801c4cba-c25b-418f-b48e-19f8ff52a189
       Content-Length:
       - '7264'
       Connection:
@@ -8593,7 +8593,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:32.981316Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:17.037301Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8672,10 +8672,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NIePo70VSiCJGs8Vezyqnw"],
-        "issued_at": "2018-08-03T19:39:32.981397Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N-8s1jRBTJymuBILy16xdw"],
+        "issued_at": "2018-08-06T16:53:17.037368Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8690,7 +8690,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a686f7fdd364b72ad6feb5babb198d6
+      - c4eda03ea411482a988386f7fa45daf1
   response:
     status:
       code: 200
@@ -8701,16 +8701,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9b296a0d-b04e-4109-89c0-07036df8247a
+      - req-3ca79b87-8221-485b-a0f1-bf6eacd39a31
       Date:
-      - Fri, 03 Aug 2018 19:39:33 GMT
+      - Mon, 06 Aug 2018 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8728,15 +8728,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:33 GMT
+      - Mon, 06 Aug 2018 16:53:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0d99126316b24cec903e921445e8673e
+      - 44644d849b4d4d2cac4ac364d3df06c3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eb84472e-a37e-4056-a152-69a1b4fdab61
+      - req-9208b6ce-fb59-45db-b534-2e06f682a9bf
       Content-Length:
       - '7278'
       Connection:
@@ -8748,7 +8748,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:33.541971Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:17.910218Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8827,10 +8827,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XVWTV0qNQcG0uwMjKoaO4Q"],
-        "issued_at": "2018-08-03T19:39:33.542085Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Bpo2VCCwQ_ul8PvHIPXm4w"],
+        "issued_at": "2018-08-06T16:53:17.910294Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8845,7 +8845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d99126316b24cec903e921445e8673e
+      - 44644d849b4d4d2cac4ac364d3df06c3
   response:
     status:
       code: 200
@@ -8856,16 +8856,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a28c79f5-0695-411d-8972-024f1974912b
+      - req-0df3fbad-eeb4-4789-b7f9-7fd08a538cdf
       Date:
-      - Fri, 03 Aug 2018 19:39:33 GMT
+      - Mon, 06 Aug 2018 16:53:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8880,7 +8880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6a88e044f1f4d25851e0290c1665b14
+      - 944acba135024d6f8eb679f2d946af56
   response:
     status:
       code: 200
@@ -8891,16 +8891,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-415c1c1e-ef14-4cdb-97af-2bae83f85bde
+      - req-60459fe6-3050-4f54-91d7-d7ad51f3a655
       Date:
-      - Fri, 03 Aug 2018 19:39:33 GMT
+      - Mon, 06 Aug 2018 16:53:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8918,15 +8918,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:34 GMT
+      - Mon, 06 Aug 2018 16:53:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cda20115e11447b7a9bf816a64b8b8f8
+      - 8c8dcb1555054b539dec276bffc5d599
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5335a2d9-e2cb-4896-995e-cfe91b743ef5
+      - req-f33b1933-a9b7-4e49-ad03-9eea548af148
       Content-Length:
       - '7265'
       Connection:
@@ -8938,7 +8938,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:34.213043Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:18.740925Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9017,10 +9017,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cg3YRpwuSLG_XR0V1D2Y4A"],
-        "issued_at": "2018-08-03T19:39:34.213156Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ExPp6A_TRtSnjHEEFZZdsw"],
+        "issued_at": "2018-08-06T16:53:18.741067Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -9035,7 +9035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cda20115e11447b7a9bf816a64b8b8f8
+      - 8c8dcb1555054b539dec276bffc5d599
   response:
     status:
       code: 200
@@ -9046,16 +9046,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7d0896e8-4d23-46b6-a7f5-6145b45bba85
+      - req-a9686d41-bb2b-439b-94fa-c5ed514615e4
       Date:
-      - Fri, 03 Aug 2018 19:39:34 GMT
+      - Mon, 06 Aug 2018 16:53:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9073,15 +9073,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:34 GMT
+      - Mon, 06 Aug 2018 16:53:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cc6eece84106408e93ee62284eac7c06
+      - 6c8dd515ab104338a977e22706087edb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6131e818-790e-4570-b4bb-e29abbc61238
+      - req-aa13a418-3cbd-4bbb-be2d-9016824e4053
       Content-Length:
       - '7278'
       Connection:
@@ -9093,7 +9093,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:34.754792Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:19.272628Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9172,10 +9172,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YpCYA7YuTHyFsdFXuDvxgg"],
-        "issued_at": "2018-08-03T19:39:34.754883Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3GTvxPXBSFiMZa7ohptMwQ"],
+        "issued_at": "2018-08-06T16:53:19.272701Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -9190,7 +9190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc6eece84106408e93ee62284eac7c06
+      - 6c8dd515ab104338a977e22706087edb
   response:
     status:
       code: 200
@@ -9201,16 +9201,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-91b0f359-27d5-4a06-9f56-581b76df7913
+      - req-115c6566-632b-499e-ad3e-7bac12ff5366
       Date:
-      - Fri, 03 Aug 2018 19:39:35 GMT
+      - Mon, 06 Aug 2018 16:53:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9225,7 +9225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9238,9 +9238,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-306a29df-9d97-4f5d-a866-326cf88ffa83
+      - req-66963a89-53ed-4fb6-aff1-bb1036389319
       Date:
-      - Fri, 03 Aug 2018 19:39:35 GMT
+      - Mon, 06 Aug 2018 16:53:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9263,7 +9263,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9278,7 +9278,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9291,9 +9291,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-48c728d8-51c8-4863-82d3-2de149e28d2b
+      - req-e61d4241-00f0-4b63-8759-6b39686d70a8
       Date:
-      - Fri, 03 Aug 2018 19:39:35 GMT
+      - Mon, 06 Aug 2018 16:53:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9316,7 +9316,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9331,7 +9331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9344,9 +9344,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-985e3763-044a-4af2-93f3-7c1b1f5f9eec
+      - req-810db3fa-844f-42e0-ba82-d4c4d83d3598
       Date:
-      - Fri, 03 Aug 2018 19:39:35 GMT
+      - Mon, 06 Aug 2018 16:53:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9369,7 +9369,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9384,7 +9384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9397,9 +9397,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-c3b97bd9-2fee-4bde-aa09-3db9cf5caa2d
+      - req-0c652426-b08b-4afa-823e-bd3162580720
       Date:
-      - Fri, 03 Aug 2018 19:39:36 GMT
+      - Mon, 06 Aug 2018 16:53:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9422,7 +9422,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9437,7 +9437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9450,9 +9450,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-5e9118aa-a8f1-4ecb-bb5f-d36a75269f07
+      - req-de1c0b4b-9955-4159-a6bf-321e5078d15b
       Date:
-      - Fri, 03 Aug 2018 19:39:36 GMT
+      - Mon, 06 Aug 2018 16:53:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9475,7 +9475,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -9490,7 +9490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9503,15 +9503,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-42ce4e72-b6f3-4d0e-a712-cd9d6543225c
+      - req-605fc09d-a3ae-4d54-bcd6-5423db4f485e
       Date:
-      - Fri, 03 Aug 2018 19:39:37 GMT
+      - Mon, 06 Aug 2018 16:53:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9526,7 +9526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9539,9 +9539,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-b059f3f6-9e3d-4dbf-88ac-88302c94b38b
+      - req-6f5949c6-6a1e-4eb4-852d-9522b4c2fb01
       Date:
-      - Fri, 03 Aug 2018 19:39:37 GMT
+      - Mon, 06 Aug 2018 16:53:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9564,7 +9564,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9579,7 +9579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9592,15 +9592,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-106ac1b8-e2ce-4dd5-98e7-c51a889539e7
+      - req-0772ecdb-4e17-43c2-810b-d9e67989e056
       Date:
-      - Fri, 03 Aug 2018 19:39:37 GMT
+      - Mon, 06 Aug 2018 16:53:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9615,7 +9615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9628,9 +9628,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-88fbddb5-3a4f-4b63-85ed-b7001454abe4
+      - req-4ff9ba5a-ca3c-46fa-a966-b55a02fe8014
       Date:
-      - Fri, 03 Aug 2018 19:39:38 GMT
+      - Mon, 06 Aug 2018 16:53:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9653,7 +9653,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9668,7 +9668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9681,9 +9681,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-4f1b36ae-e895-413f-a2b4-88766e2249ac
+      - req-36a42bcf-1e4b-4694-8513-578da6557c09
       Date:
-      - Fri, 03 Aug 2018 19:39:39 GMT
+      - Mon, 06 Aug 2018 16:53:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9706,7 +9706,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9721,7 +9721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16d5a002bb344caeb79f36ea73dd72e8
+      - 63a39736873d48ae8dd8b976d9f2f7e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9734,9 +9734,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-efce9ea1-4c96-4f26-be7b-825267a9634f
+      - req-accecb2a-c48e-4bca-bf33-03c568874d57
       Date:
-      - Fri, 03 Aug 2018 19:39:39 GMT
+      - Mon, 06 Aug 2018 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9759,7 +9759,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9777,15 +9777,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:39 GMT
+      - Mon, 06 Aug 2018 16:53:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 99238ec500b6485a8fb9f1c3feb0bdfc
+      - ddf6f4cd6ee3443388bbd043547512f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ea89f823-0c88-461b-ac92-73f7d3a0528c
+      - req-64775336-f161-4853-bef8-715489df54a6
       Content-Length:
       - '7311'
       Connection:
@@ -9797,7 +9797,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:39.981716Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:23.337370Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9876,16 +9876,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bv_DW6kNSwCyRFt4tPsepQ"],
-        "issued_at": "2018-08-03T19:39:39.981776Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mx9QqLyySFetI5n63ImrIA"],
+        "issued_at": "2018-08-06T16:53:23.337441Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"99238ec500b6485a8fb9f1c3feb0bdfc"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"ddf6f4cd6ee3443388bbd043547512f9"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9897,15 +9897,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:40 GMT
+      - Mon, 06 Aug 2018 16:53:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 68dfd4e949c94fad9b7036be79bca661
+      - 80374c3c0e4f42f2813c8951ec146173
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8fc8b77f-f4f8-4989-8226-d87460ecb39c
+      - req-21d82ef2-5727-4a71-83bb-39e592e0c761
       Content-Length:
       - '7346'
       Connection:
@@ -9917,7 +9917,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:39.981716Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:23.337370Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9996,10 +9996,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jHF4ldAvRUqJjmv4wdoKjg",
-        "bv_DW6kNSwCyRFt4tPsepQ"], "issued_at": "2018-08-03T19:39:40.283805Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R4Ie6AC_QESRYJepFUZJGg",
+        "Mx9QqLyySFetI5n63ImrIA"], "issued_at": "2018-08-06T16:53:23.633744Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10017,15 +10017,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:40 GMT
+      - Mon, 06 Aug 2018 16:53:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6368f1ba476f4437881e8164141dec3a
+      - 22eb0446fb3b4e6bba0319cdd6a5993f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a16f8fa3-d0b6-4ef1-bca5-976ec663109e
+      - req-798c9837-733c-4d9b-b64f-764df25514f6
       Content-Length:
       - '7311'
       Connection:
@@ -10037,7 +10037,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:40.661920Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:24.017229Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10116,16 +10116,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_MhFOpo0RZafWfj6wqJv3w"],
-        "issued_at": "2018-08-03T19:39:40.661999Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wrs4VpDiTxKyajfvf3jiaw"],
+        "issued_at": "2018-08-06T16:53:24.017317Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"6368f1ba476f4437881e8164141dec3a"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"22eb0446fb3b4e6bba0319cdd6a5993f"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10137,15 +10137,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:40 GMT
+      - Mon, 06 Aug 2018 16:53:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 694684468ed649f7835e72f99f102cfa
+      - 418ff659447e4b21b06a8367c6495c4f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3f442963-3eae-4968-889a-bee15ea5832e
+      - req-fa490732-4fa2-4b03-805c-155a6bbaf52a
       Content-Length:
       - '7346'
       Connection:
@@ -10157,7 +10157,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:40.661920Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:24.017229Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10236,10 +10236,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t3d6ZhtyQ9eH0pEcL3IWMw",
-        "_MhFOpo0RZafWfj6wqJv3w"], "issued_at": "2018-08-03T19:39:40.987407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t_03zFbFRVesF8vgF6o3Xw",
+        "wrs4VpDiTxKyajfvf3jiaw"], "issued_at": "2018-08-06T16:53:24.355087Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -10254,7 +10254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eea81839f2924215a946e1ff289ddd5e
+      - 41d5bf394ab4414ca3ed0c799d4f0837
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10267,14 +10267,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-87e0d9fd-5596-43ff-b970-b9dc146d98d7
+      - req-ea2d1bbd-e1f6-4a72-ae53-fa2f20ea52f0
       Date:
-      - Fri, 03 Aug 2018 19:39:41 GMT
+      - Mon, 06 Aug 2018 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -10289,27 +10289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3007ab3-9d59-4e1b-9abf-8caa38338ab3
+      - req-f460a4fc-9ee3-4197-8094-2f287e91bd44
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d3007ab3-9d59-4e1b-9abf-8caa38338ab3
+      - req-f460a4fc-9ee3-4197-8094-2f287e91bd44
       Date:
-      - Fri, 03 Aug 2018 19:39:41 GMT
+      - Mon, 06 Aug 2018 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -10324,27 +10324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18581706-eaec-4849-9c72-49fdcaf10682
+      - req-70244c3b-9150-4bcd-b9ae-45f87b60b8b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-18581706-eaec-4849-9c72-49fdcaf10682
+      - req-70244c3b-9150-4bcd-b9ae-45f87b60b8b7
       Date:
-      - Fri, 03 Aug 2018 19:39:41 GMT
+      - Mon, 06 Aug 2018 16:53:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -10359,22 +10359,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ec363328-8004-492b-96a3-42e29d1cd566
+      - req-a1eb93bb-16a1-41d5-be99-08f863608201
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-ec363328-8004-492b-96a3-42e29d1cd566
+      - req-a1eb93bb-16a1-41d5-be99-08f863608201
       Date:
-      - Fri, 03 Aug 2018 19:39:41 GMT
+      - Mon, 06 Aug 2018 16:53:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10407,7 +10407,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -10422,22 +10422,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d49c05d1-0472-4429-a531-9ace47096d22
+      - req-54778cec-adce-4d3a-bded-70160a95377e
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-d49c05d1-0472-4429-a531-9ace47096d22
+      - req-54778cec-adce-4d3a-bded-70160a95377e
       Date:
-      - Fri, 03 Aug 2018 19:39:42 GMT
+      - Mon, 06 Aug 2018 16:53:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -10454,7 +10454,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -10469,27 +10469,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e156c3e0-136e-4f65-b236-29065c82d764
+      - req-23dfb1da-34ca-4bd8-b41d-17ac815d9f07
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e156c3e0-136e-4f65-b236-29065c82d764
+      - req-23dfb1da-34ca-4bd8-b41d-17ac815d9f07
       Date:
-      - Fri, 03 Aug 2018 19:39:42 GMT
+      - Mon, 06 Aug 2018 16:53:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -10504,27 +10504,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5c52872e-e42b-4c24-84e9-340c0a75856c
+      - req-e7b88bd3-f5bc-445e-a1ac-f4d46417dbd7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5c52872e-e42b-4c24-84e9-340c0a75856c
+      - req-e7b88bd3-f5bc-445e-a1ac-f4d46417dbd7
       Date:
-      - Fri, 03 Aug 2018 19:39:42 GMT
+      - Mon, 06 Aug 2018 16:53:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -10539,27 +10539,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00fa211b-c2b4-40f9-a76a-d46da71aa7e5
+      - req-aada8155-1823-4017-b80a-01143734b873
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-00fa211b-c2b4-40f9-a76a-d46da71aa7e5
+      - req-aada8155-1823-4017-b80a-01143734b873
       Date:
-      - Fri, 03 Aug 2018 19:39:43 GMT
+      - Mon, 06 Aug 2018 16:53:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -10574,27 +10574,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9b8fb82-319e-4336-b3fb-6d2c1c485a61
+      - req-4adf079e-5348-4112-ab7e-811ab639392e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b9b8fb82-319e-4336-b3fb-6d2c1c485a61
+      - req-4adf079e-5348-4112-ab7e-811ab639392e
       Date:
-      - Fri, 03 Aug 2018 19:39:43 GMT
+      - Mon, 06 Aug 2018 16:53:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -10609,27 +10609,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f89ff058-87e2-4ce5-8447-612a5edcef8f
+      - req-2c585295-f594-4faf-8afe-d7c962c61720
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f89ff058-87e2-4ce5-8447-612a5edcef8f
+      - req-2c585295-f594-4faf-8afe-d7c962c61720
       Date:
-      - Fri, 03 Aug 2018 19:39:43 GMT
+      - Mon, 06 Aug 2018 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -10644,27 +10644,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a7f72a93-14a2-46af-b1cd-44f4f79cf74c
+      - req-ece34bab-c6d4-402d-adcd-84be20389d8c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a7f72a93-14a2-46af-b1cd-44f4f79cf74c
+      - req-ece34bab-c6d4-402d-adcd-84be20389d8c
       Date:
-      - Fri, 03 Aug 2018 19:39:43 GMT
+      - Mon, 06 Aug 2018 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -10679,27 +10679,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7afc955-dd12-4cd3-b8b4-39235e7a8c4a
+      - req-dc0eabed-4521-4b47-b96d-a0e4059d6246
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e7afc955-dd12-4cd3-b8b4-39235e7a8c4a
+      - req-dc0eabed-4521-4b47-b96d-a0e4059d6246
       Date:
-      - Fri, 03 Aug 2018 19:39:43 GMT
+      - Mon, 06 Aug 2018 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -10714,27 +10714,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-878a3068-5930-48f2-ad1b-b799d5e38a30
+      - req-ca14178c-5781-4418-a26f-e6cbc2c5b680
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-878a3068-5930-48f2-ad1b-b799d5e38a30
+      - req-ca14178c-5781-4418-a26f-e6cbc2c5b680
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -10749,22 +10749,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b4fd8e28-dbff-4430-8674-fb4c6b2def1c
+      - req-e7ebc738-7027-45b9-ac75-3755c26e3b72
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b4fd8e28-dbff-4430-8674-fb4c6b2def1c
+      - req-e7ebc738-7027-45b9-ac75-3755c26e3b72
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10779,7 +10779,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -10794,22 +10794,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb1860f3-29ea-4f9b-b93d-285fa6809faa
+      - req-85c94e92-c0e0-4720-95ae-82043e085dfd
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-bb1860f3-29ea-4f9b-b93d-285fa6809faa
+      - req-85c94e92-c0e0-4720-95ae-82043e085dfd
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10824,7 +10824,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -10839,27 +10839,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9683aa1a-c8d0-42f5-905e-d8c3ced5a33e
+      - req-83172e17-2581-4c7f-90b9-0bb4fb361272
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9683aa1a-c8d0-42f5-905e-d8c3ced5a33e
+      - req-83172e17-2581-4c7f-90b9-0bb4fb361272
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -10874,27 +10874,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b184db3d-8966-4296-becb-991db1e6d860
+      - req-46e72971-34fd-4558-b518-6942ef1c88f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b184db3d-8966-4296-becb-991db1e6d860
+      - req-46e72971-34fd-4558-b518-6942ef1c88f0
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -10909,27 +10909,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0ed2ce1-4d1c-4d09-9ddc-86b0dec8c9cf
+      - req-e00337cd-8161-4009-a6c9-ff336739ee92
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a0ed2ce1-4d1c-4d09-9ddc-86b0dec8c9cf
+      - req-e00337cd-8161-4009-a6c9-ff336739ee92
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -10944,27 +10944,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94b2cd4e-ee2b-453f-80ef-2f39109c9e87
+      - req-bbbe0319-6250-4c18-a5f6-729bf5aac54f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-94b2cd4e-ee2b-453f-80ef-2f39109c9e87
+      - req-bbbe0319-6250-4c18-a5f6-729bf5aac54f
       Date:
-      - Fri, 03 Aug 2018 19:39:44 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10979,27 +10979,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99ac4f83-6f3d-4bba-ba84-89f193679d5d
+      - req-e243509b-d274-4554-9cf6-cedd5728e0d6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-99ac4f83-6f3d-4bba-ba84-89f193679d5d
+      - req-e243509b-d274-4554-9cf6-cedd5728e0d6
       Date:
-      - Fri, 03 Aug 2018 19:39:45 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -11014,27 +11014,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b7c12004-6f4b-4526-aa35-7adea52aba7c
+      - req-095d432d-6147-409f-b96d-c0bb622befc4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b7c12004-6f4b-4526-aa35-7adea52aba7c
+      - req-095d432d-6147-409f-b96d-c0bb622befc4
       Date:
-      - Fri, 03 Aug 2018 19:39:45 GMT
+      - Mon, 06 Aug 2018 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11049,27 +11049,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-870a55fd-84d8-4a37-bd82-a19979f06746
+      - req-235015d2-89b0-4bcb-a08b-ffd739a76044
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-870a55fd-84d8-4a37-bd82-a19979f06746
+      - req-235015d2-89b0-4bcb-a08b-ffd739a76044
       Date:
-      - Fri, 03 Aug 2018 19:39:45 GMT
+      - Mon, 06 Aug 2018 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -11084,27 +11084,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9a5f7f7-c675-4136-b4ef-5c4766172d3d
+      - req-dfea7aca-ddb0-4364-adcf-5d50bd850a32
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d9a5f7f7-c675-4136-b4ef-5c4766172d3d
+      - req-dfea7aca-ddb0-4364-adcf-5d50bd850a32
       Date:
-      - Fri, 03 Aug 2018 19:39:45 GMT
+      - Mon, 06 Aug 2018 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11119,27 +11119,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d662485eff7c47fd9358b7607d893fc4
+      - cad9e91e30e0410eb1ddce63016d3d62
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cfef3cd4-8350-4634-8464-9046878b3ab1
+      - req-40dc9510-d12d-4d40-9e42-d0ae0b4346f6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cfef3cd4-8350-4634-8464-9046878b3ab1
+      - req-40dc9510-d12d-4d40-9e42-d0ae0b4346f6
       Date:
-      - Fri, 03 Aug 2018 19:39:45 GMT
+      - Mon, 06 Aug 2018 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11154,27 +11154,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 234e37b94f404f0094b25b8abad8e729
+      - 7dd441518e8c45ea87e7df57a6d73c32
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c323848f-9df5-437b-808e-9e389150f67c
+      - req-7607549d-fbc1-42f6-bb0f-560d12e082c1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c323848f-9df5-437b-808e-9e389150f67c
+      - req-7607549d-fbc1-42f6-bb0f-560d12e082c1
       Date:
-      - Fri, 03 Aug 2018 19:39:46 GMT
+      - Mon, 06 Aug 2018 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11189,22 +11189,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7be87d24-d913-4ab3-b3ac-14ba450045fd
+      - req-6a1c926c-5e8e-4209-873d-62e85947a834
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-7be87d24-d913-4ab3-b3ac-14ba450045fd
+      - req-6a1c926c-5e8e-4209-873d-62e85947a834
       Date:
-      - Fri, 03 Aug 2018 19:39:46 GMT
+      - Mon, 06 Aug 2018 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11237,7 +11237,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11252,22 +11252,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1366fe1f-7bdd-4072-8ea5-8af376191afa
+      - req-cf9054a7-b899-4d65-8b61-cc67208ec8c2
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-1366fe1f-7bdd-4072-8ea5-8af376191afa
+      - req-cf9054a7-b899-4d65-8b61-cc67208ec8c2
       Date:
-      - Fri, 03 Aug 2018 19:39:46 GMT
+      - Mon, 06 Aug 2018 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11308,7 +11308,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11323,22 +11323,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4ede1b0-f5c3-4c9e-8d24-c89323293d5b
+      - req-7b7a3207-75c5-465d-a86a-e1ea5c7045b2
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a4ede1b0-f5c3-4c9e-8d24-c89323293d5b
+      - req-7b7a3207-75c5-465d-a86a-e1ea5c7045b2
       Date:
-      - Fri, 03 Aug 2018 19:39:47 GMT
+      - Mon, 06 Aug 2018 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11372,7 +11372,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11387,27 +11387,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3185bf3deef4d1a81bcf8112448b047
+      - 2cf5885fd52946b8a6a3e357e027043a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eac76be5-98da-498d-8773-2cfb474e1cde
+      - req-fda425c5-ebfe-49ac-83d7-bf1a4ca6ce2a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-eac76be5-98da-498d-8773-2cfb474e1cde
+      - req-fda425c5-ebfe-49ac-83d7-bf1a4ca6ce2a
       Date:
-      - Fri, 03 Aug 2018 19:39:47 GMT
+      - Mon, 06 Aug 2018 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11422,27 +11422,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea5daaa9d571468b987f347a1850758e
+      - e25e243b18bf4886951279e452918e9f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-34cf1855-d58d-4e73-ac83-adfb99add261
+      - req-2ab83494-2052-4cd4-8eb9-21a0e22b7ed7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-34cf1855-d58d-4e73-ac83-adfb99add261
+      - req-2ab83494-2052-4cd4-8eb9-21a0e22b7ed7
       Date:
-      - Fri, 03 Aug 2018 19:39:47 GMT
+      - Mon, 06 Aug 2018 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11457,27 +11457,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f7fcf4ea89e4d3297f2303c18319175
+      - 1fdc621e6d184be6865cc4e81fd54f43
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38c18474-78c4-4834-a39f-a1b1ffbce577
+      - req-7e39ced8-aed2-492d-ad8e-028cde964a49
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-38c18474-78c4-4834-a39f-a1b1ffbce577
+      - req-7e39ced8-aed2-492d-ad8e-028cde964a49
       Date:
-      - Fri, 03 Aug 2018 19:39:47 GMT
+      - Mon, 06 Aug 2018 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11492,27 +11492,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 468707da97f2459bbf217e5126f80a1b
+      - 5c7a3237e1c14de4af3ae8fc4589b3b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73fd82af-1392-410c-8127-1ce0a467d8f5
+      - req-3643321d-b110-41cd-b6ee-e18d6d24eea3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-73fd82af-1392-410c-8127-1ce0a467d8f5
+      - req-3643321d-b110-41cd-b6ee-e18d6d24eea3
       Date:
-      - Fri, 03 Aug 2018 19:39:47 GMT
+      - Mon, 06 Aug 2018 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11527,27 +11527,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2af72c7aca6461aa2f55b5baf655805
+      - 4fb8facf445c40bb9793fd60e8fdf6fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e50cd89-791b-4576-aa96-37da26b4fa6d
+      - req-ebe7f6a3-42b7-4b82-8099-ce2a859b0e44
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0e50cd89-791b-4576-aa96-37da26b4fa6d
+      - req-ebe7f6a3-42b7-4b82-8099-ce2a859b0e44
       Date:
-      - Fri, 03 Aug 2018 19:39:48 GMT
+      - Mon, 06 Aug 2018 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11565,15 +11565,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:49 GMT
+      - Mon, 06 Aug 2018 16:53:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d79b768430e140acbdb2f8bb4884289a
+      - a4265d4ff8fa41a38ed67fb958b17429
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6ef4cb8-c165-48c8-ad74-c248ba8b7fb5
+      - req-5ee158d6-2915-4ad3-95db-e087538c69d4
       Content-Length:
       - '7311'
       Connection:
@@ -11585,7 +11585,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:49.478232Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:34.472531Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11664,10 +11664,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WsD6MQbGRQGF_jkfxLBnYw"],
-        "issued_at": "2018-08-03T19:39:49.478295Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a8wq06bPRTKeqNdudl0yAQ"],
+        "issued_at": "2018-08-06T16:53:34.472613Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11685,15 +11685,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:49 GMT
+      - Mon, 06 Aug 2018 16:53:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9358e4e5-e57d-49e7-896b-16e8378fc5ff
+      - req-0d79d445-4f7a-43af-9d20-dfc29dd497d4
       Content-Length:
       - '7311'
       Connection:
@@ -11705,7 +11705,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:49.826788Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:34.897449Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11784,10 +11784,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X7viNoAYTkiAm97qgvvaGw"],
-        "issued_at": "2018-08-03T19:39:49.826873Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tzC7OKoHS8yR_Fvjd2Jnnw"],
+        "issued_at": "2018-08-06T16:53:34.897515Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -11802,7 +11802,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -11813,52 +11813,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-6a8f85d1-9c11-420f-b43f-bb9750bfd0f0
+      - req-b69f5813-338f-4c49-bcfe-418c3286c059
       Date:
-      - Fri, 03 Aug 2018 19:39:50 GMT
+      - Mon, 06 Aug 2018 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "c2ab9441-dd1c-4acc-a3a6-753f1a582291"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        59}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        13}, {"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -11868,24 +11843,49 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11903,15 +11903,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:50 GMT
+      - Mon, 06 Aug 2018 16:53:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b54889659c084ff98418770b9deba1a6
+      - 9b164379471c4e6e8ea10c49613a2299
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-973e711f-85ce-4c5a-b2e2-bf2a24e0c5f0
+      - req-a58464c1-b98f-4ace-9e8d-26fbfb307289
       Content-Length:
       - '7311'
       Connection:
@@ -11923,7 +11923,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:39:50.417566Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:35.498370Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12002,10 +12002,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1Z3GWkofSwOxRcWmdf8MCw"],
-        "issued_at": "2018-08-03T19:39:50.417642Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U1g4vmWBSMGuUp5HFL4WAg"],
+        "issued_at": "2018-08-06T16:53:35.498444Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12023,15 +12023,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:50 GMT
+      - Mon, 06 Aug 2018 16:53:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc9b2c7cb8d440f597609da8e3b82469
+      - b9bd7d5ee90e4ac68b46bc681b143967
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dfc5e0b1-c33d-4eaa-914d-a629c6b5b376
+      - req-13645191-275c-4515-9595-3eb80b0d7bdf
       Content-Length:
       - '297'
       Connection:
@@ -12040,12 +12040,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:39:50.653810Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:53:35.740765Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tyylztpyRQqVYMTphAUPeA"],
-        "issued_at": "2018-08-03T19:39:50.653870Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cSl0b4HJQ1y8KWpsmGDgWw"],
+        "issued_at": "2018-08-06T16:53:35.740835Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -12060,20 +12060,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9b2c7cb8d440f597609da8e3b82469
+      - b9bd7d5ee90e4ac68b46bc681b143967
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:50 GMT
+      - Mon, 06 Aug 2018 16:53:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d33f1b60-c0fb-4ddb-875d-a08ef4c09c68
+      - req-4f158242-71a4-415c-9f48-a65963d19bf9
       Content-Length:
       - '2457'
       Connection:
@@ -12106,13 +12106,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"bc9b2c7cb8d440f597609da8e3b82469"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"b9bd7d5ee90e4ac68b46bc681b143967"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12124,15 +12124,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:51 GMT
+      - Mon, 06 Aug 2018 16:53:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 29cac1530b744df4b118082695f7aaac
+      - 9e511290876b49bb9f16e5051bac399a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0e3bf53a-0927-4abb-a808-3f789c005632
+      - req-f452cd37-a923-41f4-b056-d0096d7c2478
       Content-Length:
       - '7313'
       Connection:
@@ -12144,7 +12144,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:50.653810Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:35.740765Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12223,10 +12223,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GR2gJBJnQLG6GHDMTujFMw",
-        "tyylztpyRQqVYMTphAUPeA"], "issued_at": "2018-08-03T19:39:51.252547Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqyNNZZ1Q6SDthq7x2SzUw",
+        "cSl0b4HJQ1y8KWpsmGDgWw"], "issued_at": "2018-08-06T16:53:36.180678Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12241,20 +12241,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 29cac1530b744df4b118082695f7aaac
+      - 9e511290876b49bb9f16e5051bac399a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:51 GMT
+      - Mon, 06 Aug 2018 16:53:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ccb7d9fd-1ae2-4053-b628-05ffed818d97
+      - req-cdbe699e-7450-4bc3-a36e-22083099720b
       Content-Length:
       - '2179'
       Connection:
@@ -12287,7 +12287,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12305,15 +12305,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:51 GMT
+      - Mon, 06 Aug 2018 16:53:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f1afbe01710f453c93b779f76b1d76db
+      - ebb4b1a3f3a54865ba0bf18f9de9f288
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1e5e6f5a-a33a-43ec-98ab-d23ce141e027
+      - req-5eae81df-5976-4114-97ed-f90811f8b227
       Content-Length:
       - '7278'
       Connection:
@@ -12325,7 +12325,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:51.769716Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:36.791223Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12404,10 +12404,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mLqOA1gFS6ymI5Ez2VtVpA"],
-        "issued_at": "2018-08-03T19:39:51.769793Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y_DUM1pBT4W6qFuRHwWuKQ"],
+        "issued_at": "2018-08-06T16:53:36.791315Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12425,15 +12425,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:51 GMT
+      - Mon, 06 Aug 2018 16:53:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cdf2cf45fcd04060b8fccc060848ae68
+      - 24cbe1af6ed24ba586c76ece59171aa1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-52140f9e-6e01-4e72-8ed0-b5ba74497b23
+      - req-6a5de8e9-1eb1-40e3-80bb-06df8173a811
       Content-Length:
       - '7278'
       Connection:
@@ -12445,7 +12445,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:52.098062Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:37.143963Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12524,10 +12524,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VEdZPUAlR_2likKJklr8Eg"],
-        "issued_at": "2018-08-03T19:39:52.098165Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MIxEJPSUSTudgTeKuzX5BA"],
+        "issued_at": "2018-08-06T16:53:37.144056Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12545,15 +12545,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:52 GMT
+      - Mon, 06 Aug 2018 16:53:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c3e0a9a488147868ef2e9865b67008d
+      - e5a4d0e4c725476fa6628ff19253b16a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a3fc534f-7f60-4877-a4dc-5119cd3dc0bc
+      - req-38154866-6cda-4ea4-9a0b-dd64265318ab
       Content-Length:
       - '7264'
       Connection:
@@ -12565,7 +12565,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:52.433806Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:37.476755Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12644,10 +12644,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LQUd0QD-TS-r9o-4uJrFVA"],
-        "issued_at": "2018-08-03T19:39:52.433866Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NReBAP8bTLWkXP4Eguqe7A"],
+        "issued_at": "2018-08-06T16:53:37.476836Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12665,15 +12665,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:52 GMT
+      - Mon, 06 Aug 2018 16:53:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5bb3eccf9cc541729d4af66892e10f75
+      - b9857e11c44948269352154d644f67a4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9935bb3e-afc4-48b0-b975-58f388815334
+      - req-68c35496-547b-49c3-a4a3-f91cac551db7
       Content-Length:
       - '7278'
       Connection:
@@ -12685,7 +12685,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:52.764942Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:37.810402Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12764,10 +12764,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dvZDYx4qRJK96ZHq_FkLLA"],
-        "issued_at": "2018-08-03T19:39:52.765014Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tBSAKnkkQUSemBMgGM9Q5w"],
+        "issued_at": "2018-08-06T16:53:37.810469Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12785,15 +12785,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:52 GMT
+      - Mon, 06 Aug 2018 16:53:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 350007b78ec6452885d43c46eb4a17a3
+      - 6a639a32d4534d8787c3c3ca755648f8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-05838d90-0a9b-47b4-a17a-439e3b9679ef
+      - req-580cdb1b-ac67-44b2-bdc9-a03419a346e5
       Content-Length:
       - '7265'
       Connection:
@@ -12805,7 +12805,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:53.249483Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:38.137649Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12884,10 +12884,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4CAQ8zxUTVqIPFCa0xuU_g"],
-        "issued_at": "2018-08-03T19:39:53.249591Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kjJBcw5uQn2APaAVsV9x6Q"],
+        "issued_at": "2018-08-06T16:53:38.137715Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12905,15 +12905,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:53 GMT
+      - Mon, 06 Aug 2018 16:53:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d6a09b80496e472c9a1414b90886305c
+      - 6d486a5387464d6fb9d5796321f0c047
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c1089d9-e773-4620-b39e-99550667aa69
+      - req-53aaecc7-b08d-4153-84ff-3d8242ab5ac5
       Content-Length:
       - '7278'
       Connection:
@@ -12925,7 +12925,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:53.616018Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:38.730044Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13004,10 +13004,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["i6aqVliUTmKi3Z2w5tbUwg"],
-        "issued_at": "2018-08-03T19:39:53.616095Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PDLZyzFuR0KY8IUkVjpCTQ"],
+        "issued_at": "2018-08-06T16:53:38.730240Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13025,15 +13025,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:53 GMT
+      - Mon, 06 Aug 2018 16:53:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 91d4336b4ced4069870759a04b369742
+      - 33dab8c200b54407bbd46227401769d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8dc5062c-0b5e-45c5-bdb9-a542ed8a1254
+      - req-282184e6-715d-430e-a407-55676814ef6e
       Content-Length:
       - '7278'
       Connection:
@@ -13045,7 +13045,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:53.942848Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:39.179164Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13124,10 +13124,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5ESjX7BtRyu3gN_PLeA7jw"],
-        "issued_at": "2018-08-03T19:39:53.942911Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["De-KjAeeRtKcgW47cZDPdQ"],
+        "issued_at": "2018-08-06T16:53:39.179235Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -13142,7 +13142,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91d4336b4ced4069870759a04b369742
+      - 33dab8c200b54407bbd46227401769d8
   response:
     status:
       code: 200
@@ -13153,14 +13153,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7c5c53f4-afcb-48bf-8570-7d0a5621f9c0
+      - req-82e21235-d759-41be-90ab-9353d0343a64
       Date:
-      - Fri, 03 Aug 2018 19:39:54 GMT
+      - Mon, 06 Aug 2018 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13178,15 +13178,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:54 GMT
+      - Mon, 06 Aug 2018 16:53:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2594d2bdc54403e92b759659a0fbbd3
+      - e6b64a053a024d619ccece2c9da0d0dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c8472118-acc1-4a1b-9aa2-666aba029677
+      - req-6d363381-87d7-442e-97d3-8df9d69bb97a
       Content-Length:
       - '7278'
       Connection:
@@ -13198,7 +13198,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:54.483573Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:39.727279Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13277,10 +13277,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L3ptiJUdSH2HvHbbdwzzIA"],
-        "issued_at": "2018-08-03T19:39:54.483642Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mRlR9jfaSRalHZlJE5vR9Q"],
+        "issued_at": "2018-08-06T16:53:39.727359Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -13295,7 +13295,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2594d2bdc54403e92b759659a0fbbd3
+      - e6b64a053a024d619ccece2c9da0d0dc
   response:
     status:
       code: 200
@@ -13306,14 +13306,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0f0fab1a-5905-4a32-bdba-590e524bf49f
+      - req-03c4d788-2b66-48a9-9b59-ffbf5b86c8cb
       Date:
-      - Fri, 03 Aug 2018 19:39:54 GMT
+      - Mon, 06 Aug 2018 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13331,15 +13331,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:55 GMT
+      - Mon, 06 Aug 2018 16:53:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d95f731c-2d0d-4943-ab62-1cabe4cdc57f
+      - req-ad4e7ddf-b2e2-4273-a25c-0288693b7c81
       Content-Length:
       - '7264'
       Connection:
@@ -13351,7 +13351,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:55.951466Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:40.301887Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13430,10 +13430,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vg235VjwS4-l_wfkCr2XRQ"],
-        "issued_at": "2018-08-03T19:39:55.951550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MVG0IoOdTASJ01HT3lZGRA"],
+        "issued_at": "2018-08-06T16:53:40.301978Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -13448,7 +13448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -13459,9 +13459,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-bfbaff6b-5fb7-42a0-b8bb-bdb4df7bcf90
+      - req-c80c4823-47c7-4a14-8108-0c46aca5798b
       Date:
-      - Fri, 03 Aug 2018 19:39:56 GMT
+      - Mon, 06 Aug 2018 16:53:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -13495,7 +13495,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -13510,7 +13510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -13521,14 +13521,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-22019919-fa7b-487e-a84f-316befde6767
+      - req-bbc42238-2dea-42fe-ab54-f04fb91fe2b6
       Date:
-      - Fri, 03 Aug 2018 19:39:56 GMT
+      - Mon, 06 Aug 2018 16:53:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13546,15 +13546,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:56 GMT
+      - Mon, 06 Aug 2018 16:53:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e16cef727384615ae0b5451c2c59b83
+      - 8bd5d504e9034f0eb109c5fab8f3ce32
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-715f7db9-0788-4b52-a016-f9730a6e3b9c
+      - req-81e9b4b6-bfa4-4290-9171-cf839de60fbd
       Content-Length:
       - '7278'
       Connection:
@@ -13566,7 +13566,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:56.810515Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:41.167324Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13645,10 +13645,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqjrTcs2RI2rrgVhUY3PRg"],
-        "issued_at": "2018-08-03T19:39:56.810578Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cX7TflGhRBuDNNeG4bF2CQ"],
+        "issued_at": "2018-08-06T16:53:41.167415Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -13663,7 +13663,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e16cef727384615ae0b5451c2c59b83
+      - 8bd5d504e9034f0eb109c5fab8f3ce32
   response:
     status:
       code: 200
@@ -13674,14 +13674,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b10f36b7-1c48-427d-b76e-f4d3f3154632
+      - req-c1c2390c-1f96-4e42-99c5-3c46ac7791bb
       Date:
-      - Fri, 03 Aug 2018 19:39:57 GMT
+      - Mon, 06 Aug 2018 16:53:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -13696,7 +13696,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b54889659c084ff98418770b9deba1a6
+      - 9b164379471c4e6e8ea10c49613a2299
   response:
     status:
       code: 200
@@ -13707,14 +13707,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f0f392f4-3cc1-44da-9133-741d85240477
+      - req-79caa8dc-3c87-4df8-8b09-55e3cfe58e92
       Date:
-      - Fri, 03 Aug 2018 19:39:57 GMT
+      - Mon, 06 Aug 2018 16:53:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13732,15 +13732,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:57 GMT
+      - Mon, 06 Aug 2018 16:53:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43d1b8736bdf4aa59b918e29eb8b048a
+      - f46269aa72b04455a30e43f88e25d5f7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3810694c-53c2-4d42-b410-6ddd994eb627
+      - req-9dfa8579-78cb-4c7b-ba35-be01a296122d
       Content-Length:
       - '7265'
       Connection:
@@ -13752,7 +13752,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:57.673595Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:41.930798Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13831,10 +13831,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1A_4MEn7ROORLmFM4hYO3A"],
-        "issued_at": "2018-08-03T19:39:57.673658Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HT0aULaaRKOf0scwOsDbQA"],
+        "issued_at": "2018-08-06T16:53:41.930861Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -13849,7 +13849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43d1b8736bdf4aa59b918e29eb8b048a
+      - f46269aa72b04455a30e43f88e25d5f7
   response:
     status:
       code: 200
@@ -13860,14 +13860,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1404d46d-c00c-4bad-a1cc-82ac4bf28012
+      - req-3d73b69b-3cbe-40ae-83cb-1859b63d36f2
       Date:
-      - Fri, 03 Aug 2018 19:39:57 GMT
+      - Mon, 06 Aug 2018 16:53:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13885,15 +13885,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:39:58 GMT
+      - Mon, 06 Aug 2018 16:53:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1b8674eea2dc42858fe61f9fb69822a8
+      - 0d268a0616384971bf8123b25cd14c9c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7881a7aa-edcc-42f6-ba79-c67e998817fa
+      - req-d567f618-e529-42bc-ac9c-786f356da3a8
       Content-Length:
       - '7278'
       Connection:
@@ -13905,7 +13905,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:39:58.214282Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:42.511300Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13984,10 +13984,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CYHJ1zugRM-Au1LV9Wp0qA"],
-        "issued_at": "2018-08-03T19:39:58.214348Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F3obmZLgROC2bG_hLofx-g"],
+        "issued_at": "2018-08-06T16:53:42.511382Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -14002,7 +14002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b8674eea2dc42858fe61f9fb69822a8
+      - 0d268a0616384971bf8123b25cd14c9c
   response:
     status:
       code: 200
@@ -14013,14 +14013,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b8484d65-9060-4264-970c-70120c839811
+      - req-5698d64d-4fb7-4618-9e5d-cdaa781be587
       Date:
-      - Fri, 03 Aug 2018 19:39:58 GMT
+      - Mon, 06 Aug 2018 16:53:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -14035,7 +14035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14046,9 +14046,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-eca71542-91d4-4b7b-a36b-0f24838489c5
+      - req-bf07c60b-6fdd-4ae9-8afb-0b64a41e83d1
       Date:
-      - Fri, 03 Aug 2018 19:39:59 GMT
+      - Mon, 06 Aug 2018 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14075,7 +14075,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:39:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -14090,7 +14090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14101,9 +14101,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d4825ab6-9b33-4ed0-84e9-54d008a4e46d
+      - req-2b28b6d3-0086-4abc-a3ff-678e2d920b59
       Date:
-      - Fri, 03 Aug 2018 19:40:00 GMT
+      - Mon, 06 Aug 2018 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14130,7 +14130,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -14145,7 +14145,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14156,9 +14156,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e30f7909-b38c-4607-b890-b0cc6dc29ea1
+      - req-49c8d009-ce5a-4994-89c8-ca189341c92d
       Date:
-      - Fri, 03 Aug 2018 19:40:01 GMT
+      - Mon, 06 Aug 2018 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14185,7 +14185,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -14200,7 +14200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14211,9 +14211,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d27a5275-38a0-429a-b98a-758e187bae4d
+      - req-a95ab519-cbad-44a9-96dd-5e1ada1bc48a
       Date:
-      - Fri, 03 Aug 2018 19:40:01 GMT
+      - Mon, 06 Aug 2018 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14225,7 +14225,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -14240,7 +14240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14251,9 +14251,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ad566dfc-6837-4d39-ab19-083921f1ebd0
+      - req-13f9f805-15b8-4e58-b9bd-8740cfcac2f6
       Date:
-      - Fri, 03 Aug 2018 19:40:01 GMT
+      - Mon, 06 Aug 2018 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14265,7 +14265,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -14280,7 +14280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb6c03fe36d457cac594001ac324759
+      - d250d71d06094bc9a71c97b563b06720
   response:
     status:
       code: 200
@@ -14291,9 +14291,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-147e128a-4004-4c1f-9eb6-029341f33d61
+      - req-064aff6a-78a4-46be-9210-33cbe27e3ede
       Date:
-      - Fri, 03 Aug 2018 19:40:02 GMT
+      - Mon, 06 Aug 2018 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14305,7 +14305,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14323,15 +14323,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:02 GMT
+      - Mon, 06 Aug 2018 16:53:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-395ad2be-6c81-4480-850e-b8a011b59b39
+      - req-dce50e97-50c7-4bf3-a163-b1582232b80d
       Content-Length:
       - '7278'
       Connection:
@@ -14343,7 +14343,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:03.277018Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:45.893287Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14422,10 +14422,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ybuut-FVTWeEM36ZaUlNNg"],
-        "issued_at": "2018-08-03T19:40:03.277102Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7Xk0rv5yTAa6zDvFJl1a1w"],
+        "issued_at": "2018-08-06T16:53:45.893353Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14440,7 +14440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -14451,9 +14451,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-637341aa-e5c5-45ae-a724-22e30520b4eb
+      - req-67ede455-83d7-4338-915b-402d299ac34a
       Date:
-      - Fri, 03 Aug 2018 19:40:03 GMT
+      - Mon, 06 Aug 2018 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -14467,259 +14467,7 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1c912681-e4c3-43c1-b05e-c5f108ac8aff
-      Date:
-      - Fri, 03 Aug 2018 19:40:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b16d0d0e-2e36-4475-99e8-37d90d6c9153
-      Date:
-      - Fri, 03 Aug 2018 19:40:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -14796,34 +14544,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -14835,7 +14572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -14846,53 +14583,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2014e1e6-063e-46e0-ab9d-2dcffdb10602
+      - req-7a5c7b2b-c853-4a66-b8ba-01804fa6c865
       Date:
-      - Fri, 03 Aug 2018 19:40:04 GMT
+      - Mon, 06 Aug 2018 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
@@ -14904,21 +14600,22 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
@@ -14932,26 +14629,67 @@ http_interactions:
         "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
         "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14969,15 +14707,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:04 GMT
+      - Mon, 06 Aug 2018 16:53:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-36e9ad74-dacf-4adb-a1b5-6ed210c2ee5f
+      - req-6e3fe759-6884-4cd5-9945-02614683ed9f
       Content-Length:
       - '7278'
       Connection:
@@ -14989,7 +14727,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:04.784445Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:46.814640Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15068,10 +14806,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ULfM5VMsR3-zLSEHR_wkew"],
-        "issued_at": "2018-08-03T19:40:04.784527Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kbpd49biRH-tMn8lmULsiw"],
+        "issued_at": "2018-08-06T16:53:46.814724Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15086,7 +14824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -15097,9 +14835,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1bcc563a-2360-4bf8-bf95-d12f601961cd
+      - req-8302bdf4-c3a0-42d5-a1cd-39fb3c359d80
       Date:
-      - Fri, 03 Aug 2018 19:40:05 GMT
+      - Mon, 06 Aug 2018 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -15113,127 +14851,7 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:05 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-89d82ae5-9fff-41c3-b7ff-c784b2d22e46
-      Date:
-      - Fri, 03 Aug 2018 19:40:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -15310,8 +14928,52 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - be127882bd1d479c8d6ed3a62fc5a248
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e2958fde-09b2-4ec1-9192-d9cc1c855113
+      Date:
+      - Mon, 06 Aug 2018 16:53:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -15321,20 +14983,97 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15352,15 +15091,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:05 GMT
+      - Mon, 06 Aug 2018 16:53:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2802cc3f-e160-4264-82a7-227ab88053db
+      - req-05a7cb5e-fe8e-441e-9e5c-037b72894ff4
       Content-Length:
       - '7264'
       Connection:
@@ -15372,7 +15111,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:05.749044Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:47.586102Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15451,10 +15190,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bTgce7jYRYS2BsJpYPFbow"],
-        "issued_at": "2018-08-03T19:40:05.749102Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1pENW1qgSVeIHZQhQmESCQ"],
+        "issued_at": "2018-08-06T16:53:47.586223Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15469,7 +15208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -15480,35 +15219,23 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a3bf0fe3-10a4-47d5-a792-bca2fdf942e5
+      - req-7e0e1d3f-9aa1-4016-b574-f6af5ca543d9
       Date:
-      - Fri, 03 Aug 2018 19:40:06 GMT
+      - Mon, 06 Aug 2018 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -15538,6 +15265,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -15545,16 +15278,10 @@ http_interactions:
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -15573,6 +15300,18 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -15586,7 +15325,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15601,7 +15340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -15612,167 +15351,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-db0d3316-c81a-4320-9bc5-f93240a3359b
+      - req-4a91e196-c558-4d0c-94ac-8635315b0152
       Date:
-      - Fri, 03 Aug 2018 19:40:06 GMT
+      - Mon, 06 Aug 2018 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a75257ca-6b03-4821-8165-a55322701942
-      Date:
-      - Fri, 03 Aug 2018 19:40:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
@@ -15836,20 +15420,44 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15867,15 +15475,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:06 GMT
+      - Mon, 06 Aug 2018 16:53:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a8ac66ba-fa82-48e4-8dbb-a5d130c3fa79
+      - req-64a0fff6-9df3-4b6b-a257-8757108b2262
       Content-Length:
       - '7278'
       Connection:
@@ -15887,7 +15495,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:07.001480Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:48.405397Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15966,10 +15574,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LWa2BmsVSYeYt7aXjggDpw"],
-        "issued_at": "2018-08-03T19:40:07.001550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YoL06OQmRNiRi1lxXS3cHg"],
+        "issued_at": "2018-08-06T16:53:48.405466Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15984,7 +15592,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -15995,13 +15603,37 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d3545e91-c59b-4989-b6bf-5ce8668f3280
+      - req-797f1c01-d37b-4f00-9160-0292de872563
       Date:
-      - Fri, 03 Aug 2018 19:40:07 GMT
+      - Mon, 06 Aug 2018 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -16011,17 +15643,11 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
@@ -16029,17 +15655,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -16058,16 +15684,90 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2715c712388345c1abef5ac7c0c996c5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-346d77ee-c2a6-4d71-8534-028f8d05d06c
+      Date:
+      - Mon, 06 Aug 2018 16:53:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
@@ -16081,29 +15781,70 @@ http_interactions:
         "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
         "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -16115,7 +15856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -16126,12 +15867,155 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-acc2fa7e-dcd2-46d9-8d32-e86c0cd25c31
+      - req-0c21a3ad-142c-4f03-96fb-90dab23a51e4
       Date:
-      - Fri, 03 Aug 2018 19:40:07 GMT
+      - Mon, 06 Aug 2018 16:53:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 57f62534d5714cb08da5daa158475eee
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-522fc6b5-dd98-478f-97ad-a9d97183e9ff
+      Date:
+      - Mon, 06 Aug 2018 16:53:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16208,294 +16092,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cf4aada8-ddd6-4f02-bb0f-8e5da6c15fe8
-      Date:
-      - Fri, 03 Aug 2018 19:40:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ab371540-a26e-4ca7-bac2-fb0fe0ffffe1
-      Date:
-      - Fri, 03 Aug 2018 19:40:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16513,15 +16123,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:08 GMT
+      - Mon, 06 Aug 2018 16:53:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a445ee4a-7c2b-4b1f-9e41-05a1764a8b65
+      - req-9581232d-1c18-4da5-8a80-2acf32a48d2d
       Content-Length:
       - '7265'
       Connection:
@@ -16533,7 +16143,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:08.330070Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:49.754885Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16612,10 +16222,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6glXwi76SA2yLwTIa99Dfg"],
-        "issued_at": "2018-08-03T19:40:08.330194Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["75BTQ5IkQVCmI0yRnqHwWw"],
+        "issued_at": "2018-08-06T16:53:49.754948Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16630,7 +16240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -16641,180 +16251,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9b53e13b-8d1c-4884-89f1-f7f922a6a2c4
+      - req-12921bda-cd27-44ff-9547-e58d62fe0c8e
       Date:
-      - Fri, 03 Aug 2018 19:40:08 GMT
+      - Mon, 06 Aug 2018 16:53:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
         true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-da6b69d5-a299-4b0b-81a6-adbf540888d6
-      Date:
-      - Fri, 03 Aug 2018 19:40:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -16860,198 +16303,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5ecffba6-d6d1-4d57-8d08-b35a27fd4129
-      Date:
-      - Fri, 03 Aug 2018 19:40:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-43e6c7e0-d87c-4772-998f-e53d3e2be3cb
-      Date:
-      - Fri, 03 Aug 2018 19:40:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -17076,8 +16344,52 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 40a1f139aad841d88bac4e6f3caed542
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5cbbe2a3-1fbe-436b-9f2a-79ebedee280d
+      Date:
+      - Mon, 06 Aug 2018 16:53:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -17123,287 +16435,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-365c275f-0b80-43b9-bce1-cabe23a28209
-      Date:
-      - Fri, 03 Aug 2018 19:40:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a248a512-79ea-4e00-8215-cec24a8d6866
-      Date:
-      - Fri, 03 Aug 2018 19:40:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17421,15 +16507,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:09 GMT
+      - Mon, 06 Aug 2018 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e57df657-a9a7-4b88-92e1-3fe5f1e13ee0
+      - req-8476aba2-6695-46de-9c4a-9f830fe0f11a
       Content-Length:
       - '7278'
       Connection:
@@ -17441,7 +16527,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:10.026803Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:53:50.915023Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17520,10 +16606,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["itUEsBuUQuSnOTiHk4yH3g"],
-        "issued_at": "2018-08-03T19:40:10.026877Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nhQR-sLxS32WUDUDyczynw"],
+        "issued_at": "2018-08-06T16:53:50.915085Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -17538,7 +16624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -17549,12 +16635,23 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3eca7871-5026-4f01-a942-625a6fcac790
+      - req-c96af4fa-7270-48f1-a5f3-521754e3eaad
       Date:
-      - Fri, 03 Aug 2018 19:40:10 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -17631,34 +16728,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -17670,7 +16756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -17681,49 +16767,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d632d3cb-f650-46c1-9542-301e0d715f42
+      - req-d58925ab-5a5e-4057-98d6-cc587f278aa6
       Date:
-      - Fri, 03 Aug 2018 19:40:10 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -17769,198 +16819,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-23ca4474-653a-48e9-b12b-68d37a06aa8e
-      Date:
-      - Fri, 03 Aug 2018 19:40:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5f18e835-abe9-4312-8e3a-ea25f7c482ea
-      Date:
-      - Fri, 03 Aug 2018 19:40:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -17985,597 +16860,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9b599d88-46c1-4791-8346-4d0a2003ed67
-      Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a1bd1b72-d6b9-4c0c-931b-a0b0280ddeed
-      Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-16ec0549-7375-4a41-83e5-6132174e900c
-      Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-81c1e882-7cb2-4fec-b6de-380c0fb60271
-      Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18590,7 +16888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -18601,9 +16899,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bd4b4b14-d46e-4ff2-bb40-3d40d2e58c51
+      - req-5e152ddc-dc50-492f-84d1-99d11af2f642
       Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18645,7 +16943,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18660,7 +16958,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -18671,9 +16969,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7131ef0c-e7b1-46cb-ad4a-d8a4776f407a
+      - req-ead26422-6717-4d25-ad14-f3858442f785
       Date:
-      - Fri, 03 Aug 2018 19:40:11 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18715,7 +17013,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18730,7 +17028,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -18741,9 +17039,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5ca0fcad-8aaf-46a1-86d1-26a81a80ffc6
+      - req-0674c7db-cbcb-4ba3-917f-d1a052bd5e72
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18785,7 +17083,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18800,7 +17098,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -18811,9 +17109,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ecb4501d-11b5-4bac-b47a-bb31d9836f29
+      - req-9a9f55e4-ce74-438a-835a-5897d93d5763
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18855,7 +17153,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18870,7 +17168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -18881,9 +17179,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-29a6b7d2-bf45-4f83-b3ab-6822a7950984
+      - req-b53a5dc8-21be-4a56-9a46-8fa6c9318fbd
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18925,7 +17223,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18940,7 +17238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -18951,9 +17249,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b261117c-a32d-4385-b724-325c7f2aabf9
+      - req-4df98601-298c-4eec-acfb-7ebf9797eedb
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18995,7 +17293,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19010,7 +17308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -19021,9 +17319,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-052af925-c373-4830-b31e-5e2d690cb913
+      - req-960c2be4-955e-4d4d-a7ff-734e5ad0afae
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19065,7 +17363,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19080,7 +17378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -19091,9 +17389,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-16d70ea6-c40e-4048-a27b-35c8a3553d90
+      - req-20685deb-14d7-4eec-928f-00ba001f4fbb
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19135,7 +17433,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19150,7 +17448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -19161,9 +17459,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4387b5ab-eda1-49d6-aac1-cc3de6c491d2
+      - req-24b9343c-9b23-4a10-9eef-0e0e18f8d87c
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19205,7 +17503,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19220,7 +17518,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -19231,9 +17529,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6e3749a3-4a60-48ea-8509-e118d8bffa6c
+      - req-0613edb7-8480-4434-b065-228d9bbe55f8
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19275,7 +17573,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19290,7 +17588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -19301,9 +17599,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-d8d836fc-f353-43c3-a2fb-bd0413ca160e
+      - req-9352655d-5225-45d0-a60e-e8456bfcb7a3
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19345,7 +17643,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19360,7 +17658,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -19371,9 +17669,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0a04d7ce-ab2f-41e6-89d7-f017642a3e57
+      - req-747d8523-447f-46ed-bd20-5037e0ae6ce7
       Date:
-      - Fri, 03 Aug 2018 19:40:12 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19415,7 +17713,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -19430,7 +17728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -19441,9 +17739,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-cebcdf6f-7fe5-4dae-b0ec-789e7ac556f0
+      - req-9fa37a95-5a36-473d-b56b-ec2ab25c3541
       Date:
-      - Fri, 03 Aug 2018 19:40:13 GMT
+      - Mon, 06 Aug 2018 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19485,7 +17783,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -19500,7 +17798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -19511,9 +17809,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7c286f91-e6a9-4f86-9740-fd96e28bc379
+      - req-2c90d0eb-1e96-4823-b50b-be74d2ced958
       Date:
-      - Fri, 03 Aug 2018 19:40:13 GMT
+      - Mon, 06 Aug 2018 16:53:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -19555,7 +17853,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19570,7 +17868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -19581,9 +17879,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-a61d298e-1963-49b7-a024-af41c79fde45
+      - req-4b3cacbf-2ddc-48ee-946e-79b18a574e9c
       Date:
-      - Fri, 03 Aug 2018 19:40:13 GMT
+      - Mon, 06 Aug 2018 16:53:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19986,7 +18284,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20001,7 +18299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -20012,9 +18310,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4629baa1-43d9-4994-9f6a-907f778cc175
+      - req-0ee409f6-06a5-472c-8d7c-cbcc631004de
       Date:
-      - Fri, 03 Aug 2018 19:40:13 GMT
+      - Mon, 06 Aug 2018 16:53:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20417,7 +18715,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20432,7 +18730,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -20443,9 +18741,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-16121578-47a9-4a55-8d8d-e2c1d2fbfa24
+      - req-ac65dbc0-a00a-4456-961d-af25016d3165
       Date:
-      - Fri, 03 Aug 2018 19:40:13 GMT
+      - Mon, 06 Aug 2018 16:53:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20848,7 +19146,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20863,7 +19161,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -20874,9 +19172,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-53a20b38-5a73-4bbb-8090-3ec14e91f673
+      - req-faaed306-d480-4d8e-802e-43c1c13f2ce0
       Date:
-      - Fri, 03 Aug 2018 19:40:14 GMT
+      - Mon, 06 Aug 2018 16:53:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21279,7 +19577,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21294,7 +19592,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -21305,9 +19603,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9d75af9a-f3f3-4df4-a02b-267efdbfa5e0
+      - req-190207d7-fc35-4481-966f-7772ec88e0e9
       Date:
-      - Fri, 03 Aug 2018 19:40:14 GMT
+      - Mon, 06 Aug 2018 16:53:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21710,7 +20008,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21725,7 +20023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -21736,9 +20034,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-393ef4b9-8bce-4963-9c6a-c12b0b545cc3
+      - req-f5ee8c9c-80b4-4971-82d8-1fa27f9cfd06
       Date:
-      - Fri, 03 Aug 2018 19:40:14 GMT
+      - Mon, 06 Aug 2018 16:53:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22141,7 +20439,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22156,7 +20454,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -22167,9 +20465,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d2312d8d-c226-429f-b67b-0ceaf5bb7748
+      - req-dfd860c3-b25c-4b00-8a59-ab8a6cc0344a
       Date:
-      - Fri, 03 Aug 2018 19:40:14 GMT
+      - Mon, 06 Aug 2018 16:53:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22572,7 +20870,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22587,7 +20885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -22598,9 +20896,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6c2bb01f-0be9-4c31-8b62-a78051c3c66c
+      - req-562ffbbc-06ef-4819-9469-85f6504a5c75
       Date:
-      - Fri, 03 Aug 2018 19:40:15 GMT
+      - Mon, 06 Aug 2018 16:53:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23003,7 +21301,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -23018,7 +21316,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -23029,9 +21327,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d00dcec0-1bcd-4452-8a3d-dce962c8b50b
+      - req-ceaa64a3-dcdf-470b-9afe-da034ef298df
       Date:
-      - Fri, 03 Aug 2018 19:40:15 GMT
+      - Mon, 06 Aug 2018 16:53:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23434,7 +21732,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -23449,7 +21747,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -23460,9 +21758,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ae1e2f37-c7d9-4b41-9389-5e4ffe6b1518
+      - req-f7cd5617-e09b-4636-ab18-db6b4572aa88
       Date:
-      - Fri, 03 Aug 2018 19:40:15 GMT
+      - Mon, 06 Aug 2018 16:53:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23865,7 +22163,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -23880,7 +22178,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -23891,9 +22189,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-574cfb3b-15a4-4791-9cb4-936881f91bb8
+      - req-87dfdf14-cd3f-4114-9f2f-ef516d5de6f3
       Date:
-      - Fri, 03 Aug 2018 19:40:16 GMT
+      - Mon, 06 Aug 2018 16:53:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24296,7 +22594,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -24311,7 +22609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -24322,9 +22620,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-e5a99774-84f5-4d76-a762-7f73f29c8c40
+      - req-0e5c5f41-6d5d-4e6a-a1bb-05d088390724
       Date:
-      - Fri, 03 Aug 2018 19:40:16 GMT
+      - Mon, 06 Aug 2018 16:53:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24727,7 +23025,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -24742,7 +23040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -24753,9 +23051,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4163e0af-f7f0-44c0-a857-1ff74896abe6
+      - req-c44055c6-4afb-423d-9cdd-b7b4c6e58bcf
       Date:
-      - Fri, 03 Aug 2018 19:40:16 GMT
+      - Mon, 06 Aug 2018 16:53:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -25158,7 +23456,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -25173,7 +23471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -25184,9 +23482,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-98d30c30-fb1e-489a-9be6-6be24f459d11
+      - req-d2123073-4e68-4b4a-9128-1c7cd5fd097b
       Date:
-      - Fri, 03 Aug 2018 19:40:16 GMT
+      - Mon, 06 Aug 2018 16:53:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -25589,7 +23887,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25604,7 +23902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -25615,9 +23913,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-15566498-5bf4-4be3-9eda-122c58dfd01a
+      - req-92c70d6d-3345-4617-8a4a-9a8939313830
       Date:
-      - Fri, 03 Aug 2018 19:40:17 GMT
+      - Mon, 06 Aug 2018 16:53:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25649,7 +23947,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25664,7 +23962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -25675,9 +23973,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-689256e7-21eb-41e3-890d-480ba293364b
+      - req-d2b6e1b8-5b52-4774-a635-f878ca90e385
       Date:
-      - Fri, 03 Aug 2018 19:40:17 GMT
+      - Mon, 06 Aug 2018 16:53:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25709,7 +24007,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25724,7 +24022,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -25735,9 +24033,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a3d7ff4c-bef8-4780-b549-d5311677bc13
+      - req-e40e6668-748b-41b6-ac96-11d1ac565160
       Date:
-      - Fri, 03 Aug 2018 19:40:17 GMT
+      - Mon, 06 Aug 2018 16:53:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25769,7 +24067,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25784,7 +24082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -25795,9 +24093,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5b657006-eb48-4738-81f3-cc88059fd069
+      - req-a819e28c-ce94-4f27-b23d-6b3055811ee1
       Date:
-      - Fri, 03 Aug 2018 19:40:17 GMT
+      - Mon, 06 Aug 2018 16:53:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25829,7 +24127,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25844,7 +24142,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -25855,9 +24153,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8c4ca107-5b2d-4519-ab93-48b997fbad36
+      - req-eea6234a-cd5e-42ef-a414-a8b9fe05c685
       Date:
-      - Fri, 03 Aug 2018 19:40:17 GMT
+      - Mon, 06 Aug 2018 16:53:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25889,7 +24187,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25904,7 +24202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -25915,9 +24213,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-68f05929-5836-4ac2-9221-3019ed55d61d
+      - req-1e5f4322-077c-43b6-a7d4-4a016acb7875
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25949,7 +24247,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25964,7 +24262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -25975,9 +24273,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-40bfafab-5bed-4ba6-9d64-14e12598c823
+      - req-5fa12401-620f-4181-a694-ca557a1fea2f
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26009,7 +24307,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26024,7 +24322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -26035,9 +24333,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e232ab9a-c803-483b-8c64-cfc719e0db03
+      - req-3f4a615b-29ee-4992-ad88-73b20949f768
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26069,7 +24367,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -26084,7 +24382,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -26095,9 +24393,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e77a7930-03a2-4365-ba44-f9796c02eb14
+      - req-16b7fad1-6500-4efd-9a52-24c826fb491a
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26129,7 +24427,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26144,7 +24442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -26155,9 +24453,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5007f92e-3773-4679-99a5-c738c46962f3
+      - req-45b8abf1-c617-4c5c-9f38-2c90d671c475
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26189,7 +24487,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:53:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -26204,7 +24502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -26215,9 +24513,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9274241d-2628-4b1b-b8c9-788f3e042f31
+      - req-5c1f9efc-d7be-4354-aa44-b214e142b639
       Date:
-      - Fri, 03 Aug 2018 19:40:18 GMT
+      - Mon, 06 Aug 2018 16:53:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26249,7 +24547,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26264,7 +24562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -26275,9 +24573,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8a3fe009-56b3-4736-9d0d-da2bda240608
+      - req-cf59675d-3d59-4168-9aab-c4ac0de0ffb1
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26309,7 +24607,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -26324,7 +24622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -26335,9 +24633,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-92ae1e11-846c-4ae9-a3c2-cffb76b1fcdf
+      - req-0d283072-2bfc-4888-a5aa-d5ab728b5212
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26369,7 +24667,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -26384,7 +24682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -26395,9 +24693,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f7bf5181-742e-464d-8e92-fbaed866ecf8
+      - req-8597ee44-5f1b-4442-bf4d-610f21f2a95c
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -26429,7 +24727,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26444,7 +24742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26455,9 +24753,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-93f98526-0cd3-49c0-8580-be80105adf5f
+      - req-d7c1fbcb-b1a2-4f49-aba3-f67395153146
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26492,7 +24790,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26507,7 +24805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26518,9 +24816,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-92b50adb-eaa0-4b0f-8487-e40aa9e90063
+      - req-9c22d83e-bb01-40ad-bece-15d01e3ffc33
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26563,7 +24861,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26578,7 +24876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26589,9 +24887,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6b0484fa-4956-4abe-8721-6da016ec6fcb
+      - req-fbfc31ad-273b-43b9-97fd-9801a95cdbc6
       Date:
-      - Fri, 03 Aug 2018 19:40:19 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26634,7 +24932,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26649,7 +24947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26660,9 +24958,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-5fa868d0-6a84-4207-b5c6-0edc6aff7b01
+      - req-373d0131-b412-4c33-b589-3f99bcb1ede5
       Date:
-      - Fri, 03 Aug 2018 19:40:20 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26769,7 +25067,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26784,7 +25082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26795,9 +25093,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0c4bf02e-c4b0-4517-9fab-621461235614
+      - req-f5b3a7e4-e18b-4660-b59c-a73595b037a3
       Date:
-      - Fri, 03 Aug 2018 19:40:20 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26839,7 +25137,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26854,7 +25152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19303cf88e63406dbc6e2943fcabc0fb
+      - c094de13176e432cbddba9ca9b23083d
   response:
     status:
       code: 200
@@ -26865,15 +25163,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-5081d759-1cf1-44b9-8eca-ee75451d4be8
+      - req-a76f4094-758d-4a6f-bb75-30912d752a02
       Date:
-      - Fri, 03 Aug 2018 19:40:20 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26888,7 +25186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -26899,9 +25197,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-4fe1cd03-579f-4892-b0c8-70eb77505104
+      - req-76eadcdf-672e-4734-ad96-cf814d363385
       Date:
-      - Fri, 03 Aug 2018 19:40:20 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26936,7 +25234,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26951,7 +25249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -26962,9 +25260,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4122d463-456b-4f3d-a29c-345868608280
+      - req-a42c7fb4-b25e-4a28-ba3c-18c3536d70ee
       Date:
-      - Fri, 03 Aug 2018 19:40:20 GMT
+      - Mon, 06 Aug 2018 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27007,7 +25305,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27022,7 +25320,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -27033,9 +25331,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bf8db111-9b34-4ae1-a3a8-a5645d832b7a
+      - req-a864d839-4731-4dd2-8b5d-b2e41ab23172
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27078,7 +25376,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27093,7 +25391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -27104,9 +25402,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-6e756494-64b0-42f7-b6ec-3477e7bec923
+      - req-1b187bb7-d189-4a2c-9688-662284816881
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27213,7 +25511,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27228,7 +25526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -27239,9 +25537,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-67f21944-650b-42ce-be04-4881037f6699
+      - req-cb1f74b0-fd7f-4897-ab59-c2b43379eca3
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27283,7 +25581,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27298,7 +25596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 140da77ad1fd47c08e636d5998c3c874
+      - be127882bd1d479c8d6ed3a62fc5a248
   response:
     status:
       code: 200
@@ -27309,15 +25607,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-03c0284f-a3d0-47d0-b256-69573e12784c
+      - req-2ad64059-494a-4b0a-b5e3-32158949a9fe
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27332,7 +25630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27343,9 +25641,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-ee647f14-b157-4836-b59d-c6d8f0160361
+      - req-c85227a0-739e-4dc7-bea3-f9b88080b93a
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27380,7 +25678,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27395,7 +25693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27406,9 +25704,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c73cfc6f-076d-4cd3-ac77-c793d9c521fa
+      - req-a392ef72-d685-4fac-bfa4-c2ed4971fa86
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27451,7 +25749,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27466,7 +25764,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27477,9 +25775,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fa60f3d1-80b8-4d91-a13d-6bca263cbcff
+      - req-02c50692-b101-40fd-84a2-9e5c96016212
       Date:
-      - Fri, 03 Aug 2018 19:40:21 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27522,7 +25820,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27537,7 +25835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27548,9 +25846,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-fdab04c2-2784-4b5e-afd2-a2b012b708fa
+      - req-2621dfe3-6a47-416e-b457-7c9303c974b5
       Date:
-      - Fri, 03 Aug 2018 19:40:22 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27657,7 +25955,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27672,7 +25970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27683,9 +25981,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b64efc19-f7a5-4d02-b663-3db308dcb694
+      - req-9fb571da-f470-48f1-93f9-e2cb18cf5e6a
       Date:
-      - Fri, 03 Aug 2018 19:40:22 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27727,7 +26025,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27742,7 +26040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660a23fd51954de1a3ba1f79e29ac6c7
+      - bb5bf27cdbc64881b8b55f7c86d53641
   response:
     status:
       code: 200
@@ -27753,15 +26051,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-320e4127-c3c2-4ca7-ade4-d30f9ccbc173
+      - req-a09bb8ce-eee7-4815-b931-e25a0e8703b2
       Date:
-      - Fri, 03 Aug 2018 19:40:22 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27776,7 +26074,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -27787,9 +26085,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-8d5e6aeb-7b43-4e4d-b920-cf8e32cc70b6
+      - req-dc71a30a-84c6-4194-82f7-ae2baebb8195
       Date:
-      - Fri, 03 Aug 2018 19:40:23 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27824,7 +26122,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27839,7 +26137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -27850,9 +26148,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-663f9562-3546-4f05-a124-84e38a5f771f
+      - req-9ecf0fda-2619-418f-bfc0-2a90ea52ff5c
       Date:
-      - Fri, 03 Aug 2018 19:40:23 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27895,7 +26193,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27910,7 +26208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -27921,9 +26219,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-25b60858-0d95-4824-a95d-9be3ac9cad12
+      - req-a1c3ff3d-385a-4280-9d94-f06acb6724b9
       Date:
-      - Fri, 03 Aug 2018 19:40:23 GMT
+      - Mon, 06 Aug 2018 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27966,7 +26264,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27981,7 +26279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -27992,9 +26290,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-d6480f97-6899-4432-8502-ee6d36b9165f
+      - req-8742f7cd-05fd-482e-bc29-718b4d6f4f1c
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28101,7 +26399,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28116,7 +26414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -28127,9 +26425,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-30ae5a8e-8a7b-446a-9588-6463df35cbaa
+      - req-78f3007c-746f-4c83-a557-14ad0ee38c77
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28171,7 +26469,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28186,7 +26484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a0a089709234a0aa12e260e7a7b8c78
+      - 2715c712388345c1abef5ac7c0c996c5
   response:
     status:
       code: 200
@@ -28197,15 +26495,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-31c2c900-30f1-4eca-94e3-aabe1ad008da
+      - req-be000fb6-4d4a-42c8-993f-f6a2a09eed99
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28220,7 +26518,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28231,9 +26529,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-c215e206-7e5f-4fa0-a606-5d1bf90f8619
+      - req-55f88b43-8aaa-4668-b5f2-09743bee5f2e
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28268,7 +26566,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28283,7 +26581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28294,9 +26592,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-32da0519-779b-4396-bae7-5fad9424cf14
+      - req-d4483eea-170f-4c0a-b43d-f5dd18d5d51f
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28339,7 +26637,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28354,7 +26652,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28365,9 +26663,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f63a9812-50e7-474f-88e0-7c8cb730da2b
+      - req-b09506e9-5b6b-4f00-bf24-bdb80623f98a
       Date:
-      - Fri, 03 Aug 2018 19:40:24 GMT
+      - Mon, 06 Aug 2018 16:54:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28410,7 +26708,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28425,7 +26723,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28436,9 +26734,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-2a2b6080-4be4-4cae-972e-e3f03c67dc98
+      - req-3503a788-e07b-4c34-8444-7b7555d04965
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28545,7 +26843,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28560,7 +26858,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28571,9 +26869,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e6439664-5345-4b0b-b790-4162ae9faa29
+      - req-209561b2-0da5-4f97-ae7a-2d1c4c1e73d0
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28615,7 +26913,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28630,7 +26928,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc3eda096f6346e6b2cd801cdb977be0
+      - 57f62534d5714cb08da5daa158475eee
   response:
     status:
       code: 200
@@ -28641,15 +26939,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-e82e50aa-491f-4037-8708-4e6207d8c351
+      - req-1599e057-18a5-42a7-917a-67ffc7bffb9a
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28664,7 +26962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -28675,9 +26973,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-9dbc86c7-dc57-4bc0-b57a-bd9cd1e51953
+      - req-e7f0d266-353b-44da-b669-a9d25b14c234
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28712,7 +27010,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28727,7 +27025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -28738,9 +27036,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c8908bb8-d256-4b43-8be4-4d4cc79e2736
+      - req-c933ba08-abe2-47a1-b8ee-d87f1874166b
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28783,7 +27081,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28798,7 +27096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -28809,9 +27107,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-52a8cd06-3363-49b3-976d-f7c58efcaed1
+      - req-c8d074b0-e82f-49d3-89ee-d8e9891afa82
       Date:
-      - Fri, 03 Aug 2018 19:40:25 GMT
+      - Mon, 06 Aug 2018 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28854,7 +27152,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28869,7 +27167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -28880,9 +27178,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-ebc6d7f9-0298-47ab-b46a-3e75597af961
+      - req-6a34d0f3-87df-4c29-b180-6276002b9417
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28989,7 +27287,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -29004,7 +27302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -29015,9 +27313,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d72d94d7-b1c3-42a7-8876-d4349e0aee64
+      - req-97875884-3e53-4f58-a2f7-53eb4f704921
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -29059,7 +27357,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -29074,7 +27372,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7043969ce7d34aa89117d95bc9d664c7
+      - 40a1f139aad841d88bac4e6f3caed542
   response:
     status:
       code: 200
@@ -29085,15 +27383,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-1ee2d7f5-72b1-4562-8019-d0126793befd
+      - req-fa867d3f-28a9-4e9d-af0c-4e57627e70b9
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -29108,7 +27406,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29119,9 +27417,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-43d099d3-e1ec-497e-9847-2ead18d6ab5b
+      - req-2308ef19-ea6e-488c-a19b-ae6533b2c552
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -29156,7 +27454,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -29171,7 +27469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29182,9 +27480,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ee59e06c-b8e0-4556-9bf1-79542c737170
+      - req-bc1c7197-1d10-438a-8077-99c8ff555f79
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -29227,7 +27525,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -29242,7 +27540,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29253,9 +27551,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4ea7c2b2-83fa-4b28-92c1-98546dc5ddb2
+      - req-e53d6639-2aaf-489b-a574-641e910a241f
       Date:
-      - Fri, 03 Aug 2018 19:40:26 GMT
+      - Mon, 06 Aug 2018 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -29298,7 +27596,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -29313,7 +27611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29324,9 +27622,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-30756526-a3cb-4ebc-ba13-1a4324945679
+      - req-56c5a776-7682-479a-b5e1-6079f6d2335c
       Date:
-      - Fri, 03 Aug 2018 19:40:27 GMT
+      - Mon, 06 Aug 2018 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -29433,7 +27731,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -29448,7 +27746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29459,9 +27757,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4d300923-dc9c-4109-b7c0-976a6017dcc4
+      - req-df67c15d-37f5-4db7-87c7-f2c6d1b21c1a
       Date:
-      - Fri, 03 Aug 2018 19:40:27 GMT
+      - Mon, 06 Aug 2018 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -29503,7 +27801,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -29518,7 +27816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7ee32e7d1d04863a282f37dd7b6bbde
+      - 1d9cef21ce994d10bf4c33b826c45976
   response:
     status:
       code: 200
@@ -29529,15 +27827,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-b1143462-d2dd-4bae-a88c-c8f43a14ffdd
+      - req-0e672300-ec4d-46ce-850c-63da0d1c88b5
       Date:
-      - Fri, 03 Aug 2018 19:40:27 GMT
+      - Mon, 06 Aug 2018 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29555,15 +27853,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:28 GMT
+      - Mon, 06 Aug 2018 16:54:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1b0f343adbfb4e18a707992186f753ca
+      - 28bd0ce6f6d74a029385d907e025474b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d89004c1-11ad-4add-8c2b-5ee50d214a2e
+      - req-b2959247-4bfd-4825-841f-ee6e71b2e5e2
       Content-Length:
       - '7311'
       Connection:
@@ -29575,7 +27873,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:28.381231Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:09.601375Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29654,10 +27952,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3th-S_gUT6qnJY6S9miZcg"],
-        "issued_at": "2018-08-03T19:40:28.381303Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["alHb0YywRCG9kS0a0gQHqQ"],
+        "issued_at": "2018-08-06T16:54:09.601445Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29675,15 +27973,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:28 GMT
+      - Mon, 06 Aug 2018 16:54:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7428ff62-0176-42d7-94d7-e3bcc0e65c96
+      - req-84b03c4c-5cbe-44e4-882b-7a05824a9073
       Content-Length:
       - '7311'
       Connection:
@@ -29695,7 +27993,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:28.728001Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:09.953373Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29774,10 +28072,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8YOC_rlXRNqNF8_niVnJRA"],
-        "issued_at": "2018-08-03T19:40:28.728078Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ii0-5ezrQhG1q6DyDmxxCQ"],
+        "issued_at": "2018-08-06T16:54:09.953452Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29795,15 +28093,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:28 GMT
+      - Mon, 06 Aug 2018 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fc606dd9d9494fc69be71b8e8a1cbd57
+      - 77d99277d26140a5947e319cd25c0f55
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7c257ce6-4bde-4fe7-8830-160e2a545095
+      - req-c9e5bf21-e4cd-4baa-b626-b040390a254f
       Content-Length:
       - '297'
       Connection:
@@ -29812,12 +28110,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:40:29.028058Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:10.182532Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Enq_Luj9SdShvg2AspDURQ"],
-        "issued_at": "2018-08-03T19:40:29.028180Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WhcmYhrFRiOirDnPNFAwHg"],
+        "issued_at": "2018-08-06T16:54:10.182592Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -29832,20 +28130,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc606dd9d9494fc69be71b8e8a1cbd57
+      - 77d99277d26140a5947e319cd25c0f55
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:29 GMT
+      - Mon, 06 Aug 2018 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5fc1fd67-767b-4a99-a6de-783714274d1d
+      - req-f1fe07de-f3e4-4a40-bd61-f05e50f1252b
       Content-Length:
       - '2457'
       Connection:
@@ -29878,13 +28176,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"fc606dd9d9494fc69be71b8e8a1cbd57"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"77d99277d26140a5947e319cd25c0f55"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29896,15 +28194,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:29 GMT
+      - Mon, 06 Aug 2018 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 676c40bbf81340a9874658566687cd22
+      - 51a043bb55ea4e149f920f91e2918b43
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1fc33f59-7aa4-47d1-9c81-3c64a503c710
+      - req-bd059e29-8b2f-47ca-8ae9-920e4668b12a
       Content-Length:
       - '7313'
       Connection:
@@ -29916,7 +28214,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:29.028058Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:10.182532Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29995,10 +28293,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bOiIXEq4Ryytlh0ccX5lpw",
-        "Enq_Luj9SdShvg2AspDURQ"], "issued_at": "2018-08-03T19:40:29.510479Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqNxJDZCRv6ZaKiVkfmq0g",
+        "WhcmYhrFRiOirDnPNFAwHg"], "issued_at": "2018-08-06T16:54:10.713706Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -30013,20 +28311,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 676c40bbf81340a9874658566687cd22
+      - 51a043bb55ea4e149f920f91e2918b43
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:29 GMT
+      - Mon, 06 Aug 2018 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b7d2555-4c64-4e66-9a42-6dd570f8b4ba
+      - req-dc8c5425-cd9c-4b86-a0a0-b8ee19413f55
       Content-Length:
       - '2179'
       Connection:
@@ -30059,7 +28357,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30077,15 +28375,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:29 GMT
+      - Mon, 06 Aug 2018 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 84413980f7514c829e1533cf3c446b62
+      - a988a30f1125459cb41d6831843424b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ef9a4a15-8dbd-43aa-9641-159ce2ff3065
+      - req-3efaf729-c9df-4fb6-9a1c-b5dfd5e8acfb
       Content-Length:
       - '7278'
       Connection:
@@ -30097,7 +28395,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:29.993374Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:11.228241Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30176,10 +28474,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ik4Kq_FZTg6jCTsiiCAQLw"],
-        "issued_at": "2018-08-03T19:40:29.993443Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["54EJy8jpQPmFtQxI7uU__A"],
+        "issued_at": "2018-08-06T16:54:11.228310Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30197,15 +28495,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:30 GMT
+      - Mon, 06 Aug 2018 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 57a3715ca78c4ab38c906a67a5ae87ca
+      - bb7895b9f2d94828898115d5a7503b1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7a640d7d-2d4b-4e4e-9af4-1f237ab1b25b
+      - req-ff11d22d-f6b7-4c84-b81f-df692814acd7
       Content-Length:
       - '7278'
       Connection:
@@ -30217,7 +28515,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:30.354685Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:11.565448Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30296,10 +28594,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1btioRMxTXGgMZa_lwNdqg"],
-        "issued_at": "2018-08-03T19:40:30.354753Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["00--bdfhRECPJLsP0JTIqA"],
+        "issued_at": "2018-08-06T16:54:11.565517Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30317,15 +28615,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:30 GMT
+      - Mon, 06 Aug 2018 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3f542d1845bc463e9174223e652c7994
+      - 0737de6eb38e466ebdc236f555fd4989
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2dbc060d-ef4d-4123-9f0a-63344e9d2945
+      - req-8ccc289b-b4f2-4b60-8fee-6fa9610516d2
       Content-Length:
       - '7264'
       Connection:
@@ -30337,7 +28635,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:30.685781Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:11.908513Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30416,10 +28714,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MgcYH6OIQEiHlPQ3kWitDA"],
-        "issued_at": "2018-08-03T19:40:30.685873Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wP4NnVe-Sg-smh_hKiPgAg"],
+        "issued_at": "2018-08-06T16:54:11.908576Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30437,15 +28735,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:30 GMT
+      - Mon, 06 Aug 2018 16:54:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aef7027d02754f5d8ec6cfd64638fc32
+      - bc116c56bf0242608e57fdcc39f3b1da
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-567b2960-e2e4-4cfb-b4fc-e3bf63ef7b64
+      - req-69c71bda-ff41-4b70-b221-c233161a290f
       Content-Length:
       - '7278'
       Connection:
@@ -30457,7 +28755,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:31.062870Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:12.236471Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30536,10 +28834,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uooz76zMS5GKBNEWNG06zA"],
-        "issued_at": "2018-08-03T19:40:31.062952Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nDFAnlvtSCmz4uZRUrZffA"],
+        "issued_at": "2018-08-06T16:54:12.236535Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30557,15 +28855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:31 GMT
+      - Mon, 06 Aug 2018 16:54:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2463e3d322304191ab8147a503dd394e
+      - 5fbd599237ca4f20be16ebe5e2059551
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3ba9be61-f247-4acb-9329-de6f5cf8f2d1
+      - req-30b9b995-d09e-4840-867e-ab026e371097
       Content-Length:
       - '7265'
       Connection:
@@ -30577,7 +28875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:31.414581Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:12.590035Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30656,10 +28954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sXSdHFl7RIqp2F6rSQjHmg"],
-        "issued_at": "2018-08-03T19:40:31.414646Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TbS22RXCRqOoPf-tR6248Q"],
+        "issued_at": "2018-08-06T16:54:12.590158Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30677,15 +28975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:31 GMT
+      - Mon, 06 Aug 2018 16:54:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5b5d57313ef943008c8b8ba88bd7a7de
+      - 83144d2e24654879986a80c7c24ef934
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eba1eb24-407a-43ce-a776-f212b9bee4e9
+      - req-6c1042a1-f927-4d45-9956-8888bfe4e522
       Content-Length:
       - '7278'
       Connection:
@@ -30697,7 +28995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:31.707188Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:12.958591Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30776,10 +29074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k-tDnOryRFyRf5N2YBNY1A"],
-        "issued_at": "2018-08-03T19:40:31.707246Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nd254ObzT2WxeI0pD_37WQ"],
+        "issued_at": "2018-08-06T16:54:12.958656Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30797,15 +29095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:31 GMT
+      - Mon, 06 Aug 2018 16:54:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9827d76-e0b5-4fda-a2fa-8a2bf5a61e94
+      - req-cc731966-ea78-4246-a055-b1f53a0a8147
       Content-Length:
       - '7278'
       Connection:
@@ -30817,7 +29115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:32.040184Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:13.261364Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30896,10 +29194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NLFbsREVQYKtedi7y5TGtQ"],
-        "issued_at": "2018-08-03T19:40:32.040247Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kDNPlHdNSzme43ZYbSiVfw"],
+        "issued_at": "2018-08-06T16:54:13.261421Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -30914,27 +29212,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c5c4c949-2676-4565-8364-4d3a3d4a70d0
+      - req-50c08224-f1aa-4a32-bccc-18bbfd5df347
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c5c4c949-2676-4565-8364-4d3a3d4a70d0
+      - req-50c08224-f1aa-4a32-bccc-18bbfd5df347
       Date:
-      - Fri, 03 Aug 2018 19:40:32 GMT
+      - Mon, 06 Aug 2018 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30952,15 +29250,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:32 GMT
+      - Mon, 06 Aug 2018 16:54:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5e3d4240-d6fd-4deb-a39c-ea204d24fbc4
+      - req-202cb36c-790b-4ede-b332-f85aa589839a
       Content-Length:
       - '7278'
       Connection:
@@ -30972,7 +29270,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:32.651337Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:13.871380Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31051,10 +29349,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hd8pfP0YQQCoNE22vs3XlA"],
-        "issued_at": "2018-08-03T19:40:32.651400Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PX4kYBr_RS-TVC_psPKSVA"],
+        "issued_at": "2018-08-06T16:54:13.871444Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -31069,27 +29367,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a58e2f7b-5db8-4430-aa61-c4b74ed27ccd
+      - req-c26a57a3-970b-441d-989e-ab590c2409cc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a58e2f7b-5db8-4430-aa61-c4b74ed27ccd
+      - req-c26a57a3-970b-441d-989e-ab590c2409cc
       Date:
-      - Fri, 03 Aug 2018 19:40:32 GMT
+      - Mon, 06 Aug 2018 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31107,15 +29405,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:33 GMT
+      - Mon, 06 Aug 2018 16:54:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61319ee9-cf60-4755-9773-ceb3c145128e
+      - req-c05121f9-2c9d-4ac0-b1f1-9fc6eaed2914
       Content-Length:
       - '7264'
       Connection:
@@ -31127,7 +29425,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:33.367559Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:14.553513Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31206,10 +29504,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K4E3eu3uS--e0e45DO-xxw"],
-        "issued_at": "2018-08-03T19:40:33.367626Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jw6DbFt_R7GD_alncm7Viw"],
+        "issued_at": "2018-08-06T16:54:14.553599Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -31224,22 +29522,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7f27bcb9-684d-4709-9ea1-26ec90944170
+      - req-94263cbc-7715-4f44-870b-f8c04e61e788
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-7f27bcb9-684d-4709-9ea1-26ec90944170
+      - req-94263cbc-7715-4f44-870b-f8c04e61e788
       Date:
-      - Fri, 03 Aug 2018 19:40:33 GMT
+      - Mon, 06 Aug 2018 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -31272,7 +29570,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -31287,22 +29585,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-640e8e45-a815-4830-8c87-2fb8129717b3
+      - req-d646bb07-5709-49dd-95b3-36a8890cc6cd
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-640e8e45-a815-4830-8c87-2fb8129717b3
+      - req-d646bb07-5709-49dd-95b3-36a8890cc6cd
       Date:
-      - Fri, 03 Aug 2018 19:40:34 GMT
+      - Mon, 06 Aug 2018 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -31343,7 +29641,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -31358,22 +29656,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3d0d7388-f7a5-457c-834a-8a855f370b71
+      - req-8b230377-8ba1-4519-bbb7-fb3a6386c335
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-3d0d7388-f7a5-457c-834a-8a855f370b71
+      - req-8b230377-8ba1-4519-bbb7-fb3a6386c335
       Date:
-      - Fri, 03 Aug 2018 19:40:34 GMT
+      - Mon, 06 Aug 2018 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -31407,7 +29705,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -31422,27 +29720,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-842ce4be-6c4e-4579-9a6b-09c0da18cc38
+      - req-2f88ba29-8d51-41c3-8558-b8274c187dae
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-842ce4be-6c4e-4579-9a6b-09c0da18cc38
+      - req-2f88ba29-8d51-41c3-8558-b8274c187dae
       Date:
-      - Fri, 03 Aug 2018 19:40:34 GMT
+      - Mon, 06 Aug 2018 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31460,15 +29758,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:34 GMT
+      - Mon, 06 Aug 2018 16:54:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8609232b-f181-4715-aaf9-7cec043db9b4
+      - req-03972ebb-4174-452d-b8f7-88d7a7f5d0d2
       Content-Length:
       - '7278'
       Connection:
@@ -31480,7 +29778,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:35.230178Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:16.866488Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31559,10 +29857,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VpTZiW16TUC0skWcGtZUxg"],
-        "issued_at": "2018-08-03T19:40:35.230289Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["okJewQnFRP6-F2EGPo7GRQ"],
+        "issued_at": "2018-08-06T16:54:16.866568Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -31577,27 +29875,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c3bfc802-8575-491c-a7eb-30c1cd410b29
+      - req-3e36ebc5-506b-40de-9a39-06bf3c64c2c1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c3bfc802-8575-491c-a7eb-30c1cd410b29
+      - req-3e36ebc5-506b-40de-9a39-06bf3c64c2c1
       Date:
-      - Fri, 03 Aug 2018 19:40:35 GMT
+      - Mon, 06 Aug 2018 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -31612,27 +29910,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-33345bb2-fd5d-484f-8b4a-ff22e04f8f5c
+      - req-9df4c4f0-31b6-4058-860e-0cd35fcf58bd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-33345bb2-fd5d-484f-8b4a-ff22e04f8f5c
+      - req-9df4c4f0-31b6-4058-860e-0cd35fcf58bd
       Date:
-      - Fri, 03 Aug 2018 19:40:35 GMT
+      - Mon, 06 Aug 2018 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31650,15 +29948,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:35 GMT
+      - Mon, 06 Aug 2018 16:54:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7acfb511-75db-4f0d-b89c-5644f2957035
+      - req-f33ddad3-9c71-40f0-9765-c3ab5ff09bd1
       Content-Length:
       - '7265'
       Connection:
@@ -31670,7 +29968,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:36.148526Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:17.734737Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31749,10 +30047,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y2KeWIdRRT-nDp2L3WRBCQ"],
-        "issued_at": "2018-08-03T19:40:36.148608Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kX7nc3m_Qz2a7TWh4FZVuQ"],
+        "issued_at": "2018-08-06T16:54:17.734804Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -31767,27 +30065,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70fb257f-f8ed-4d50-9ed4-7834cbe7aec9
+      - req-aaf0cd57-6ba1-468f-bee0-af2ee57d1e5b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-70fb257f-f8ed-4d50-9ed4-7834cbe7aec9
+      - req-aaf0cd57-6ba1-468f-bee0-af2ee57d1e5b
       Date:
-      - Fri, 03 Aug 2018 19:40:36 GMT
+      - Mon, 06 Aug 2018 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31805,15 +30103,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:36 GMT
+      - Mon, 06 Aug 2018 16:54:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6c4c5ccb-f429-4090-801c-e1cacc9c200c
+      - req-78092eb8-0455-4a74-8de5-82fc18908989
       Content-Length:
       - '7278'
       Connection:
@@ -31825,7 +30123,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:36.759363Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:18.330858Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31904,10 +30202,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NUcUT3nZRcCPKK76d0pQdw"],
-        "issued_at": "2018-08-03T19:40:36.759432Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dw6orGGkQ--5-8TFKieihQ"],
+        "issued_at": "2018-08-06T16:54:18.330925Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -31922,27 +30220,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ac07f4b-504b-49e2-aa62-5e8162ed8015
+      - req-e9f75c94-7d5f-4ef4-97eb-b78418689252
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0ac07f4b-504b-49e2-aa62-5e8162ed8015
+      - req-e9f75c94-7d5f-4ef4-97eb-b78418689252
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -31957,27 +30255,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-214f3bcb-00c4-456f-92f5-a148e0e8773f
+      - req-b1040b05-4423-48ce-8a3f-05184d52e8b8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-214f3bcb-00c4-456f-92f5-a148e0e8773f
+      - req-b1040b05-4423-48ce-8a3f-05184d52e8b8
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -31992,27 +30290,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a9f7adf-0e2b-4799-b936-5da9366e63cd
+      - req-e2aa40f4-198a-4545-b4f6-77a2bd409356
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6a9f7adf-0e2b-4799-b936-5da9366e63cd
+      - req-e2aa40f4-198a-4545-b4f6-77a2bd409356
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -32027,27 +30325,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-98b22c02-2320-4ec4-9b86-c44250400cd5
+      - req-763e4060-893d-4342-8c39-5b2276244d90
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-98b22c02-2320-4ec4-9b86-c44250400cd5
+      - req-763e4060-893d-4342-8c39-5b2276244d90
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -32062,27 +30360,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52a2a4ec-fff6-4603-a10f-3a7a1a4a9eec
+      - req-3094dfd0-195e-4822-b405-672ac7ac0946
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-52a2a4ec-fff6-4603-a10f-3a7a1a4a9eec
+      - req-3094dfd0-195e-4822-b405-672ac7ac0946
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -32097,22 +30395,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c8ef8d00-da0a-4327-90e3-fc11e07b33fc
+      - req-229165eb-8902-4e0f-93c5-67828ea31208
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-c8ef8d00-da0a-4327-90e3-fc11e07b33fc
+      - req-229165eb-8902-4e0f-93c5-67828ea31208
       Date:
-      - Fri, 03 Aug 2018 19:40:37 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -32127,7 +30425,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -32142,22 +30440,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-54788594-4171-45b7-86ae-8e41d4272e5e
+      - req-4ba288cf-fb45-42fa-9f51-c4c1f77d96d6
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-54788594-4171-45b7-86ae-8e41d4272e5e
+      - req-4ba288cf-fb45-42fa-9f51-c4c1f77d96d6
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -32172,7 +30470,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -32187,27 +30485,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf3fb3c0-7874-4ea8-a791-5d805a397bcb
+      - req-38926624-f3f2-4467-a3b9-cdaec68a9f31
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cf3fb3c0-7874-4ea8-a791-5d805a397bcb
+      - req-38926624-f3f2-4467-a3b9-cdaec68a9f31
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -32222,27 +30520,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f77e9a37-2b01-415e-9dcb-fd807cdc148f
+      - req-a8944727-1e09-448a-a4c6-692c0887ee10
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f77e9a37-2b01-415e-9dcb-fd807cdc148f
+      - req-a8944727-1e09-448a-a4c6-692c0887ee10
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -32257,27 +30555,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9ad13f42-b2cf-4262-9ecb-bbcf8f7950fb
+      - req-d3feb4db-6b15-456c-81ca-2a669cfe9921
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9ad13f42-b2cf-4262-9ecb-bbcf8f7950fb
+      - req-d3feb4db-6b15-456c-81ca-2a669cfe9921
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -32292,27 +30590,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e6d05856-9594-4043-8f14-bf9cd3dc181b
+      - req-94a98be3-2389-4f00-814c-4c612589045c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e6d05856-9594-4043-8f14-bf9cd3dc181b
+      - req-94a98be3-2389-4f00-814c-4c612589045c
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -32327,27 +30625,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6233ca87-76b6-4aa5-8a50-6c1765cdead3
+      - req-174bc53f-4ede-45ac-af40-4283e26896fd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6233ca87-76b6-4aa5-8a50-6c1765cdead3
+      - req-174bc53f-4ede-45ac-af40-4283e26896fd
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -32362,27 +30660,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ea8e502-3477-4e96-a999-1a810bbe3572
+      - req-105bdd43-2b41-4428-8361-82c00114f77f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4ea8e502-3477-4e96-a999-1a810bbe3572
+      - req-105bdd43-2b41-4428-8361-82c00114f77f
       Date:
-      - Fri, 03 Aug 2018 19:40:38 GMT
+      - Mon, 06 Aug 2018 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -32397,27 +30695,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c07a3e08-d388-4eba-bb23-ba947ec6d3d2
+      - req-fd783066-34ee-4df8-b1f3-449b70f2221a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c07a3e08-d388-4eba-bb23-ba947ec6d3d2
+      - req-fd783066-34ee-4df8-b1f3-449b70f2221a
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -32432,27 +30730,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e7d2e00-0ef3-4483-a2f6-8fcfe48b94c8
+      - req-f8430b3b-dda9-46d5-896f-70c3593edeb4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5e7d2e00-0ef3-4483-a2f6-8fcfe48b94c8
+      - req-f8430b3b-dda9-46d5-896f-70c3593edeb4
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -32467,27 +30765,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7090e23c-51e3-442d-a16b-c0de843c3b59
+      - req-61bce7de-bde1-46e3-b944-f98f5c25a251
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7090e23c-51e3-442d-a16b-c0de843c3b59
+      - req-61bce7de-bde1-46e3-b944-f98f5c25a251
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -32502,27 +30800,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86a66b7e-0393-44c2-9375-d052940e1746
+      - req-681383b3-8a51-46a6-971f-0a9cfd0f7031
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-86a66b7e-0393-44c2-9375-d052940e1746
+      - req-681383b3-8a51-46a6-971f-0a9cfd0f7031
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -32537,27 +30835,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a8c2b00-3b7c-4bbe-820c-8f76a8a1aff7
+      - req-b87e1c6b-cd92-498d-996f-de9c2a5e00eb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7a8c2b00-3b7c-4bbe-820c-8f76a8a1aff7
+      - req-b87e1c6b-cd92-498d-996f-de9c2a5e00eb
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -32572,27 +30870,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-094e9bdb-4791-47d0-ab70-10b01b81e1f0
+      - req-0a40242c-d42a-4684-b553-c88ac167ba12
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-094e9bdb-4791-47d0-ab70-10b01b81e1f0
+      - req-0a40242c-d42a-4684-b553-c88ac167ba12
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -32607,27 +30905,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f65925bd-ad5d-417c-8726-7e5b8fd1c05c
+      - req-55898f06-e37b-4718-83bb-227b0092d6e8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f65925bd-ad5d-417c-8726-7e5b8fd1c05c
+      - req-55898f06-e37b-4718-83bb-227b0092d6e8
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -32642,27 +30940,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-83e83ae6-55c9-4d7b-ad1c-ffe37f31d36a
+      - req-2f4142f0-7558-470b-95ea-fe14b535c1f4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-83e83ae6-55c9-4d7b-ad1c-ffe37f31d36a
+      - req-2f4142f0-7558-470b-95ea-fe14b535c1f4
       Date:
-      - Fri, 03 Aug 2018 19:40:39 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -32677,27 +30975,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7e0d36e-be5b-4a2e-bcf4-eb71a106a5fd
+      - req-84154149-6136-49e4-b538-fee2d8a67c8e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d7e0d36e-be5b-4a2e-bcf4-eb71a106a5fd
+      - req-84154149-6136-49e4-b538-fee2d8a67c8e
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -32712,27 +31010,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c1bca459-9e8a-4ddb-b5ed-6d4e89b28e8f
+      - req-8edca855-95b3-41e5-b5de-6973f81d8851
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c1bca459-9e8a-4ddb-b5ed-6d4e89b28e8f
+      - req-8edca855-95b3-41e5-b5de-6973f81d8851
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -32747,27 +31045,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ca10d8e-cdf7-4a03-9838-4ba20d19a024
+      - req-fe83ab79-4174-493b-8caf-ff8dffd14823
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ca10d8e-cdf7-4a03-9838-4ba20d19a024
+      - req-fe83ab79-4174-493b-8caf-ff8dffd14823
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -32782,27 +31080,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3365cb62-404f-4d4f-ad2b-c820b3a33597
+      - req-f3bda142-91b6-40c2-9c11-c97440c8bdee
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3365cb62-404f-4d4f-ad2b-c820b3a33597
+      - req-f3bda142-91b6-40c2-9c11-c97440c8bdee
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -32817,27 +31115,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52d56d7d-ecce-4e23-9cbb-b0ede2f1cb68
+      - req-89821d97-b653-4a8a-81fe-ea7a0d2fcc61
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-52d56d7d-ecce-4e23-9cbb-b0ede2f1cb68
+      - req-89821d97-b653-4a8a-81fe-ea7a0d2fcc61
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -32852,27 +31150,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-007d274c-4213-44d3-854c-5d576a66bd74
+      - req-419a1595-028c-4c78-808a-1eec8cc0bdd4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-007d274c-4213-44d3-854c-5d576a66bd74
+      - req-419a1595-028c-4c78-808a-1eec8cc0bdd4
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -32887,27 +31185,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49df6bad-8289-42aa-8936-84781cee3d48
+      - req-8018bcfc-f1e5-4a1a-bcff-38dd9701ea54
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-49df6bad-8289-42aa-8936-84781cee3d48
+      - req-8018bcfc-f1e5-4a1a-bcff-38dd9701ea54
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -32922,27 +31220,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60aa5616-3b8b-4324-83a7-2995ec4b3090
+      - req-1f7319ab-7539-4a88-9b7d-84e09b8e3165
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-60aa5616-3b8b-4324-83a7-2995ec4b3090
+      - req-1f7319ab-7539-4a88-9b7d-84e09b8e3165
       Date:
-      - Fri, 03 Aug 2018 19:40:40 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -32957,22 +31255,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-285aa70a-482c-4998-a280-4b0b5df2a4d3
+      - req-056d3f1d-e54a-4ed9-9eb4-51e5f6528f03
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-285aa70a-482c-4998-a280-4b0b5df2a4d3
+      - req-056d3f1d-e54a-4ed9-9eb4-51e5f6528f03
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32984,7 +31282,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32999,22 +31297,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612ab14713414c608df6e7c59d0c88f9
+      - '0807f527d5f1419b8bf13626c76dfd89'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-610dd340-6610-4f2e-8b1a-0558fe4f8434
+      - req-f152fb31-7ac9-4eb5-9dc3-10f7042da2f4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-610dd340-6610-4f2e-8b1a-0558fe4f8434
+      - req-f152fb31-7ac9-4eb5-9dc3-10f7042da2f4
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33026,7 +31324,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -33041,22 +31339,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7857507-af38-4877-bbcf-884bcbfcc595
+      - req-a5f6087b-0626-4f78-95ba-ee790beb7a09
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c7857507-af38-4877-bbcf-884bcbfcc595
+      - req-a5f6087b-0626-4f78-95ba-ee790beb7a09
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33068,7 +31366,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33083,22 +31381,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284b0f71532a4e73b63aba3ddb5e8a94
+      - 15b597d8a43d47fcbc500d645863bdea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c5e60bdc-4466-4434-b0a5-852f8a4673da
+      - req-be68026b-012b-490a-939b-05bfffc090fa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c5e60bdc-4466-4434-b0a5-852f8a4673da
+      - req-be68026b-012b-490a-939b-05bfffc090fa
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33110,7 +31408,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -33125,22 +31423,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99fa95e4-360e-4551-acf7-cc62ec5e4c1b
+      - req-29b4171a-1704-42c0-a7ed-7570cbb87fd0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-99fa95e4-360e-4551-acf7-cc62ec5e4c1b
+      - req-29b4171a-1704-42c0-a7ed-7570cbb87fd0
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33152,7 +31450,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33167,22 +31465,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5005334347c4c7cb2de1cb483aa518a
+      - 8700d4f0d4f24dd18ea5b2345ab24a3f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0ef9711-ad09-458f-a787-ca66018f6282
+      - req-b3a5b026-17f2-495d-9d31-bf2ecfb4df84
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d0ef9711-ad09-458f-a787-ca66018f6282
+      - req-b3a5b026-17f2-495d-9d31-bf2ecfb4df84
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33194,7 +31492,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -33209,22 +31507,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-79cc95ae-d1bb-4232-9f99-58967f81443d
+      - req-e5f4cb32-48c9-4cc7-905e-399e77b6b704
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-79cc95ae-d1bb-4232-9f99-58967f81443d
+      - req-e5f4cb32-48c9-4cc7-905e-399e77b6b704
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33236,7 +31534,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33251,22 +31549,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b0c284484e541169f0c2c93dedcf185
+      - 9ab599f98b074e3c833cd63e45b7a720
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fcf46aee-dcb4-4c9b-bb5f-6874df16aaf2
+      - req-ffa66c5b-92d8-496c-8aec-47713182f255
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fcf46aee-dcb4-4c9b-bb5f-6874df16aaf2
+      - req-ffa66c5b-92d8-496c-8aec-47713182f255
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33278,7 +31576,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -33293,22 +31591,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73ed22ea-01e8-4223-82b9-5ab8eaeb411f
+      - req-dad8c4ab-f6d1-4956-99de-d37d28c0b9b5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-73ed22ea-01e8-4223-82b9-5ab8eaeb411f
+      - req-dad8c4ab-f6d1-4956-99de-d37d28c0b9b5
       Date:
-      - Fri, 03 Aug 2018 19:40:41 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33320,7 +31618,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33335,22 +31633,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfe8d9a995c54336bd44ebd450ea0cca
+      - 499536d75c3e4abe8d717f9c105da6f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-feac7643-e564-4d1c-8784-27df47a634e0
+      - req-e64f987d-90c1-4a5e-a0e4-a2c24ed108a1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-feac7643-e564-4d1c-8784-27df47a634e0
+      - req-e64f987d-90c1-4a5e-a0e4-a2c24ed108a1
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33362,7 +31660,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -33377,22 +31675,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e4d47f8c-9639-42a9-b069-ded0af68addd
+      - req-38d8e558-eccf-4280-97b0-856c6ba2cff7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e4d47f8c-9639-42a9-b069-ded0af68addd
+      - req-38d8e558-eccf-4280-97b0-856c6ba2cff7
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33404,7 +31702,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33419,22 +31717,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0a6248a8a254a4fa32eb246f94dcef1
+      - bd125d12b7154d25ac19efd31fdbf7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9c0b625-a811-4365-bb94-95b3b91942c8
+      - req-a06bc3c9-a2f6-47de-8a71-85aec9367a45
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e9c0b625-a811-4365-bb94-95b3b91942c8
+      - req-a06bc3c9-a2f6-47de-8a71-85aec9367a45
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33446,7 +31744,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -33461,22 +31759,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-45ae6f6c-af53-4d83-9a51-486319de8614
+      - req-a4cc7d75-02f3-4b2c-8a72-c5f5113d2135
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-45ae6f6c-af53-4d83-9a51-486319de8614
+      - req-a4cc7d75-02f3-4b2c-8a72-c5f5113d2135
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33488,7 +31786,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -33503,22 +31801,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8151105e1da34433933d54232c3925a6
+      - 0ead4ea1e84c424f82edc664661bedcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93b6e4c2-95b0-43e3-9c7f-b206ec4d6b1d
+      - req-361aead2-2a3a-4dd6-afa5-8cc63c78ea44
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-93b6e4c2-95b0-43e3-9c7f-b206ec4d6b1d
+      - req-361aead2-2a3a-4dd6-afa5-8cc63c78ea44
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -33530,7 +31828,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33548,15 +31846,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:42 GMT
+      - Mon, 06 Aug 2018 16:54:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e8d5d7f4deeb4a1ca13861236aebb60b
+      - 8a1a5c9035624d77809944ff71e1ba50
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ac7dae0-468a-43ce-8cbc-7f968787e1fb
+      - req-4bb98fdd-b59f-42f7-9931-a42c8b764a1d
       Content-Length:
       - '7311'
       Connection:
@@ -33568,7 +31866,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:43.009782Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:25.104681Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33647,10 +31945,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jBj8VEB0RoC2TOgSP7VPUA"],
-        "issued_at": "2018-08-03T19:40:43.009915Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GunoYCbwSni6DAQdBYoj_w"],
+        "issued_at": "2018-08-06T16:54:25.104759Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33668,15 +31966,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:43 GMT
+      - Mon, 06 Aug 2018 16:54:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3d5e79e0ddfe4e78a50925363914968f
+      - 5f41dfae1704404aaacf2f1ce7b99f63
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-084f892d-ce88-4781-b904-abaa8d779c66
+      - req-a03bedce-32ce-4cc8-ad83-839b48bab03c
       Content-Length:
       - '7311'
       Connection:
@@ -33688,7 +31986,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:43.481941Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:25.446430Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33767,10 +32065,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uc7aDElLQLa71qYQzCeUig"],
-        "issued_at": "2018-08-03T19:40:43.482021Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3v3o2xlMQLGTZqOMNG2YOw"],
+        "issued_at": "2018-08-06T16:54:25.446505Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33788,15 +32086,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:43 GMT
+      - Mon, 06 Aug 2018 16:54:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aa282b6cf79c4cadb99078b69ba2ded8
+      - 12ee7c0a4f09430180d65f197ea9396b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eaae9c91-4a7a-4e8d-adc4-5be435f7a549
+      - req-8c991c09-0275-4dec-8d59-42dd31ca6542
       Content-Length:
       - '297'
       Connection:
@@ -33805,12 +32103,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:40:43.908631Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:25.671776Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3FmWYDo4Q_mYAUIchVWcDQ"],
-        "issued_at": "2018-08-03T19:40:43.908696Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Uj-qu3sQUC-oFE-n4H2Ug"],
+        "issued_at": "2018-08-06T16:54:25.671837Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -33825,20 +32123,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa282b6cf79c4cadb99078b69ba2ded8
+      - 12ee7c0a4f09430180d65f197ea9396b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:44 GMT
+      - Mon, 06 Aug 2018 16:54:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a32b9334-9728-4eb2-a02a-a7442339dcc3
+      - req-fc3e4093-2559-46cb-bdd0-98fe22ddd47f
       Content-Length:
       - '2457'
       Connection:
@@ -33871,13 +32169,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"aa282b6cf79c4cadb99078b69ba2ded8"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"12ee7c0a4f09430180d65f197ea9396b"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33889,15 +32187,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:44 GMT
+      - Mon, 06 Aug 2018 16:54:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9af7169170ea4b99889f81a1c8ac36f5
+      - 01bba11a893649daa1230ddf589617e7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-08cf4e51-81db-4349-a2a2-291f69452cd5
+      - req-21bcbebb-33e7-42aa-a3dd-57ca88d8a54a
       Content-Length:
       - '7313'
       Connection:
@@ -33909,7 +32207,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:43.908631Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:25.671776Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33988,10 +32286,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cj1Wx6itSLKr2D0AsUVmsg",
-        "3FmWYDo4Q_mYAUIchVWcDQ"], "issued_at": "2018-08-03T19:40:44.392672Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J4--wvYdQlydCuq70Y5EQw",
+        "2Uj-qu3sQUC-oFE-n4H2Ug"], "issued_at": "2018-08-06T16:54:26.124872Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -34006,20 +32304,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af7169170ea4b99889f81a1c8ac36f5
+      - 01bba11a893649daa1230ddf589617e7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:44 GMT
+      - Mon, 06 Aug 2018 16:54:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-913aff95-0524-4201-9914-304429c49040
+      - req-0402aaf4-fdaf-48dc-a867-04defdf4ecb6
       Content-Length:
       - '2179'
       Connection:
@@ -34052,7 +32350,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34070,15 +32368,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:44 GMT
+      - Mon, 06 Aug 2018 16:54:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2d48576a1c64b3e8d79f4f3c6cf87eb
+      - 6c9524ee68064750a24edaa49a2d57b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-243ccefb-0efa-4f05-b829-d6e82e3279ff
+      - req-2594de80-1907-442d-8f9c-8f3e2d19cb30
       Content-Length:
       - '7278'
       Connection:
@@ -34090,7 +32388,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:44.876184Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:26.650738Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34169,10 +32467,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QGsYcXsJS4qaT1ZCfe9bCw"],
-        "issued_at": "2018-08-03T19:40:44.876255Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6clBl68HT92wdXOrtOJNRw"],
+        "issued_at": "2018-08-06T16:54:26.650824Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34190,15 +32488,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:45 GMT
+      - Mon, 06 Aug 2018 16:54:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 055f58af76944363a86bd9677ffd52e8
+      - 13d7a1e13d984c818c7be60a2a526854
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a9bbc15d-daec-49b1-815d-757c8752bb86
+      - req-31813316-782d-4ff1-b96e-9e2044bcfa05
       Content-Length:
       - '7278'
       Connection:
@@ -34210,7 +32508,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:45.320222Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:27.073856Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34289,10 +32587,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eGDCwMFwSWifjxAXJR0hCg"],
-        "issued_at": "2018-08-03T19:40:45.320302Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0brqCPhoSTSGAH5OPNvolA"],
+        "issued_at": "2018-08-06T16:54:27.073930Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34310,15 +32608,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:45 GMT
+      - Mon, 06 Aug 2018 16:54:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 779aa7e2074e4bed9dffa41f9bf5a608
+      - b6cf9523bcc1432ab87cec9f4fefac86
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aeaf34ae-cbba-4c19-a17d-d113f01a4f88
+      - req-0aa5d57d-5358-442e-a5d2-436dcf205163
       Content-Length:
       - '7264'
       Connection:
@@ -34330,7 +32628,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:45.668000Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:27.459982Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34409,10 +32707,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ga4zn47wRjGlKb4graIq1Q"],
-        "issued_at": "2018-08-03T19:40:45.668078Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gKWULFSPQeCbnHIYtN4Evg"],
+        "issued_at": "2018-08-06T16:54:27.460047Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34430,15 +32728,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:45 GMT
+      - Mon, 06 Aug 2018 16:54:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 789397831dfa45d5a235cfe1356ac52b
+      - 4fbf35750fb84ea5b46c05957cf33d3f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-41bb0b47-b886-4df3-adf7-400f17b2af32
+      - req-d3b6c88e-c4d2-487f-87ca-7bb387457f8c
       Content-Length:
       - '7278'
       Connection:
@@ -34450,7 +32748,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:46.002217Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:27.776413Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34529,10 +32827,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1Q1vPeqsQIWNh54UoyBzHQ"],
-        "issued_at": "2018-08-03T19:40:46.002283Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xt8L4njbR5uATYoK8pZr8A"],
+        "issued_at": "2018-08-06T16:54:27.776471Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34550,15 +32848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:46 GMT
+      - Mon, 06 Aug 2018 16:54:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b03ccec3a522486cb1f049be5e2e0a30
+      - 933383b244504485b0d593c02b7217b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ed5e0ac-daea-4b6c-9c82-e51372835f2c
+      - req-0e41d699-5101-4127-bd3a-2cbf1c3ab3a6
       Content-Length:
       - '7265'
       Connection:
@@ -34570,7 +32868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:46.371638Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:28.192478Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34649,10 +32947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hVWn0XZkQAeWHXQchCD9rQ"],
-        "issued_at": "2018-08-03T19:40:46.371711Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rTF-aDhgSFa38ZkO8RClfQ"],
+        "issued_at": "2018-08-06T16:54:28.192553Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34670,15 +32968,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:46 GMT
+      - Mon, 06 Aug 2018 16:54:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 833e8585bf1841cbb0b5e3f1a5bba02b
+      - 2941ca839c2b41df8ce239e35b78d49b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-84720eb4-e5cd-4cbf-aa99-86505b5e0801
+      - req-9e4f4c62-95a6-45bb-b202-d67f7d1de2e2
       Content-Length:
       - '7278'
       Connection:
@@ -34690,7 +32988,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:46.708996Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:28.626285Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34769,10 +33067,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sX9fsY-IQ0a_6IwL29P0mA"],
-        "issued_at": "2018-08-03T19:40:46.709064Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hUZ_SNkjR1OSL7blJ92dYQ"],
+        "issued_at": "2018-08-06T16:54:28.626393Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34790,15 +33088,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:46 GMT
+      - Mon, 06 Aug 2018 16:54:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2e55e8c2e9940a2b16702578ede5e4f
+      - e2d30d75efdc4bf8abac426dfb0f0cd8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b7a063cc-1fb6-4d42-8595-7e657aaddc93
+      - req-b6dbdfce-15a9-43ac-8974-cac816742fb3
       Content-Length:
       - '7278'
       Connection:
@@ -34810,7 +33108,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:47.115647Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:29.027534Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34889,10 +33187,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QAdgs9J6Rr-UH6fNEe-8ow"],
-        "issued_at": "2018-08-03T19:40:47.115777Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["83DFOkHdSZ6NGcAvCXNqMA"],
+        "issued_at": "2018-08-06T16:54:29.027598Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -34907,7 +33205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2e55e8c2e9940a2b16702578ede5e4f
+      - e2d30d75efdc4bf8abac426dfb0f0cd8
   response:
     status:
       code: 200
@@ -34920,22 +33218,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325247.54355'
+      - '1533574469.20414'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325247.54355'
+      - '1533574469.20414'
       X-Trans-Id:
-      - tx7d448b1fd981454a9dc45-005b64afbf
+      - tx65898532fb294e2f98332-005b687d45
       Date:
-      - Fri, 03 Aug 2018 19:40:47 GMT
+      - Mon, 06 Aug 2018 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34953,15 +33251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:47 GMT
+      - Mon, 06 Aug 2018 16:54:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8ab234ce47b649e683303a0aa2328d0f
+      - 226d96d2ad6b4320acc122a4c6413170
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8d36853b-45ae-4a30-b053-52e66a24e529
+      - req-1970e370-f3f0-4ecf-a914-3965b7d201ec
       Content-Length:
       - '7278'
       Connection:
@@ -34973,7 +33271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:47.832411Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:29.501463Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -35052,10 +33350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OCRxF87zR7iTZQFHaoVQ7w"],
-        "issued_at": "2018-08-03T19:40:47.832505Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pAEwVMCWSZ-fwIMClEUkUg"],
+        "issued_at": "2018-08-06T16:54:29.501528Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -35070,7 +33368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab234ce47b649e683303a0aa2328d0f
+      - 226d96d2ad6b4320acc122a4c6413170
   response:
     status:
       code: 200
@@ -35083,22 +33381,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325248.03697'
+      - '1533574469.72104'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325248.03697'
+      - '1533574469.72104'
       X-Trans-Id:
-      - tx50b5e236e3544c919bc99-005b64afbf
+      - tx85b602f9f98e485eb43ce-005b687d45
       Date:
-      - Fri, 03 Aug 2018 19:40:48 GMT
+      - Mon, 06 Aug 2018 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -35116,15 +33414,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:48 GMT
+      - Mon, 06 Aug 2018 16:54:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f08c2a6-b9a7-4c1f-a341-c2ed5f1f561f
+      - req-21d0725a-3162-4cd2-95dc-29258033436f
       Content-Length:
       - '7264'
       Connection:
@@ -35136,7 +33434,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:48.366688Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:30.133916Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -35215,10 +33513,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pb_uKDURQOekBtF57qOa-Q"],
-        "issued_at": "2018-08-03T19:40:48.366785Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P8ASFKzASCqlPSqjjOAbpw"],
+        "issued_at": "2018-08-06T16:54:30.134029Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -35233,7 +33531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
   response:
     status:
       code: 200
@@ -35262,15 +33560,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx154623a3771c4942b941d-005b64afc0
+      - txc7f67334760a4d9797fb1-005b687d46
       Date:
-      - Fri, 03 Aug 2018 19:40:48 GMT
+      - Mon, 06 Aug 2018 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -35285,7 +33583,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
   response:
     status:
       code: 200
@@ -35314,14 +33612,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx1e5d96dcea8f4946b6034-005b64afc0
+      - txba1f881adabe431ca2c18-005b687d46
       Date:
-      - Fri, 03 Aug 2018 19:40:48 GMT
+      - Mon, 06 Aug 2018 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -35339,15 +33637,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:48 GMT
+      - Mon, 06 Aug 2018 16:54:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ab06563dfed94003bc4de5d0b024eac3
+      - 110eeda9281143b8ab7376d4ed7b69b9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c7df7a1-de53-4b7b-90c4-f2460e0d618d
+      - req-130baa50-3bd5-4459-bc84-922d22f84c38
       Content-Length:
       - '7278'
       Connection:
@@ -35359,7 +33657,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:49.048574Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:30.787419Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -35438,10 +33736,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P1XYL2AmQIyTZHfrUJkN8Q"],
-        "issued_at": "2018-08-03T19:40:49.048660Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5uGolzcUR5W6qoiIc-BRUw"],
+        "issued_at": "2018-08-06T16:54:30.787495Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -35456,7 +33754,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab06563dfed94003bc4de5d0b024eac3
+      - 110eeda9281143b8ab7376d4ed7b69b9
   response:
     status:
       code: 200
@@ -35469,22 +33767,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325249.29859'
+      - '1533574471.02363'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325249.29859'
+      - '1533574471.02363'
       X-Trans-Id:
-      - txada9e7a12bad4396aa71b-005b64afc1
+      - tx6faff2f7e3da432094386-005b687d46
       Date:
-      - Fri, 03 Aug 2018 19:40:49 GMT
+      - Mon, 06 Aug 2018 16:54:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -35499,7 +33797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d5e79e0ddfe4e78a50925363914968f
+      - 5f41dfae1704404aaacf2f1ce7b99f63
   response:
     status:
       code: 200
@@ -35512,22 +33810,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325249.80215'
+      - '1533574471.18823'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325249.80215'
+      - '1533574471.18823'
       X-Trans-Id:
-      - tx607bac8623d84e449004b-005b64afc1
+      - tx707061583e754487a3325-005b687d47
       Date:
-      - Fri, 03 Aug 2018 19:40:49 GMT
+      - Mon, 06 Aug 2018 16:54:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -35545,15 +33843,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:49 GMT
+      - Mon, 06 Aug 2018 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63d74d498f2d40c89b9ca0ab28d5eacd
+      - 9dde1c6d9e394caeb7954c01e098aa2e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-18961e43-cfb6-4c7c-88db-2bbabc6a0a34
+      - req-f0c6d187-e50e-47b1-a67b-4bce49daa6da
       Content-Length:
       - '7265'
       Connection:
@@ -35565,7 +33863,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:50.121214Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:31.503962Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -35644,10 +33942,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9qPdc7PFQyGFrw2Pc65qGA"],
-        "issued_at": "2018-08-03T19:40:50.121288Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O2GbHKxsTna_ITs0MTYKMg"],
+        "issued_at": "2018-08-06T16:54:31.504061Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -35662,7 +33960,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63d74d498f2d40c89b9ca0ab28d5eacd
+      - 9dde1c6d9e394caeb7954c01e098aa2e
   response:
     status:
       code: 200
@@ -35675,22 +33973,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325250.32997'
+      - '1533574471.70282'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325250.32997'
+      - '1533574471.70282'
       X-Trans-Id:
-      - tx7f0178ed3db943a2a3fa0-005b64afc2
+      - tx0d88ec0b13d845058d4fa-005b687d47
       Date:
-      - Fri, 03 Aug 2018 19:40:50 GMT
+      - Mon, 06 Aug 2018 16:54:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -35708,15 +34006,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:50 GMT
+      - Mon, 06 Aug 2018 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a965a960da2f482484afa5798042964f
+      - 3c098d6649924d74a47dfe13a09d657e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bfc25158-3a3b-4c7c-8a3d-e152fa55a981
+      - req-cbc54c16-6a51-4c18-9ad3-18fee2904566
       Content-Length:
       - '7278'
       Connection:
@@ -35728,7 +34026,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:40:50.655284Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:32.032267Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -35807,10 +34105,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oAIAu_myTqelsTR11udobQ"],
-        "issued_at": "2018-08-03T19:40:50.655353Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MDJgQE6cTcqSHAB3bhLywg"],
+        "issued_at": "2018-08-06T16:54:32.032336Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -35825,7 +34123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a965a960da2f482484afa5798042964f
+      - 3c098d6649924d74a47dfe13a09d657e
   response:
     status:
       code: 200
@@ -35838,22 +34136,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325250.87437'
+      - '1533574472.22998'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325250.87437'
+      - '1533574472.22998'
       X-Trans-Id:
-      - txa5a43b34945b4e7095fcf-005b64afc2
+      - tx3fde4219a4254d949c228-005b687d48
       Date:
-      - Fri, 03 Aug 2018 19:40:50 GMT
+      - Mon, 06 Aug 2018 16:54:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -35868,7 +34166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
   response:
     status:
       code: 200
@@ -35889,9 +34187,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx334f3a9f5232457fb140a-005b64afc2
+      - tx43d846e0a4634e6d812f0-005b687d48
       Date:
-      - Fri, 03 Aug 2018 19:40:50 GMT
+      - Mon, 06 Aug 2018 16:54:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -35901,7 +34199,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -35916,7 +34214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
   response:
     status:
       code: 200
@@ -35937,14 +34235,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx996b5b2b6604499cbeb06-005b64afc3
+      - tx2744b61d9e914612a7868-005b687d48
       Date:
-      - Fri, 03 Aug 2018 19:40:51 GMT
+      - Mon, 06 Aug 2018 16:54:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -35959,7 +34257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 384197cf9c8b456aa6e3e1530dd8d920
+      - fe6a04e76e0e488a8fccb65f9d55cd1e
   response:
     status:
       code: 200
@@ -35980,12 +34278,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txe8508f1997e94acf91aa4-005b64afc3
+      - tx54e0701a08fc429b85058-005b687d48
       Date:
-      - Fri, 03 Aug 2018 19:40:51 GMT
+      - Mon, 06 Aug 2018 16:54:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:11 GMT
+      - Mon, 06 Aug 2018 16:54:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd17d79e-0597-416d-87b3-3679c4a04518
+      - req-565bb955-e191-4224-ac00-ba3c454be20b
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:11.580644Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:44.965810Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["164OsJU2TVO6eeWmHJ8KVA"],
-        "issued_at": "2018-08-03T19:42:11.580749Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GITwMhR8Qsi5lCf4qAZBsQ"],
+        "issued_at": "2018-08-06T16:54:44.965877Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:11 GMT
+      - Mon, 06 Aug 2018 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-2662b3b8-007a-40f7-bd30-8ac407cbcf65
+      - req-eb0d4313-2e4e-4019-b035-dc80299671e4
       Date:
-      - Fri, 03 Aug 2018 19:42:11 GMT
+      - Mon, 06 Aug 2018 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:12 GMT
+      - Mon, 06 Aug 2018 16:54:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd15f520-60a0-4707-8e00-ed05af47d622
+      - req-01a43672-317a-451d-b851-62481619b536
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:12.241511Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:45.897600Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8XGIuVJ2QTu65qmnS8qcqg"],
-        "issued_at": "2018-08-03T19:42:12.241579Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wnf-leVZSayT6sS8avKdoA"],
+        "issued_at": "2018-08-06T16:54:45.897663Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b43c72dd-72c5-4de0-823c-0da471a5fb70
+      - req-ef17c13e-90a8-4a69-abe4-cae7a64cc110
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-b43c72dd-72c5-4de0-823c-0da471a5fb70
+      - req-ef17c13e-90a8-4a69-abe4-cae7a64cc110
       Date:
-      - Fri, 03 Aug 2018 19:42:12 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-5940af02-be86-452f-b377-f463445f3bb5
+      - req-a130ad85-aeaf-4be6-9b02-1d85c8761fa7
       Date:
-      - Fri, 03 Aug 2018 19:42:12 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:42:03.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:54:45.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:42:08.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:54:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:42:08.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:54:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:42:03.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:54:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:42:03.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:54:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-426a9239-4932-4c96-bd67-ea2cdf60b978
+      - req-71b19838-2371-409a-9903-589a618ca9e0
       Date:
-      - Fri, 03 Aug 2018 19:42:12 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:42:03.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:54:45.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:42:08.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:54:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:42:08.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:54:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:42:03.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:54:38.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:42:03.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:54:38.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-4ee28cd5-a883-43ee-88ae-874b36b99c7f
+      - req-703e4d47-ae41-474b-8539-aa823c02af09
       Date:
-      - Fri, 03 Aug 2018 19:42:13 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-7d13e1a9-a70e-40ed-82cc-fadf6efed98c
+      - req-57fc9f56-a742-4b94-814b-bd44c920b2f6
       Date:
-      - Fri, 03 Aug 2018 19:42:13 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-25e8263f-fed9-46cf-954d-c5f0c5fbed50
+      - req-96eb09e1-d9b7-42a0-b3da-67efbae9e5b1
       Date:
-      - Fri, 03 Aug 2018 19:42:13 GMT
+      - Mon, 06 Aug 2018 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-9f80407d-05a9-4e7d-9015-b0b8b70696c6
+      - req-5acf9a2b-054b-4d89-95ca-3c6755ba532d
       Date:
-      - Fri, 03 Aug 2018 19:42:13 GMT
+      - Mon, 06 Aug 2018 16:54:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +613,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:13 GMT
+      - Mon, 06 Aug 2018 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bedc257b366f4ff189daf56b4bfbc3d6
+      - 03ca8c04352340efaaddfa07ca9b8037
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-52e0cdd0-2217-4b2c-8b5c-28f7ff7d88bd
+      - req-d0405d2a-fa74-4673-a9f3-2a3352e3c12b
       Content-Length:
       - '7311'
       Connection:
@@ -651,7 +651,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:13.943899Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:47.455958Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -730,10 +730,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ajTYzmw8RTe94UNz-FwoJA"],
-        "issued_at": "2018-08-03T19:42:13.943970Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2v2thBMKRS6HnfwgO3WQKQ"],
+        "issued_at": "2018-08-06T16:54:47.456028Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -748,20 +748,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bedc257b366f4ff189daf56b4bfbc3d6
+      - 03ca8c04352340efaaddfa07ca9b8037
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:14 GMT
+      - Mon, 06 Aug 2018 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04538c59-6407-4085-8cf5-0c02a6373eba
+      - req-7b25d850-6041-482a-801f-bc36a93a5835
       Content-Length:
       - '2179'
       Connection:
@@ -794,7 +794,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -809,7 +809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -822,15 +822,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-c2002f9d-8c8f-4b11-b8f1-61cfc660c815
+      - req-7629b8f6-2f5f-4718-8ad8-6e6184e8d82b
       Date:
-      - Fri, 03 Aug 2018 19:42:14 GMT
+      - Mon, 06 Aug 2018 16:54:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -848,15 +848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:14 GMT
+      - Mon, 06 Aug 2018 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ce05119eb5a94bea9a4eeb2f935cedd4
+      - c4a6788b02de4494ac41b376a488cad9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7b11671e-8e86-4e94-a610-7fa51e68a98e
+      - req-d3fa0f26-4027-4371-86fe-1b05d7ea934e
       Content-Length:
       - '7311'
       Connection:
@@ -868,7 +868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:14.560144Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:48.087404Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -947,10 +947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QUqMMI5PRKKfcZFaLD1g3g"],
-        "issued_at": "2018-08-03T19:42:14.560227Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4NG_5kIvRbWvG8IcLOzFRA"],
+        "issued_at": "2018-08-06T16:54:48.087466Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -965,7 +965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce05119eb5a94bea9a4eeb2f935cedd4
+      - c4a6788b02de4494ac41b376a488cad9
   response:
     status:
       code: 300
@@ -976,7 +976,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:42:14 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -989,7 +989,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce05119eb5a94bea9a4eeb2f935cedd4
+      - c4a6788b02de4494ac41b376a488cad9
   response:
     status:
       code: 200
@@ -1015,14 +1015,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-96183301-a62f-45ee-8734-55057f7a7244
+      - req-7c69eefd-0260-4ebd-9fab-923cef29e640
       Date:
-      - Fri, 03 Aug 2018 19:42:14 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce05119eb5a94bea9a4eeb2f935cedd4
+      - c4a6788b02de4494ac41b376a488cad9
   response:
     status:
       code: 200
@@ -1048,9 +1048,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-45446c1c-7921-46a5-9d20-eb48e8b80ab5
+      - req-4b7b0ed2-b1d9-47d4-b306-3885c2e2e800
       Date:
-      - Fri, 03 Aug 2018 19:42:15 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1092,7 +1092,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -1107,7 +1107,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1120,9 +1120,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-810290d8-5303-4c11-9508-d794de400095
+      - req-96e648ff-b7eb-4722-92ce-f416426ffec4
       Date:
-      - Fri, 03 Aug 2018 19:42:15 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1132,7 +1132,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1147,7 +1147,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1160,9 +1160,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-0bf68b05-4319-46a1-8dee-feb5a01418f6
+      - req-09b7ed44-900e-418f-af2c-d0915b45dc3f
       Date:
-      - Fri, 03 Aug 2018 19:42:15 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1172,7 +1172,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1190,15 +1190,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:15 GMT
+      - Mon, 06 Aug 2018 16:54:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33d233c776c7420ca771c3ca87591101
+      - 71d4fee230d84c0a9ba04ac1d8198213
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-06b06aa5-ea3c-4ed0-b44f-64dec70448fd
+      - req-949a9a4a-2ac0-417d-b9fa-449b52095b1a
       Content-Length:
       - '7311'
       Connection:
@@ -1210,7 +1210,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:15.687406Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:49.121628Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1289,10 +1289,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j9Aj0nhPSfOo1AjW7OhT0w"],
-        "issued_at": "2018-08-03T19:42:15.687480Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9NvBg0KcTE6X0eJZ_N5PAQ"],
+        "issued_at": "2018-08-06T16:54:49.121703Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1310,15 +1310,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:15 GMT
+      - Mon, 06 Aug 2018 16:54:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 23ebdc1bdf10483ba2d27511ae5a4247
+      - 7cea50d7f3d34956b727764f627e9300
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-97cc9f91-b1e2-4845-9892-aa17c23b595c
+      - req-bc541d79-633b-4556-be6b-e228c6830838
       Content-Length:
       - '297'
       Connection:
@@ -1327,12 +1327,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:42:15.921730Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:49.529821Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4549t1LmR1-XmN43f2mj4Q"],
-        "issued_at": "2018-08-03T19:42:15.921791Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vGUY-04QQrWF1-uhr19HCg"],
+        "issued_at": "2018-08-06T16:54:49.529883Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1347,20 +1347,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23ebdc1bdf10483ba2d27511ae5a4247
+      - 7cea50d7f3d34956b727764f627e9300
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:16 GMT
+      - Mon, 06 Aug 2018 16:54:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-05f411c0-06b5-4b4d-a43e-a61db9883043
+      - req-eed7fad4-d5b5-486f-ae73-8718a2186005
       Content-Length:
       - '2457'
       Connection:
@@ -1393,13 +1393,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"23ebdc1bdf10483ba2d27511ae5a4247"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7cea50d7f3d34956b727764f627e9300"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1411,15 +1411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:16 GMT
+      - Mon, 06 Aug 2018 16:54:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e35fae1a2e64ab48db357320a163f88
+      - 43f4bb52b7a343ee87abf95ccb7b7790
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5152b57-4e7e-410f-a68e-1d6df11acca3
+      - req-2787c1d6-aab0-454b-b75c-9108dc90269c
       Content-Length:
       - '7313'
       Connection:
@@ -1431,7 +1431,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:15.921730Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:49.529821Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1510,10 +1510,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XOx8nsY_RO6mY060tS5FkQ",
-        "4549t1LmR1-XmN43f2mj4Q"], "issued_at": "2018-08-03T19:42:16.356525Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ARkP0QgGSgm3sI1yaoaK4w",
+        "vGUY-04QQrWF1-uhr19HCg"], "issued_at": "2018-08-06T16:54:49.959876Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1528,20 +1528,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e35fae1a2e64ab48db357320a163f88
+      - 43f4bb52b7a343ee87abf95ccb7b7790
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:16 GMT
+      - Mon, 06 Aug 2018 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86d9f6e7-0ede-47a7-b2ec-b366853a42ed
+      - req-167e0456-394b-418c-94ee-1ad18a4ac4cd
       Content-Length:
       - '2179'
       Connection:
@@ -1574,7 +1574,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1592,15 +1592,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:16 GMT
+      - Mon, 06 Aug 2018 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - add368e4b9ca4b4b87ce89d560dc9a53
+      - 8b55ee42859f4557be39a20a50e2a785
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c17f9d29-f066-4c7a-b7e4-7f4768669f8c
+      - req-b43cdfb1-c9d9-47e1-a850-ef860813fd09
       Content-Length:
       - '7278'
       Connection:
@@ -1612,7 +1612,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:16.834322Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:50.424884Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1691,10 +1691,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hK2Fzs3UQKGHVszhGXjLSg"],
-        "issued_at": "2018-08-03T19:42:16.834432Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1j_gBB9xTc6IVGozY_phrA"],
+        "issued_at": "2018-08-06T16:54:50.425010Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1709,7 +1709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add368e4b9ca4b4b87ce89d560dc9a53
+      - 8b55ee42859f4557be39a20a50e2a785
   response:
     status:
       code: 200
@@ -1720,7 +1720,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:16 GMT
+      - Mon, 06 Aug 2018 16:54:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1729,7 +1729,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1747,15 +1747,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:17 GMT
+      - Mon, 06 Aug 2018 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3a5c394449334863aac9603eaa0d549f
+      - afe2c03bbe7c460fa92b0632e1e38814
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-186133ae-4bde-4d3f-886f-58ea99ac228b
+      - req-e0ceb776-9c2a-4eaf-9249-f15a55ddc81e
       Content-Length:
       - '7278'
       Connection:
@@ -1767,7 +1767,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:17.313194Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:50.910750Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1846,10 +1846,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6kOv6GmMTqiJMN9u2oZMIw"],
-        "issued_at": "2018-08-03T19:42:17.313274Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oYyHN11HQgy0jOK_DJLKqA"],
+        "issued_at": "2018-08-06T16:54:50.910829Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1864,7 +1864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5c394449334863aac9603eaa0d549f
+      - afe2c03bbe7c460fa92b0632e1e38814
   response:
     status:
       code: 200
@@ -1875,7 +1875,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:17 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1884,7 +1884,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1902,15 +1902,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:17 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b665cfb5b16348e99a022fc7153dd66d
+      - 27fe85ced827483780124d88bf7a1796
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-93656495-884d-4ed3-82f4-8257ba036c57
+      - req-6e1c436d-3e8e-449b-ba76-dda4319329c8
       Content-Length:
       - '7264'
       Connection:
@@ -1922,7 +1922,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:17.726943Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:51.321384Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2001,10 +2001,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yrJzUAEoQjqcQFYiAsdiyw"],
-        "issued_at": "2018-08-03T19:42:17.727009Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g9UnY-wrSSeCGSCVQgu5HQ"],
+        "issued_at": "2018-08-06T16:54:51.321450Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2019,7 +2019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b665cfb5b16348e99a022fc7153dd66d
+      - 27fe85ced827483780124d88bf7a1796
   response:
     status:
       code: 200
@@ -2030,7 +2030,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:17 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2039,7 +2039,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2057,15 +2057,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:17 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f39dadc91bbd4791990d13ed35b0c78b
+      - 10ff7d8ffaf949299d29a390328b1fe1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-834231b3-0179-499f-9e12-0a2619fa126a
+      - req-c76481f7-5fa6-40bf-b0d9-99f1fbbb868b
       Content-Length:
       - '7278'
       Connection:
@@ -2077,7 +2077,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:18.129416Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:51.726842Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2156,10 +2156,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["98osIo89QdCh1K9rHcsUug"],
-        "issued_at": "2018-08-03T19:42:18.129494Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RiAmXRTjQdqSp--2-9M1qQ"],
+        "issued_at": "2018-08-06T16:54:51.726908Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2174,7 +2174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f39dadc91bbd4791990d13ed35b0c78b
+      - 10ff7d8ffaf949299d29a390328b1fe1
   response:
     status:
       code: 200
@@ -2185,7 +2185,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:18 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2194,7 +2194,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2212,15 +2212,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:18 GMT
+      - Mon, 06 Aug 2018 16:54:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb4544e53c5145dab6e313a32738f4cc
+      - fc2c3680ce834e5b8eaa86f2f4d55a2d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-70d15415-1acc-4d6f-ae32-686893889d54
+      - req-121e4f05-5c4c-4b36-a754-c9613f168c0f
       Content-Length:
       - '7265'
       Connection:
@@ -2232,7 +2232,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:18.544608Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:52.166659Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2311,10 +2311,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PtGGkq1-QVaupDQxOUqF7g"],
-        "issued_at": "2018-08-03T19:42:18.544687Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uAqDV0EHTtKodjY3ymqZMQ"],
+        "issued_at": "2018-08-06T16:54:52.166731Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2329,7 +2329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb4544e53c5145dab6e313a32738f4cc
+      - fc2c3680ce834e5b8eaa86f2f4d55a2d
   response:
     status:
       code: 200
@@ -2340,7 +2340,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:18 GMT
+      - Mon, 06 Aug 2018 16:54:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2349,7 +2349,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2367,15 +2367,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:18 GMT
+      - Mon, 06 Aug 2018 16:54:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bfae80139d8b4604864a023f36e5aec4
+      - 89fa97a588bb491dacb58a8ef4605ae2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f6373ef9-93c0-4bc2-8bb6-5c3c967f908d
+      - req-ff9bcb31-e28d-42be-96cc-9bb2e5d6b124
       Content-Length:
       - '7278'
       Connection:
@@ -2387,7 +2387,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:18.964588Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:52.668646Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2466,10 +2466,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vCKEhfa7RjWAKTbJ-UwMrg"],
-        "issued_at": "2018-08-03T19:42:18.964664Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fDvsbwoCRXqS6FJFV1xb1w"],
+        "issued_at": "2018-08-06T16:54:52.668728Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2484,7 +2484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfae80139d8b4604864a023f36e5aec4
+      - 89fa97a588bb491dacb58a8ef4605ae2
   response:
     status:
       code: 200
@@ -2495,7 +2495,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:42:19 GMT
+      - Mon, 06 Aug 2018 16:54:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2504,7 +2504,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2522,15 +2522,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:19 GMT
+      - Mon, 06 Aug 2018 16:54:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b35fe0c254f49a9be923c03ffc5fefd
+      - 67e07c7c486641528d5ca2a5aa07cbb8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9b0c91bf-1012-48e4-a4d6-2fe4c1d2f9e1
+      - req-1f69d7e7-e728-4700-a649-606f770bfc34
       Content-Length:
       - '7278'
       Connection:
@@ -2542,7 +2542,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:19.405988Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:53.098253Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2621,10 +2621,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XPZc4wwuQ2-kE8s_y_MdFA"],
-        "issued_at": "2018-08-03T19:42:19.406057Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9GDa6LPjTaSC4PfwPA2SHg"],
+        "issued_at": "2018-08-06T16:54:53.098339Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -2639,7 +2639,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b35fe0c254f49a9be923c03ffc5fefd
+      - 67e07c7c486641528d5ca2a5aa07cbb8
   response:
     status:
       code: 200
@@ -2650,14 +2650,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ec5b11ee-d8f9-4a5a-bf51-4f2393174b68
+      - req-7a6ddd0c-e4dc-4b51-b28c-76b69fa0f840
       Date:
-      - Fri, 03 Aug 2018 19:42:19 GMT
+      - Mon, 06 Aug 2018 16:54:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2675,15 +2675,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:19 GMT
+      - Mon, 06 Aug 2018 16:54:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 656afc87c4854b0aadab2318050d851c
+      - d9f2ad7c419c463d8971aac6695236f1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-45c78ea0-4a9a-44a2-97a3-bce20c5a00d7
+      - req-bc83d641-37f7-442e-a8bb-f4fd49e85349
       Content-Length:
       - '7278'
       Connection:
@@ -2695,7 +2695,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:19.976423Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:53.760006Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2774,10 +2774,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r_QsDHm3T9OJ0dNOwROHtw"],
-        "issued_at": "2018-08-03T19:42:19.976487Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UNN-vKqoQL2wVRMZPr0xFg"],
+        "issued_at": "2018-08-06T16:54:53.760073Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -2792,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 656afc87c4854b0aadab2318050d851c
+      - d9f2ad7c419c463d8971aac6695236f1
   response:
     status:
       code: 200
@@ -2803,14 +2803,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-501bcb10-d3ef-4e77-a0f2-e88ff8ca23a7
+      - req-250839eb-b02d-41af-aa35-4fcca64cb5ad
       Date:
-      - Fri, 03 Aug 2018 19:42:20 GMT
+      - Mon, 06 Aug 2018 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2828,15 +2828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:20 GMT
+      - Mon, 06 Aug 2018 16:54:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c21711e-62fb-4e19-999c-6e66f5be8fc1
+      - req-26742d4a-a3c1-434d-8dc7-b549bf33e698
       Content-Length:
       - '7264'
       Connection:
@@ -2848,7 +2848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:20.645090Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:54.690715Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2927,10 +2927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["87HY4uzmTYe1lrBgfDNCaw"],
-        "issued_at": "2018-08-03T19:42:20.645211Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o12L5zpZS7iZBIVOu0QBVg"],
+        "issued_at": "2018-08-06T16:54:54.690792Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -2945,7 +2945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -2956,9 +2956,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-94fa7851-a05c-427a-84c6-3d40608f9639
+      - req-089e81e5-7d3d-40d8-8de8-802c4c20383b
       Date:
-      - Fri, 03 Aug 2018 19:42:20 GMT
+      - Mon, 06 Aug 2018 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2992,7 +2992,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -3007,7 +3007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3018,14 +3018,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d190008a-e909-478c-845c-d0af47c13fbf
+      - req-8e283f2f-a093-4544-8bb8-75b892f3aecc
       Date:
-      - Fri, 03 Aug 2018 19:42:21 GMT
+      - Mon, 06 Aug 2018 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3043,15 +3043,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:21 GMT
+      - Mon, 06 Aug 2018 16:54:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 00b109849e8e4b1f86988a8c1fbd043a
+      - f0a200f36eee44a29fc2e9bb92b7388c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ccab0563-d30b-499f-9237-f8c5f2e82104
+      - req-7efce0cd-9a2b-4c06-b389-19c4bd6d66b1
       Content-Length:
       - '7278'
       Connection:
@@ -3063,7 +3063,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:21.501645Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:55.568163Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3142,10 +3142,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sjdqiv0vTwKkhT_smKzgYQ"],
-        "issued_at": "2018-08-03T19:42:21.501734Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xe6CHYeHQr-mfz7wkk46-g"],
+        "issued_at": "2018-08-06T16:54:55.568231Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -3160,7 +3160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00b109849e8e4b1f86988a8c1fbd043a
+      - f0a200f36eee44a29fc2e9bb92b7388c
   response:
     status:
       code: 200
@@ -3171,14 +3171,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2f716a78-6e0a-479f-a6ce-19e15fea3109
+      - req-a2660004-7a0b-4095-ad72-6413403b0e0e
       Date:
-      - Fri, 03 Aug 2018 19:42:21 GMT
+      - Mon, 06 Aug 2018 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -3193,7 +3193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33d233c776c7420ca771c3ca87591101
+      - 71d4fee230d84c0a9ba04ac1d8198213
   response:
     status:
       code: 200
@@ -3204,14 +3204,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-068ad957-9126-4432-af15-986f6756b791
+      - req-a2330195-9388-46a4-8832-c55a1d882114
       Date:
-      - Fri, 03 Aug 2018 19:42:21 GMT
+      - Mon, 06 Aug 2018 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3229,15 +3229,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:22 GMT
+      - Mon, 06 Aug 2018 16:54:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2a5ef0189bcd47068746f3aee3ec3597
+      - 3f750e1ca4e848eda3d126c719daaae1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4324ae81-34f1-4705-a40c-db04749e72fc
+      - req-ded48649-426e-41d0-98ab-f3220e4e66d4
       Content-Length:
       - '7265'
       Connection:
@@ -3249,7 +3249,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:22.240574Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:56.335295Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3328,10 +3328,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0LUj6saWRmCWPPpr-YpuzQ"],
-        "issued_at": "2018-08-03T19:42:22.240644Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2-qCnk5JRqOmDclkHpR3JA"],
+        "issued_at": "2018-08-06T16:54:56.335360Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -3346,7 +3346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a5ef0189bcd47068746f3aee3ec3597
+      - 3f750e1ca4e848eda3d126c719daaae1
   response:
     status:
       code: 200
@@ -3357,14 +3357,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2970befe-8cc2-4bea-9282-4f37ee5a5f27
+      - req-dd362087-dae6-4ba0-9392-89ddc3393971
       Date:
-      - Fri, 03 Aug 2018 19:42:22 GMT
+      - Mon, 06 Aug 2018 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3382,15 +3382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:22 GMT
+      - Mon, 06 Aug 2018 16:54:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ad5a138e710b41bba3f69b1e56a25f67
+      - 55f5ac3a1c6645db9a3e85174de4577d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e4962f75-8219-4e07-9e09-bd0cc2539061
+      - req-30994927-77a8-40a7-a3c0-fe83590fb3ee
       Content-Length:
       - '7278'
       Connection:
@@ -3402,7 +3402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:22.787545Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:54:56.984386Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3481,10 +3481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["roaph78QTjmEWjrBVuw0Fg"],
-        "issued_at": "2018-08-03T19:42:22.787625Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZqzBohUARtyyypYVQ5CZvQ"],
+        "issued_at": "2018-08-06T16:54:56.984446Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad5a138e710b41bba3f69b1e56a25f67
+      - 55f5ac3a1c6645db9a3e85174de4577d
   response:
     status:
       code: 200
@@ -3510,14 +3510,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3e9f915b-ecbf-45c8-b1d2-001f17a5a46b
+      - req-a0761fea-0d2b-4301-83a8-83d2faf65aa6
       Date:
-      - Fri, 03 Aug 2018 19:42:23 GMT
+      - Mon, 06 Aug 2018 16:54:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3543,9 +3543,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-24e0c225-98e3-4a41-ac7f-3dcfcc0bcdd9
+      - req-1f55735b-71b4-4045-bea0-85017d6c5cc0
       Date:
-      - Fri, 03 Aug 2018 19:42:23 GMT
+      - Mon, 06 Aug 2018 16:54:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3572,7 +3572,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -3587,7 +3587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3598,9 +3598,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-871e683b-2c87-4620-b2e5-80e71f60fc8e
+      - req-905bdc56-00e0-40a2-a9bc-9ba497eb7fec
       Date:
-      - Fri, 03 Aug 2018 19:42:24 GMT
+      - Mon, 06 Aug 2018 16:54:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3627,7 +3627,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -3642,7 +3642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3653,9 +3653,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fc9a113a-5db9-4601-b6ae-57674431ed47
+      - req-66434f88-9cf5-4305-a0b7-3c0c9e878952
       Date:
-      - Fri, 03 Aug 2018 19:42:25 GMT
+      - Mon, 06 Aug 2018 16:54:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3682,7 +3682,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -3697,7 +3697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3708,9 +3708,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-05ac2ef7-6652-495c-962e-70c501c565db
+      - req-a443d652-7b5b-4bfb-94ff-bcc8ed61bc33
       Date:
-      - Fri, 03 Aug 2018 19:42:25 GMT
+      - Mon, 06 Aug 2018 16:54:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3766,7 +3766,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -3781,7 +3781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -3792,9 +3792,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-62a80037-2929-4f2e-8439-9a44f762a732
+      - req-8b529a24-ed48-4f26-a13b-ef0cf84775ed
       Date:
-      - Fri, 03 Aug 2018 19:42:25 GMT
+      - Mon, 06 Aug 2018 16:55:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3806,7 +3806,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -3821,7 +3821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3834,9 +3834,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-ecccde8c-30e9-4ede-a7d6-19b070ac3a36
+      - req-3c501dee-d8ca-4298-938b-188558e6240a
       Date:
-      - Fri, 03 Aug 2018 19:42:26 GMT
+      - Mon, 06 Aug 2018 16:55:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -3882,7 +3882,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -3897,7 +3897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3910,9 +3910,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-84e10bcf-4aac-456e-9297-dcb80a039569
+      - req-e77f3cc9-7cb1-4ac8-be8a-04d935b045b5
       Date:
-      - Fri, 03 Aug 2018 19:42:26 GMT
+      - Mon, 06 Aug 2018 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -3958,7 +3958,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -3973,7 +3973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3986,9 +3986,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-e48ed9a4-33e8-4cad-8eaf-fb156c999ede
+      - req-ee716e15-1709-45f0-880f-66897517ecd2
       Date:
-      - Fri, 03 Aug 2018 19:42:27 GMT
+      - Mon, 06 Aug 2018 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -4036,7 +4036,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -4051,7 +4051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4064,9 +4064,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-5531e495-fcbe-4fc6-83f5-9e1cf4ffcf26
+      - req-526373d3-86b3-484e-8040-9880d1267375
       Date:
-      - Fri, 03 Aug 2018 19:42:28 GMT
+      - Mon, 06 Aug 2018 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -4108,7 +4108,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -4123,7 +4123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4136,9 +4136,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-678d5c78-3ebe-4554-9981-87f1e0861287
+      - req-ccf6b96a-a3a0-4eee-8e0c-3ae533481a92
       Date:
-      - Fri, 03 Aug 2018 19:42:28 GMT
+      - Mon, 06 Aug 2018 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -4161,7 +4161,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -4176,7 +4176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -4187,9 +4187,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-db06b946-6ee0-42be-8959-c6e70e8e79be
+      - req-3a1cdfb3-5d2c-486c-a74d-95675b634798
       Date:
-      - Fri, 03 Aug 2018 19:42:29 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4245,7 +4245,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -4260,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -4271,9 +4271,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e363af8f-43fa-420e-b63a-5867213bfec7
+      - req-fda404d8-928e-48b6-a8db-0f70a4a26818
       Date:
-      - Fri, 03 Aug 2018 19:42:29 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4285,7 +4285,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -4300,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -4311,9 +4311,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-eb0adcbc-7653-4541-b4bb-72e526b24536
+      - req-1e3bbf05-8acb-4675-a098-da4c64676c4c
       Date:
-      - Fri, 03 Aug 2018 19:42:29 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4369,7 +4369,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -4384,7 +4384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6369c90ed0e24360b63c6fd0e887014e
+      - 82628d7c7cf24f15ae61804c3002b792
   response:
     status:
       code: 200
@@ -4395,9 +4395,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-01af03c3-2470-4cab-8c55-32a3c29ee10f
+      - req-b65598d3-cede-4bae-9854-24629a514437
       Date:
-      - Fri, 03 Aug 2018 19:42:29 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4409,7 +4409,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4424,7 +4424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add368e4b9ca4b4b87ce89d560dc9a53
+      - 8b55ee42859f4557be39a20a50e2a785
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4437,9 +4437,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c05953c2-ef80-49a2-97f3-adb5e3c04608
+      - req-2d3244ba-93a8-4996-b2ce-f76a121312c6
       Date:
-      - Fri, 03 Aug 2018 19:42:29 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4448,7 +4448,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4463,7 +4463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5c394449334863aac9603eaa0d549f
+      - afe2c03bbe7c460fa92b0632e1e38814
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4476,9 +4476,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a7e554b3-bd89-499e-907a-e06070a4ccad
+      - req-d14ba413-e9a8-4e09-8abb-2cad65928bd3
       Date:
-      - Fri, 03 Aug 2018 19:42:30 GMT
+      - Mon, 06 Aug 2018 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4487,7 +4487,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4502,7 +4502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b665cfb5b16348e99a022fc7153dd66d
+      - 27fe85ced827483780124d88bf7a1796
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4515,9 +4515,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9323976c-fd6e-4fb0-a4ea-ae537298233a
+      - req-0c2613c8-ddf2-4b81-b32e-4717900bf8f2
       Date:
-      - Fri, 03 Aug 2018 19:42:30 GMT
+      - Mon, 06 Aug 2018 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4526,7 +4526,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4541,7 +4541,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f39dadc91bbd4791990d13ed35b0c78b
+      - 10ff7d8ffaf949299d29a390328b1fe1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4554,9 +4554,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-72574d28-2367-42d3-a4ce-cda299220e78
+      - req-5f43dc31-43f7-4e1e-a68d-515f03a5c4f3
       Date:
-      - Fri, 03 Aug 2018 19:42:30 GMT
+      - Mon, 06 Aug 2018 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4565,7 +4565,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4580,7 +4580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4593,9 +4593,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-42a36085-a32b-4251-a516-101367f827df
+      - req-f6f496a3-ec05-440d-a0ad-7bc31772c522
       Date:
-      - Fri, 03 Aug 2018 19:42:30 GMT
+      - Mon, 06 Aug 2018 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4604,7 +4604,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4619,7 +4619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb4544e53c5145dab6e313a32738f4cc
+      - fc2c3680ce834e5b8eaa86f2f4d55a2d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4632,9 +4632,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6489673f-ef1b-4d4c-8a5a-5167b65f82d5
+      - req-7ffe44c4-f566-432d-92e0-6426ac818b56
       Date:
-      - Fri, 03 Aug 2018 19:42:30 GMT
+      - Mon, 06 Aug 2018 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4643,7 +4643,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4658,7 +4658,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfae80139d8b4604864a023f36e5aec4
+      - 89fa97a588bb491dacb58a8ef4605ae2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d5103384-6ff8-4d6f-b29b-b2e7747d0f22
+      - req-5741ee8e-b062-4983-bdc4-53a4c75aa866
       Date:
-      - Fri, 03 Aug 2018 19:42:31 GMT
+      - Mon, 06 Aug 2018 16:55:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4682,7 +4682,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4700,15 +4700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:31 GMT
+      - Mon, 06 Aug 2018 16:55:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 76d732e46a754dad81f1644c2e0df267
+      - 5c706d2d99c94dcdbe458be72cd92eb6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d421be3-4c18-4079-9925-f312e8eb8217
+      - req-75d127b9-d195-4a33-b469-0546501f1596
       Content-Length:
       - '7278'
       Connection:
@@ -4720,7 +4720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:31.384803Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:05.480840Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4799,10 +4799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2wCGcypLRCeNIn9_4V7UOw"],
-        "issued_at": "2018-08-03T19:42:31.384913Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sFfn6fJOTQ2jIWMF5FO1GA"],
+        "issued_at": "2018-08-06T16:55:05.480913Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4817,22 +4817,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76d732e46a754dad81f1644c2e0df267
+      - 5c706d2d99c94dcdbe458be72cd92eb6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52ff72ef-cbc9-4521-8f5f-62097a09b7f4
+      - req-bf4d84a1-b26d-472b-b0d0-f1095f0d08f4
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-52ff72ef-cbc9-4521-8f5f-62097a09b7f4
+      - req-bf4d84a1-b26d-472b-b0d0-f1095f0d08f4
       Date:
-      - Fri, 03 Aug 2018 19:42:32 GMT
+      - Mon, 06 Aug 2018 16:55:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4842,7 +4842,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4860,15 +4860,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:32 GMT
+      - Mon, 06 Aug 2018 16:55:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3ac8ba8bd3e4cdaa34a1e3c9fb10c60
+      - 4aa65587ccbe459988c4ce6323b6582b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-00c2991e-80c0-4c87-8339-5ae2ca8dd0db
+      - req-0562d279-0f83-465b-90d9-11c8e822c882
       Content-Length:
       - '7278'
       Connection:
@@ -4880,7 +4880,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:32.403761Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:06.677659Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4959,10 +4959,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GCu_evfZSOqH1qJHD0AACg"],
-        "issued_at": "2018-08-03T19:42:32.403830Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Tx_M35nmRVSlZNivEQTaBg"],
+        "issued_at": "2018-08-06T16:55:06.677774Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4977,22 +4977,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3ac8ba8bd3e4cdaa34a1e3c9fb10c60
+      - 4aa65587ccbe459988c4ce6323b6582b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5249fbcf-a840-4557-bddf-330a321ebcdd
+      - req-bcf844cc-d714-4d7d-b40c-363d299851c1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5249fbcf-a840-4557-bddf-330a321ebcdd
+      - req-bcf844cc-d714-4d7d-b40c-363d299851c1
       Date:
-      - Fri, 03 Aug 2018 19:42:33 GMT
+      - Mon, 06 Aug 2018 16:55:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5002,7 +5002,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5020,15 +5020,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:33 GMT
+      - Mon, 06 Aug 2018 16:55:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c21d820fa7f040df9cbdd88ba6130672
+      - 7961801a61f04b4c9049641cc115e4c7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3a1e844f-70d4-4781-b9af-4eee11b6f996
+      - req-8146ae3d-5dd3-41a0-9ff6-7142de945485
       Content-Length:
       - '7264'
       Connection:
@@ -5040,7 +5040,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:33.604192Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:07.785226Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5119,10 +5119,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gT_ybduKSO6airaKxaXXZQ"],
-        "issued_at": "2018-08-03T19:42:33.604278Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9wnsIAPtQBiWrBC1XUkSgw"],
+        "issued_at": "2018-08-06T16:55:07.785343Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:33 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5137,22 +5137,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21d820fa7f040df9cbdd88ba6130672
+      - 7961801a61f04b4c9049641cc115e4c7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46100d2c-c93f-4d8d-9f65-e1157dc12827
+      - req-bf6795b2-a514-4138-9164-44066a1b2102
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-46100d2c-c93f-4d8d-9f65-e1157dc12827
+      - req-bf6795b2-a514-4138-9164-44066a1b2102
       Date:
-      - Fri, 03 Aug 2018 19:42:34 GMT
+      - Mon, 06 Aug 2018 16:55:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5162,7 +5162,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5180,15 +5180,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:34 GMT
+      - Mon, 06 Aug 2018 16:55:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 402c8ad57d2f4b2dab4a4fae37fe7abe
+      - 6afec2c48d7644af915ff8b2653d68d2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b24c9978-440d-4e11-8c06-e10b39679ba3
+      - req-429f7c8a-ab85-4cb8-aa5c-1a80b17522fa
       Content-Length:
       - '7278'
       Connection:
@@ -5200,7 +5200,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:34.595899Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:08.871329Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5279,10 +5279,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["l6yEb7XmTzCJCLjeqD7BZg"],
-        "issued_at": "2018-08-03T19:42:34.595981Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zPW35FHgThqQ-kebPn4yVA"],
+        "issued_at": "2018-08-06T16:55:08.871406Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5297,22 +5297,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 402c8ad57d2f4b2dab4a4fae37fe7abe
+      - 6afec2c48d7644af915ff8b2653d68d2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1935f8d-3ea1-48ff-811f-f5365924a44a
+      - req-1128f628-1eef-4070-b958-ddea40b3e960
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e1935f8d-3ea1-48ff-811f-f5365924a44a
+      - req-1128f628-1eef-4070-b958-ddea40b3e960
       Date:
-      - Fri, 03 Aug 2018 19:42:35 GMT
+      - Mon, 06 Aug 2018 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5322,7 +5322,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5337,22 +5337,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dfbc43ef-cd16-4445-b5fb-2abf5f10218d
+      - req-b3729774-5102-4076-99b7-90c46da9518a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-dfbc43ef-cd16-4445-b5fb-2abf5f10218d
+      - req-b3729774-5102-4076-99b7-90c46da9518a
       Date:
-      - Fri, 03 Aug 2018 19:42:36 GMT
+      - Mon, 06 Aug 2018 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5362,7 +5362,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5380,15 +5380,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:36 GMT
+      - Mon, 06 Aug 2018 16:55:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 00d3fa9c33ea4cb9a7054128b6cb779d
+      - f9fc76cb5a764ffd86fcb02a23541b5f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0926ce7f-421d-4eb6-baca-34893002445b
+      - req-5c2240db-96ff-49d5-849c-c48d1ed82444
       Content-Length:
       - '7265'
       Connection:
@@ -5400,7 +5400,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:36.473295Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:10.392426Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5479,10 +5479,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NcHLZbziQJmFe_1-mSiimg"],
-        "issued_at": "2018-08-03T19:42:36.473363Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9-9ejGwbRuuHHKjaRZMUnQ"],
+        "issued_at": "2018-08-06T16:55:10.392493Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5497,22 +5497,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00d3fa9c33ea4cb9a7054128b6cb779d
+      - f9fc76cb5a764ffd86fcb02a23541b5f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8a7f239-dfec-4aca-ac10-c28c4c2f2c74
+      - req-209be14b-6462-411a-ad38-d6a71f6d442d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d8a7f239-dfec-4aca-ac10-c28c4c2f2c74
+      - req-209be14b-6462-411a-ad38-d6a71f6d442d
       Date:
-      - Fri, 03 Aug 2018 19:42:37 GMT
+      - Mon, 06 Aug 2018 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5522,7 +5522,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5540,15 +5540,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:37 GMT
+      - Mon, 06 Aug 2018 16:55:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1c0d70e740f44a988f308d1ac82078fd
+      - aba93c1f8f1e460ca8ce6abfa9351f0b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3dea51f7-3867-4100-ab6d-87a2059acc9f
+      - req-5469f9d8-a32b-41df-8ea1-3564ae6b8d17
       Content-Length:
       - '7278'
       Connection:
@@ -5560,7 +5560,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:37.684492Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:11.469785Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5639,10 +5639,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9cs4oP1HSCeQJ1CHWZn5xQ"],
-        "issued_at": "2018-08-03T19:42:37.684564Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MxY4JSi3SrymDne7jbC-Tw"],
+        "issued_at": "2018-08-06T16:55:11.469855Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5657,22 +5657,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c0d70e740f44a988f308d1ac82078fd
+      - aba93c1f8f1e460ca8ce6abfa9351f0b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96e4e89a-bd05-438a-8177-c87441edf554
+      - req-3f9d2a9d-1d6c-46e2-8ba1-6434f86eb0d8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-96e4e89a-bd05-438a-8177-c87441edf554
+      - req-3f9d2a9d-1d6c-46e2-8ba1-6434f86eb0d8
       Date:
-      - Fri, 03 Aug 2018 19:42:38 GMT
+      - Mon, 06 Aug 2018 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5682,7 +5682,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5700,15 +5700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:38 GMT
+      - Mon, 06 Aug 2018 16:55:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 75ac278cee1246999b6d36778ab191c8
+      - 71cea231504a47e9a84919fb6b299848
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-866c1200-0e46-4dbe-aee3-05d67fcee02a
+      - req-d32a4317-9f29-4112-b792-5a86bb4aac47
       Content-Length:
       - '7311'
       Connection:
@@ -5720,7 +5720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:38.741216Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:12.449336Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5799,10 +5799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eMxxoljyR7uLqPK7A0l00g"],
-        "issued_at": "2018-08-03T19:42:38.741283Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zj3I306ARtOruHX6692tXw"],
+        "issued_at": "2018-08-06T16:55:12.449407Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -5817,7 +5817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75ac278cee1246999b6d36778ab191c8
+      - 71cea231504a47e9a84919fb6b299848
   response:
     status:
       code: 200
@@ -5828,13 +5828,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:42:38 GMT
+      - Mon, 06 Aug 2018 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5852,15 +5852,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:38 GMT
+      - Mon, 06 Aug 2018 16:55:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9da4266b051d47f5b5750201493cbb1c
+      - 301403e7b303497c8fa0a941e8790183
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-57977885-3957-4bce-a743-def9daaf9393
+      - req-a4048281-8883-4408-83a4-6161d68127c1
       Content-Length:
       - '7278'
       Connection:
@@ -5872,7 +5872,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:39.243306Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:12.916763Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5951,10 +5951,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VvB3zxGwQ5uAuyqdvqGByQ"],
-        "issued_at": "2018-08-03T19:42:39.243394Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b4xDpW--TYO_GIUIhN08hQ"],
+        "issued_at": "2018-08-06T16:55:12.916840Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5969,7 +5969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9da4266b051d47f5b5750201493cbb1c
+      - 301403e7b303497c8fa0a941e8790183
   response:
     status:
       code: 200
@@ -5980,16 +5980,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e5231114-cb5d-491b-953d-66e0a83ca87b
+      - req-3385a2ea-2b0d-4ec0-8ca8-17a364b93e8c
       Date:
-      - Fri, 03 Aug 2018 19:42:39 GMT
+      - Mon, 06 Aug 2018 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6007,15 +6007,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:39 GMT
+      - Mon, 06 Aug 2018 16:55:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb736f82aa704560878cdaabf5d0dff6
+      - b9d410aadf13416a929b1a0183455447
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c88446e3-7063-4f80-8475-a1d790361531
+      - req-90f9662d-7026-49b9-9de0-514703877168
       Content-Length:
       - '7278'
       Connection:
@@ -6027,7 +6027,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:39.770472Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:13.419580Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6106,10 +6106,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F2Rkh3YYSWqW_DmFLB6xFg"],
-        "issued_at": "2018-08-03T19:42:39.770533Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OGEh0dnOQEWXySMRJHtFIw"],
+        "issued_at": "2018-08-06T16:55:13.419649Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6124,7 +6124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb736f82aa704560878cdaabf5d0dff6
+      - b9d410aadf13416a929b1a0183455447
   response:
     status:
       code: 200
@@ -6135,16 +6135,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6feac6e7-bfca-4435-9158-92e53f4055ac
+      - req-dc0a1456-34f0-4c7d-8935-54db4ce69c93
       Date:
-      - Fri, 03 Aug 2018 19:42:39 GMT
+      - Mon, 06 Aug 2018 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6162,15 +6162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:40 GMT
+      - Mon, 06 Aug 2018 16:55:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98b3456d2e344a23a10a80c452adfdce
+      - 0c81d714507b42908ae2462c0b2e0c96
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f686021-12cd-4bc4-8804-b626cde96351
+      - req-15fdb793-a8c5-4a7e-9df3-8714ba12d223
       Content-Length:
       - '7264'
       Connection:
@@ -6182,7 +6182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:40.268368Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:13.943488Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6261,10 +6261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uvC5i9q7RYaJkXSPqZJ8cQ"],
-        "issued_at": "2018-08-03T19:42:40.268437Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uB3Xa-MRRkWXzhFFIPtllQ"],
+        "issued_at": "2018-08-06T16:55:13.943555Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6279,7 +6279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98b3456d2e344a23a10a80c452adfdce
+      - 0c81d714507b42908ae2462c0b2e0c96
   response:
     status:
       code: 200
@@ -6290,16 +6290,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4f56d7c9-94a0-4fbc-aea4-b94c6fd57d6e
+      - req-e56bcc90-85b5-4dce-9b19-22a2865b7aaa
       Date:
-      - Fri, 03 Aug 2018 19:42:40 GMT
+      - Mon, 06 Aug 2018 16:55:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6317,15 +6317,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:40 GMT
+      - Mon, 06 Aug 2018 16:55:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb7fd50702ac45e6b94d012e599b9212
+      - e9df772dd897466d995bdf9811a5b547
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a372e47-dd50-4bb5-b0a8-addca8090ddf
+      - req-efcdc8bb-099f-4721-ae6f-0bf052e043d6
       Content-Length:
       - '7278'
       Connection:
@@ -6337,7 +6337,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:40.788756Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:14.472412Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6416,10 +6416,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nfSlgyTnREO4rtPMr6O_tw"],
-        "issued_at": "2018-08-03T19:42:40.788824Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IPdo4OGHRbew29cW4_ctCw"],
+        "issued_at": "2018-08-06T16:55:14.472489Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6434,7 +6434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb7fd50702ac45e6b94d012e599b9212
+      - e9df772dd897466d995bdf9811a5b547
   response:
     status:
       code: 200
@@ -6445,16 +6445,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9c92f04d-abc7-41e5-962b-36a6d0fd95cd
+      - req-e40d5b13-d59a-4299-93e8-62e59a5b67bd
       Date:
-      - Fri, 03 Aug 2018 19:42:41 GMT
+      - Mon, 06 Aug 2018 16:55:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6469,7 +6469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75ac278cee1246999b6d36778ab191c8
+      - 71cea231504a47e9a84919fb6b299848
   response:
     status:
       code: 200
@@ -6480,16 +6480,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-60c3cfc1-17f2-485e-814a-bf2ca7388b32
+      - req-7b15860e-83f5-4147-894c-66e8b0f2db3a
       Date:
-      - Fri, 03 Aug 2018 19:42:41 GMT
+      - Mon, 06 Aug 2018 16:55:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6507,15 +6507,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:41 GMT
+      - Mon, 06 Aug 2018 16:55:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 003e912a134c47e094f7cf054b33f3e8
+      - 9a9f984b200e443faa7837e63240e938
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1cab69aa-d6c0-422c-a9b8-761741725b4f
+      - req-515bf152-b120-4808-a2b1-6d0f733b9112
       Content-Length:
       - '7265'
       Connection:
@@ -6527,7 +6527,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:41.549154Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:15.188608Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6606,10 +6606,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-EytRvxMTCakcMPWhC_BLg"],
-        "issued_at": "2018-08-03T19:42:41.549223Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xo2ttWliSFyU13QqwohHDQ"],
+        "issued_at": "2018-08-06T16:55:15.188675Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6624,7 +6624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 003e912a134c47e094f7cf054b33f3e8
+      - 9a9f984b200e443faa7837e63240e938
   response:
     status:
       code: 200
@@ -6635,16 +6635,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f9922594-4a3b-45e3-9eea-12ea9db20da3
+      - req-e2f854d4-7c59-4819-9803-0809ff5bc61e
       Date:
-      - Fri, 03 Aug 2018 19:42:41 GMT
+      - Mon, 06 Aug 2018 16:55:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6662,15 +6662,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:41 GMT
+      - Mon, 06 Aug 2018 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b26440f7f9ca4ccb891907b10f74de5d
+      - bd0de46391bd4cca8ac0308855ae2a06
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5dd47181-6d61-40b8-a436-c1f7708e40bf
+      - req-bf157e1d-04af-4b99-89ea-b2cf257e00b2
       Content-Length:
       - '7278'
       Connection:
@@ -6682,7 +6682,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:42.043446Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:15.672393Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6761,10 +6761,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7uIrVlDfQH22QLpE7gQasQ"],
-        "issued_at": "2018-08-03T19:42:42.043513Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["APAiwxvcTKqkX-HoV93K2g"],
+        "issued_at": "2018-08-06T16:55:15.672461Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6779,7 +6779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b26440f7f9ca4ccb891907b10f74de5d
+      - bd0de46391bd4cca8ac0308855ae2a06
   response:
     status:
       code: 200
@@ -6790,16 +6790,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8a985a82-c539-465e-828e-8d9fb094ca78
+      - req-7d5706b4-2ce9-4350-8c22-6c519e9aabf6
       Date:
-      - Fri, 03 Aug 2018 19:42:42 GMT
+      - Mon, 06 Aug 2018 16:55:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-9221448e-17e6-438f-8db6-5cab710a1311
+      - req-85539bba-a4a0-4ee2-a396-2494bd7af708
       Date:
-      - Fri, 03 Aug 2018 19:42:42 GMT
+      - Mon, 06 Aug 2018 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7eb9c728-2d07-4801-8aeb-6198a0e12902
+      - req-6265d4a1-7d82-4fd1-b333-fe0994e173d5
       Date:
-      - Fri, 03 Aug 2018 19:42:42 GMT
+      - Mon, 06 Aug 2018 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7957c1f3-edae-4994-b416-01f65c34daed
+      - req-81c5eafb-d18f-4f42-9ded-b9d0a8d920f4
       Date:
-      - Fri, 03 Aug 2018 19:42:43 GMT
+      - Mon, 06 Aug 2018 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a1578725-f384-4674-ac12-82536a7e2757
+      - req-b9f79ac1-75f3-4c0b-8ebd-616ddef87893
       Date:
-      - Fri, 03 Aug 2018 19:42:43 GMT
+      - Mon, 06 Aug 2018 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-20f9e916-b7db-4806-b2c7-92ea73139ca2
+      - req-e26836b1-812d-4800-a764-381deaaea479
       Date:
-      - Fri, 03 Aug 2018 19:42:43 GMT
+      - Mon, 06 Aug 2018 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6989,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,15 +7002,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-544d2e9c-c0bb-48d5-8de5-33d92080dc0f
+      - req-effd5a0a-2a64-4698-9e12-c30f3a6982a8
       Date:
-      - Fri, 03 Aug 2018 19:42:43 GMT
+      - Mon, 06 Aug 2018 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7025,7 +7025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7038,14 +7038,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5cd6e576-97ac-4095-aee4-8e9b9f8d14d2
+      - req-a4b63edb-d2d9-442f-9145-6836741ccde9
       Date:
-      - Fri, 03 Aug 2018 19:42:44 GMT
+      - Mon, 06 Aug 2018 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -7060,7 +7060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7073,15 +7073,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-66e72745-5420-4c89-981b-1068748f4b24
+      - req-483b56a7-0d6e-43d1-8d6a-01442f83856b
       Date:
-      - Fri, 03 Aug 2018 19:42:45 GMT
+      - Mon, 06 Aug 2018 16:55:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7096,7 +7096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7109,14 +7109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-08633ffd-2d72-4a54-a1c4-929d8445b31b
+      - req-2c0dcb98-ad35-4db1-8017-9eb29234a4e5
       Date:
-      - Fri, 03 Aug 2018 19:42:45 GMT
+      - Mon, 06 Aug 2018 16:55:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7131,7 +7131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7144,14 +7144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5a533adb-073a-4172-9d40-d9a0f02c8fc5
+      - req-a366dc13-5f22-4ea9-b4e0-1ad58999cdbc
       Date:
-      - Fri, 03 Aug 2018 19:42:45 GMT
+      - Mon, 06 Aug 2018 16:55:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7166,7 +7166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7179,14 +7179,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-fe4a8f41-4bec-4199-9bdd-8adf44bb0c40
+      - req-e5b30beb-0691-4090-8e01-0682816a8946
       Date:
-      - Fri, 03 Aug 2018 19:42:46 GMT
+      - Mon, 06 Aug 2018 16:55:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7204,15 +7204,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:46 GMT
+      - Mon, 06 Aug 2018 16:55:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f90a90a613884f408b77899dad666928
+      - 163e4d1526ce49cfa8ca8b93f3ff587f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cc05b2b8-c513-48e4-bc68-0e3f791a86e9
+      - req-be15c14c-1633-4bda-987e-d70dbbfcc9a9
       Content-Length:
       - '7311'
       Connection:
@@ -7224,7 +7224,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:46.470346Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:24.483306Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7303,16 +7303,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YHqog5VYSQe_5-foxAkunw"],
-        "issued_at": "2018-08-03T19:42:46.470433Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJQ10bRUR5u808Flre3VYQ"],
+        "issued_at": "2018-08-06T16:55:24.483374Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"f90a90a613884f408b77899dad666928"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"163e4d1526ce49cfa8ca8b93f3ff587f"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7324,15 +7324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:46 GMT
+      - Mon, 06 Aug 2018 16:55:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be48b5b914e94854b2d981e684452528
+      - 5dca439e1d4d42cc89402ee0ae42d310
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22ef1027-09ba-4718-a2fd-5bdf83477342
+      - req-af86e2fc-1c58-410e-a51c-a10a45e1008e
       Content-Length:
       - '7346'
       Connection:
@@ -7344,7 +7344,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:46.470346Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:24.483306Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7423,10 +7423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ioZLr07uTUmcbFYMdtX5GA",
-        "YHqog5VYSQe_5-foxAkunw"], "issued_at": "2018-08-03T19:42:46.774405Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fLfh8B9MSF65VEtZedFRsg",
+        "DJQ10bRUR5u808Flre3VYQ"], "issued_at": "2018-08-06T16:55:25.090614Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7444,15 +7444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:46 GMT
+      - Mon, 06 Aug 2018 16:55:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 55635970e15b4bd187350bdab1b95f8a
+      - 7a27aff172d84e379882dfabb87faa60
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9f71bd8c-0e45-4a59-912e-549aa427b1f4
+      - req-116fb60b-6298-4261-afa7-8c5b692fa150
       Content-Length:
       - '7311'
       Connection:
@@ -7464,7 +7464,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:47.247091Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:25.468653Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7543,16 +7543,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AsibVu-cRnWSLNb4cx9UpA"],
-        "issued_at": "2018-08-03T19:42:47.247213Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R3MFr7Q7TCu2n67aunAOXw"],
+        "issued_at": "2018-08-06T16:55:25.468725Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"55635970e15b4bd187350bdab1b95f8a"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7a27aff172d84e379882dfabb87faa60"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7564,15 +7564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:47 GMT
+      - Mon, 06 Aug 2018 16:55:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '05885e6b54504eee8fb3ef1e0da16ee0'
+      - 8847c420f2af4f259c5cd517c6f4d5b1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-49689785-0a28-49ea-835d-8e834f646c4f
+      - req-db6f82b2-8254-4c2f-8225-66c1352ac204
       Content-Length:
       - '7346'
       Connection:
@@ -7584,7 +7584,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:47.247091Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:25.468653Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7663,10 +7663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FFVhurM1SA6JpoAS9Mu3Dw",
-        "AsibVu-cRnWSLNb4cx9UpA"], "issued_at": "2018-08-03T19:42:47.538476Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_bGnRNGvTv-1Yo-0u_MvnA",
+        "R3MFr7Q7TCu2n67aunAOXw"], "issued_at": "2018-08-06T16:55:25.896730Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -7681,7 +7681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 937d617dd332476f9ff0463c57d41791
+      - fd7a7afb0bd14745b75eb6f4eeb07514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7694,14 +7694,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-abcef348-f3c9-488c-b42c-407d302aa032
+      - req-ddba317d-c928-4064-93e8-5b2f8f212c19
       Date:
-      - Fri, 03 Aug 2018 19:42:47 GMT
+      - Mon, 06 Aug 2018 16:55:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -7716,22 +7716,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eaf4bd9f-7f04-454c-991e-d87fbd5c619c
+      - req-81de3f0e-6701-4560-901f-29e62c5d714d
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-eaf4bd9f-7f04-454c-991e-d87fbd5c619c
+      - req-81de3f0e-6701-4560-901f-29e62c5d714d
       Date:
-      - Fri, 03 Aug 2018 19:42:47 GMT
+      - Mon, 06 Aug 2018 16:55:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7764,7 +7764,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -7779,22 +7779,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26c657ee-e411-4030-9eed-5c7dcae56a85
+      - req-66010d49-9895-471d-b7e6-ddac7affe973
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-26c657ee-e411-4030-9eed-5c7dcae56a85
+      - req-66010d49-9895-471d-b7e6-ddac7affe973
       Date:
-      - Fri, 03 Aug 2018 19:42:48 GMT
+      - Mon, 06 Aug 2018 16:55:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -7811,7 +7811,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -7826,27 +7826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76d732e46a754dad81f1644c2e0df267
+      - 5c706d2d99c94dcdbe458be72cd92eb6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed426006-2439-4ff8-a479-d956103e8327
+      - req-946fc6b3-e236-4cb2-b14a-9b7ae0626900
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ed426006-2439-4ff8-a479-d956103e8327
+      - req-946fc6b3-e236-4cb2-b14a-9b7ae0626900
       Date:
-      - Fri, 03 Aug 2018 19:42:48 GMT
+      - Mon, 06 Aug 2018 16:55:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -7861,27 +7861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76d732e46a754dad81f1644c2e0df267
+      - 5c706d2d99c94dcdbe458be72cd92eb6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05582ee4-f932-4031-96ae-cd6a68644e75
+      - req-312de3bf-f264-4eb7-b614-a38bf45c953f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-05582ee4-f932-4031-96ae-cd6a68644e75
+      - req-312de3bf-f264-4eb7-b614-a38bf45c953f
       Date:
-      - Fri, 03 Aug 2018 19:42:48 GMT
+      - Mon, 06 Aug 2018 16:55:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -7896,27 +7896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3ac8ba8bd3e4cdaa34a1e3c9fb10c60
+      - 4aa65587ccbe459988c4ce6323b6582b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b79938a-e177-47b2-ab13-2775dfd9497c
+      - req-879ad440-eb31-422b-862c-ae971c4234ef
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5b79938a-e177-47b2-ab13-2775dfd9497c
+      - req-879ad440-eb31-422b-862c-ae971c4234ef
       Date:
-      - Fri, 03 Aug 2018 19:42:48 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -7931,27 +7931,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3ac8ba8bd3e4cdaa34a1e3c9fb10c60
+      - 4aa65587ccbe459988c4ce6323b6582b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4097424b-457f-4122-9f08-a8c76d1d995c
+      - req-4b0ab4eb-bb35-4862-834e-b2911e12694c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4097424b-457f-4122-9f08-a8c76d1d995c
+      - req-4b0ab4eb-bb35-4862-834e-b2911e12694c
       Date:
-      - Fri, 03 Aug 2018 19:42:48 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -7966,22 +7966,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21d820fa7f040df9cbdd88ba6130672
+      - 7961801a61f04b4c9049641cc115e4c7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a8dc4211-0558-44c5-9faa-e5bfb6911da5
+      - req-ab8b0d72-58e0-4506-8180-0b1b55cf3e10
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-a8dc4211-0558-44c5-9faa-e5bfb6911da5
+      - req-ab8b0d72-58e0-4506-8180-0b1b55cf3e10
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -7996,7 +7996,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -8011,22 +8011,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21d820fa7f040df9cbdd88ba6130672
+      - 7961801a61f04b4c9049641cc115e4c7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6a1290d-7c3f-4f44-9727-c708b2b81274
+      - req-20a8541e-caa2-4528-a9f6-3d731ad304bc
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-f6a1290d-7c3f-4f44-9727-c708b2b81274
+      - req-20a8541e-caa2-4528-a9f6-3d731ad304bc
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -8041,7 +8041,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -8056,27 +8056,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 402c8ad57d2f4b2dab4a4fae37fe7abe
+      - 6afec2c48d7644af915ff8b2653d68d2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-300ff687-27f9-49d7-b0f3-28c9a767cf33
+      - req-def8c980-ffa3-4346-b13b-b60562e42e56
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-300ff687-27f9-49d7-b0f3-28c9a767cf33
+      - req-def8c980-ffa3-4346-b13b-b60562e42e56
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -8091,27 +8091,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 402c8ad57d2f4b2dab4a4fae37fe7abe
+      - 6afec2c48d7644af915ff8b2653d68d2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-40520f37-678f-40c5-8662-8b08781925f6
+      - req-a7951457-f0e6-4dfa-a040-9cb1c89fa5ec
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-40520f37-678f-40c5-8662-8b08781925f6
+      - req-a7951457-f0e6-4dfa-a040-9cb1c89fa5ec
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -8126,27 +8126,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e06d2424-9cae-42af-9b62-4d06ec368648
+      - req-e072b88f-45c5-4f1f-88f1-71068157357f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e06d2424-9cae-42af-9b62-4d06ec368648
+      - req-e072b88f-45c5-4f1f-88f1-71068157357f
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -8161,27 +8161,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21621256-5240-4a0d-9b5c-fbf07048741b
+      - req-b0159dd7-7189-4809-b183-7e9ceb467de5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-21621256-5240-4a0d-9b5c-fbf07048741b
+      - req-b0159dd7-7189-4809-b183-7e9ceb467de5
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -8196,27 +8196,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00d3fa9c33ea4cb9a7054128b6cb779d
+      - f9fc76cb5a764ffd86fcb02a23541b5f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89a9c677-52cb-4420-9ca0-5ee97199156a
+      - req-a8b57ffc-ef14-47c7-ae9a-d51c40a5d9bc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-89a9c677-52cb-4420-9ca0-5ee97199156a
+      - req-a8b57ffc-ef14-47c7-ae9a-d51c40a5d9bc
       Date:
-      - Fri, 03 Aug 2018 19:42:49 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -8231,27 +8231,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00d3fa9c33ea4cb9a7054128b6cb779d
+      - f9fc76cb5a764ffd86fcb02a23541b5f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e816b86-ef5c-460a-8b9a-afc57e550f78
+      - req-63550875-a20a-43e8-83f4-2b4fb7466017
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6e816b86-ef5c-460a-8b9a-afc57e550f78
+      - req-63550875-a20a-43e8-83f4-2b4fb7466017
       Date:
-      - Fri, 03 Aug 2018 19:42:50 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -8266,27 +8266,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c0d70e740f44a988f308d1ac82078fd
+      - aba93c1f8f1e460ca8ce6abfa9351f0b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de5eadef-8ffe-4b8d-891f-05139ff620f9
+      - req-81ec8eb8-5545-433e-b4f5-5b490c39d770
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-de5eadef-8ffe-4b8d-891f-05139ff620f9
+      - req-81ec8eb8-5545-433e-b4f5-5b490c39d770
       Date:
-      - Fri, 03 Aug 2018 19:42:50 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -8301,27 +8301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c0d70e740f44a988f308d1ac82078fd
+      - aba93c1f8f1e460ca8ce6abfa9351f0b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ba20dc01-603d-4051-b28a-95f6272ee29e
+      - req-a0621d56-11eb-4e10-807b-4a3a0d47b227
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ba20dc01-603d-4051-b28a-95f6272ee29e
+      - req-a0621d56-11eb-4e10-807b-4a3a0d47b227
       Date:
-      - Fri, 03 Aug 2018 19:42:50 GMT
+      - Mon, 06 Aug 2018 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -8336,22 +8336,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b48d2547-a6c7-427f-a28e-824e35546564
+      - req-0467bf1d-9367-4866-ad27-940d1b6d15e0
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-b48d2547-a6c7-427f-a28e-824e35546564
+      - req-0467bf1d-9367-4866-ad27-940d1b6d15e0
       Date:
-      - Fri, 03 Aug 2018 19:42:50 GMT
+      - Mon, 06 Aug 2018 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -8384,7 +8384,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -8399,22 +8399,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0aedae1d-410f-4d48-9a16-21b3f6465efa
+      - req-47c738ee-dc08-490a-9c04-924a77e19045
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-0aedae1d-410f-4d48-9a16-21b3f6465efa
+      - req-47c738ee-dc08-490a-9c04-924a77e19045
       Date:
-      - Fri, 03 Aug 2018 19:42:50 GMT
+      - Mon, 06 Aug 2018 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -8455,7 +8455,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -8470,22 +8470,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-868f7e4a-1787-4fb2-9548-23801d966753
+      - req-5d9ff0ec-a5e0-4995-b517-bfad9da536b7
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-868f7e4a-1787-4fb2-9548-23801d966753
+      - req-5d9ff0ec-a5e0-4995-b517-bfad9da536b7
       Date:
-      - Fri, 03 Aug 2018 19:42:51 GMT
+      - Mon, 06 Aug 2018 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -8519,7 +8519,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -8534,27 +8534,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b79a6e29ccbc486c8bd2431429bf0451
+      - f8cd138a23694bceb5c63d311ac1d432
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cfc40d5e-3acb-4ec6-8e7b-c8f38b2afb21
+      - req-fd2d286a-d9cd-4a47-bb06-7ce7c2c90de1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cfc40d5e-3acb-4ec6-8e7b-c8f38b2afb21
+      - req-fd2d286a-d9cd-4a47-bb06-7ce7c2c90de1
       Date:
-      - Fri, 03 Aug 2018 19:42:51 GMT
+      - Mon, 06 Aug 2018 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8572,15 +8572,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:52 GMT
+      - Mon, 06 Aug 2018 16:55:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 92a0c165d9764e998bed93525e337a8c
+      - 75d4511fc55e4d04884f5ab2effd0252
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9374573-ba3c-441a-9e11-bded95fac33d
+      - req-79641074-fa00-477b-a30e-e5b9ba1d5bae
       Content-Length:
       - '7311'
       Connection:
@@ -8592,7 +8592,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:53.047999Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:32.228939Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8671,10 +8671,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xgdPWXLVRFmuqWwFHE1EGQ"],
-        "issued_at": "2018-08-03T19:42:53.048083Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sKemJDuGSPiZC9FrNBpGLA"],
+        "issued_at": "2018-08-06T16:55:32.229040Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8692,15 +8692,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:53 GMT
+      - Mon, 06 Aug 2018 16:55:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7f024e56-6708-4c20-8aa3-f29e1f672f06
+      - req-b68d3536-8238-486b-92cc-350a775e3893
       Content-Length:
       - '7311'
       Connection:
@@ -8712,7 +8712,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:53.458602Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:32.669199Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8791,10 +8791,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["plJsEkCfR8u4-DQ894N8WQ"],
-        "issued_at": "2018-08-03T19:42:53.458681Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MpEMrRvzSoaTL_VJ78o_qg"],
+        "issued_at": "2018-08-06T16:55:32.669283Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8809,7 +8809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -8820,42 +8820,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-00793066-2c3f-46d3-9013-3a10c79623e6
+      - req-785cb30a-b6dc-49dc-aafc-d934b1e47653
       Date:
-      - Fri, 03 Aug 2018 19:42:53 GMT
+      - Mon, 06 Aug 2018 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
-        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -8880,19 +8855,44 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8910,15 +8910,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:53 GMT
+      - Mon, 06 Aug 2018 16:55:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1432bd4682654a8c9fd766d849c997bb
+      - 72eb4dc671eb42f4b4e8e0752d9fd205
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b342ed8b-9d8c-4866-981d-c58348454641
+      - req-5ad76ad1-2001-4e88-a667-42cbaeb9f001
       Content-Length:
       - '7311'
       Connection:
@@ -8930,7 +8930,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:42:54.375974Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:33.327888Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9009,10 +9009,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["__kKajobT-qfkVKHsLyx7g"],
-        "issued_at": "2018-08-03T19:42:54.376055Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UdMHuyXyRai1BpmTVNZXMA"],
+        "issued_at": "2018-08-06T16:55:33.327990Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9030,15 +9030,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:54 GMT
+      - Mon, 06 Aug 2018 16:55:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f54962033b434e2ea4a046eb536dea9b
+      - d75e0c1ab9094ab08fdc9e7dc9665331
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4cdcc6df-0994-49ce-ae95-98f581c76462
+      - req-269b77c8-1f51-454c-9d9e-e2246b99e6a5
       Content-Length:
       - '297'
       Connection:
@@ -9047,12 +9047,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:42:54.603696Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:55:33.636781Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IDxe4AWJThqnCW2A4I3a3Q"],
-        "issued_at": "2018-08-03T19:42:54.603764Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["feL3VqaESuiXIycdk7RPcQ"],
+        "issued_at": "2018-08-06T16:55:33.636842Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -9067,20 +9067,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f54962033b434e2ea4a046eb536dea9b
+      - d75e0c1ab9094ab08fdc9e7dc9665331
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:54 GMT
+      - Mon, 06 Aug 2018 16:55:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0ca0e991-dbe8-4ec8-8be0-8cb6c8ab33fa
+      - req-6a2f4d98-c001-4b9f-8848-71426a2a54a2
       Content-Length:
       - '2457'
       Connection:
@@ -9113,13 +9113,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"f54962033b434e2ea4a046eb536dea9b"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"d75e0c1ab9094ab08fdc9e7dc9665331"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9131,15 +9131,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:54 GMT
+      - Mon, 06 Aug 2018 16:55:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dbae72af234447ecbb90db70b820a859
+      - 7eed7c5b079d4b50944947bbda1aa324
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47b77154-5bcb-4430-b8af-b5112ffe46fe
+      - req-535e2005-f466-4536-aacd-ad6323dc3df7
       Content-Length:
       - '7313'
       Connection:
@@ -9151,7 +9151,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:54.603696Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:33.636781Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9230,10 +9230,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GKarHAjBTZGwN_0YWaMfSQ",
-        "IDxe4AWJThqnCW2A4I3a3Q"], "issued_at": "2018-08-03T19:42:54.950374Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a7ZEtPzURyK82FNWDpeWlQ",
+        "feL3VqaESuiXIycdk7RPcQ"], "issued_at": "2018-08-06T16:55:34.095920Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -9248,20 +9248,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbae72af234447ecbb90db70b820a859
+      - 7eed7c5b079d4b50944947bbda1aa324
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:55 GMT
+      - Mon, 06 Aug 2018 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a1d20430-ea13-42b1-8d24-1f7f39c0ee20
+      - req-33bb46af-00c7-40e0-af58-004c626925c0
       Content-Length:
       - '2179'
       Connection:
@@ -9294,7 +9294,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9312,15 +9312,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:55 GMT
+      - Mon, 06 Aug 2018 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63804ff1972f4c3d9a633abf0d3921bd
+      - 439d203d33714c9da9bc3c407bfec22d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f56bfeaa-0be7-49c5-9eee-843ded9875ce
+      - req-7af7dc9f-7235-4a88-878a-926469340279
       Content-Length:
       - '7278'
       Connection:
@@ -9332,7 +9332,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:55.461172Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:34.646366Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9411,10 +9411,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P8w8Da-2QLC4L4fcn9Sd9A"],
-        "issued_at": "2018-08-03T19:42:55.461243Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gw6Z4aVeTeKbIGmmNU0z7w"],
+        "issued_at": "2018-08-06T16:55:34.646471Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9432,15 +9432,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:55 GMT
+      - Mon, 06 Aug 2018 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1dce000357594c17ab4284fa6720a700
+      - 521430cc36704aa7b4b468f0c96a0886
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b6fc465a-f0a3-4bfa-a8db-6aa64338a583
+      - req-69202cab-ac0f-4db3-ba4e-23cab39cdf2c
       Content-Length:
       - '7278'
       Connection:
@@ -9452,7 +9452,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:55.787496Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:35.031996Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9531,10 +9531,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CFNTHsNVQ1KY_cUizLUetA"],
-        "issued_at": "2018-08-03T19:42:55.787567Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HwJ3GI8LTOKP_i-cckDF8Q"],
+        "issued_at": "2018-08-06T16:55:35.032039Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9552,15 +9552,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:55 GMT
+      - Mon, 06 Aug 2018 16:55:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - de3dce8f514946509867b099130fbe9f
+      - 5a73c458bf6848098dd1ce9821079079
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f6f81a33-5c71-495e-8bd4-ec7f011b7a2e
+      - req-db2d8e52-5c59-4675-bd72-a48f3955693f
       Content-Length:
       - '7264'
       Connection:
@@ -9572,7 +9572,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:56.140948Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:35.280577Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9651,10 +9651,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f7h-wIvTSRyhFF_1n21lNA"],
-        "issued_at": "2018-08-03T19:42:56.141020Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rccHf3IwTXm5hhCNOAN7UA"],
+        "issued_at": "2018-08-06T16:55:35.280627Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9672,15 +9672,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:56 GMT
+      - Mon, 06 Aug 2018 16:55:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6fe12f7c3edf4c0ab7d70b1ccfec2172
+      - '0648f3743864432b9dd44c2eb259b1e9'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a1684cc3-63ea-4384-b1b3-c03575a691c7
+      - req-36955875-4b45-4a5b-b03a-91f5a03bec8e
       Content-Length:
       - '7278'
       Connection:
@@ -9692,7 +9692,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:56.496697Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:35.577725Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9771,10 +9771,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6xAFWvUkTSG3xw-DRErlKg"],
-        "issued_at": "2018-08-03T19:42:56.496763Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WE2yAfW-TOa6EpuaX4FFRA"],
+        "issued_at": "2018-08-06T16:55:35.577767Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9792,15 +9792,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:56 GMT
+      - Mon, 06 Aug 2018 16:55:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 27f86887e3f7420c9d14d0fd97941fcc
+      - 9aee45b7a05c42abb5949bf853b4cc01
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3647bc2e-591f-4d3a-80aa-5acd77f53a31
+      - req-ef9c7923-ae26-4dbf-8647-9f2483b67beb
       Content-Length:
       - '7265'
       Connection:
@@ -9812,7 +9812,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:56.847655Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:35.795803Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9891,10 +9891,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["afTPBymNS1uXFO1uoPEt8A"],
-        "issued_at": "2018-08-03T19:42:56.847757Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aK2FsSFpTFiZfsGHwTp2hg"],
+        "issued_at": "2018-08-06T16:55:35.795838Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9912,15 +9912,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:56 GMT
+      - Mon, 06 Aug 2018 16:55:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9df68cc45ec6490faab3c47efa00627c
+      - 144987f0197a45698bc17d1422e78449
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bcfb3b13-a309-483a-bc08-cd139901c71e
+      - req-9430108d-8e90-4c21-a0cb-d01f34bb04ff
       Content-Length:
       - '7278'
       Connection:
@@ -9932,7 +9932,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:57.241551Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:36.167952Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10011,10 +10011,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eZXHZIIzTgGpEjVjBIhQhA"],
-        "issued_at": "2018-08-03T19:42:57.241632Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LKZiWCjCQ02dls5tVou4Iw"],
+        "issued_at": "2018-08-06T16:55:36.168038Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10032,15 +10032,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:57 GMT
+      - Mon, 06 Aug 2018 16:55:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 00f7a2d29b4845e69b84f4d8d723adcc
+      - 7247342df6034c3386ffa262c6f257dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-51aa37ec-bab5-41bd-bf3d-be17ddea7761
+      - req-11b73ed5-1a6f-4f1b-a950-600bb3755b09
       Content-Length:
       - '7278'
       Connection:
@@ -10052,7 +10052,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:57.603305Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:36.493785Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10131,10 +10131,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RPqvPxelRya5Wx8sIBa80Q"],
-        "issued_at": "2018-08-03T19:42:57.603385Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GbqBkSyvTZeuJeL36BvXvw"],
+        "issued_at": "2018-08-06T16:55:36.493855Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -10149,7 +10149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00f7a2d29b4845e69b84f4d8d723adcc
+      - 7247342df6034c3386ffa262c6f257dd
   response:
     status:
       code: 200
@@ -10160,14 +10160,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-94e7410b-b7f6-46bc-a9fc-bb200bd954b5
+      - req-c123c188-759a-4c3b-8063-f35a4dc7d6a1
       Date:
-      - Fri, 03 Aug 2018 19:42:57 GMT
+      - Mon, 06 Aug 2018 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10185,15 +10185,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:57 GMT
+      - Mon, 06 Aug 2018 16:55:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2219ba016ec54f92ab1f0d13eac4ecd3
+      - 7b29a47f8b5541afb744411aef5e3a09
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-492f272a-cc39-4590-8094-b0a99759a31a
+      - req-17507103-2309-46b4-9d5c-d7a3b37dbf85
       Content-Length:
       - '7278'
       Connection:
@@ -10205,7 +10205,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:58.135555Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:37.098923Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10284,10 +10284,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zIwOXqzsQJOzExhwF69u2Q"],
-        "issued_at": "2018-08-03T19:42:58.135622Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1wd0gp9FSoWhi5DDoj4LLg"],
+        "issued_at": "2018-08-06T16:55:37.098988Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -10302,7 +10302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2219ba016ec54f92ab1f0d13eac4ecd3
+      - 7b29a47f8b5541afb744411aef5e3a09
   response:
     status:
       code: 200
@@ -10313,14 +10313,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-687111dd-c513-4d8e-b1de-3d31e595d003
+      - req-f4767e7b-eb4c-46dc-9420-23b3a7b13452
       Date:
-      - Fri, 03 Aug 2018 19:42:58 GMT
+      - Mon, 06 Aug 2018 16:55:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10338,15 +10338,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:58 GMT
+      - Mon, 06 Aug 2018 16:55:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-160ba60d-ec2c-4392-b3fe-7846e31fe8d4
+      - req-fab59308-f221-484f-a8fe-e35c1e9e4292
       Content-Length:
       - '7264'
       Connection:
@@ -10358,7 +10358,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:58.681998Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:37.612883Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10437,10 +10437,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yfGLOMnHS2i9dBXFX9dw2g"],
-        "issued_at": "2018-08-03T19:42:58.682064Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UuS0XBR-Tf-hLzrpqhzTCw"],
+        "issued_at": "2018-08-06T16:55:37.612952Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -10455,7 +10455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -10466,9 +10466,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-eb90e060-6eb2-4f7c-8126-5e156412776f
+      - req-e999472a-4227-4e1b-a6e6-dfdda75d7ddd
       Date:
-      - Fri, 03 Aug 2018 19:42:59 GMT
+      - Mon, 06 Aug 2018 16:55:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -10502,7 +10502,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -10517,7 +10517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -10528,14 +10528,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e22b377f-591b-47ce-8648-3ae3c375e79d
+      - req-6973ca4c-bc3a-42da-9cce-ec1bddaf42f6
       Date:
-      - Fri, 03 Aug 2018 19:42:59 GMT
+      - Mon, 06 Aug 2018 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10553,15 +10553,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:59 GMT
+      - Mon, 06 Aug 2018 16:55:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1e822ddbca294c809ea22b5c6626efdd
+      - 8e6245908ce44f3da0f7e93418976a2d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d4442864-12c2-4b9c-89f2-7c72e2e819c7
+      - req-b81f2cd1-674e-4c08-af34-15a8bfd766c0
       Content-Length:
       - '7278'
       Connection:
@@ -10573,7 +10573,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:59.542231Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:38.409584Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10652,10 +10652,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MA3ezjxCS721WwJBHj5_tg"],
-        "issued_at": "2018-08-03T19:42:59.542316Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IfSWoCFbSWuRarnS9_SAuw"],
+        "issued_at": "2018-08-06T16:55:38.409665Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -10670,7 +10670,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e822ddbca294c809ea22b5c6626efdd
+      - 8e6245908ce44f3da0f7e93418976a2d
   response:
     status:
       code: 200
@@ -10681,14 +10681,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-35abd8ab-208d-4332-a123-22756f37b72c
+      - req-796154c1-3988-4edd-8bf1-82ba727d5998
       Date:
-      - Fri, 03 Aug 2018 19:42:59 GMT
+      - Mon, 06 Aug 2018 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -10703,7 +10703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1432bd4682654a8c9fd766d849c997bb
+      - 72eb4dc671eb42f4b4e8e0752d9fd205
   response:
     status:
       code: 200
@@ -10714,14 +10714,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ec4038cc-57cf-46dd-9ecf-56f2283f90a4
+      - req-1754f5e8-7e5d-41c0-9378-a74208074a98
       Date:
-      - Fri, 03 Aug 2018 19:42:59 GMT
+      - Mon, 06 Aug 2018 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10739,15 +10739,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:00 GMT
+      - Mon, 06 Aug 2018 16:55:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a8eb836966d646179e6a4d2248f51041
+      - 2f9f9d4ccf00431e894336aee15c1d35
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-49705b2b-3fdc-438f-91da-16881b95fe4a
+      - req-ab03ec11-2660-49c6-b60a-2afea07a2459
       Content-Length:
       - '7265'
       Connection:
@@ -10759,7 +10759,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:00.291191Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:39.242660Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10838,10 +10838,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jwtjAWwTQy2yW-YVB4d21A"],
-        "issued_at": "2018-08-03T19:43:00.291258Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qo-YaxsPRnO9UuPU0b123w"],
+        "issued_at": "2018-08-06T16:55:39.242743Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -10856,7 +10856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a8eb836966d646179e6a4d2248f51041
+      - 2f9f9d4ccf00431e894336aee15c1d35
   response:
     status:
       code: 200
@@ -10867,14 +10867,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-45a33adc-1a20-4951-81fb-d6175b596a1a
+      - req-ac91df55-1a7e-479c-a572-0c806d0509fc
       Date:
-      - Fri, 03 Aug 2018 19:43:00 GMT
+      - Mon, 06 Aug 2018 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10892,15 +10892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:00 GMT
+      - Mon, 06 Aug 2018 16:55:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c44ac52c743a43138d77cb32b0d1a1d9
+      - 90672b4b32e34a8ba65c0ecbf72409df
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d1bed9b0-34d8-4ed6-b03e-4e33974f797b
+      - req-c4134670-6cc6-4c6d-8cf1-5693a8bc68e1
       Content-Length:
       - '7278'
       Connection:
@@ -10912,7 +10912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:00.833991Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:39.813839Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10991,10 +10991,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ef3_moJDSgWriXHGHgd9DQ"],
-        "issued_at": "2018-08-03T19:43:00.834061Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4mltnIUbQnO3tka82OBuTA"],
+        "issued_at": "2018-08-06T16:55:39.813902Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -11009,7 +11009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c44ac52c743a43138d77cb32b0d1a1d9
+      - 90672b4b32e34a8ba65c0ecbf72409df
   response:
     status:
       code: 200
@@ -11020,14 +11020,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-905c5476-2b83-42e5-9607-1f43f369f950
+      - req-f1c5725b-9282-49e1-90f7-05cbe84ff766
       Date:
-      - Fri, 03 Aug 2018 19:43:01 GMT
+      - Mon, 06 Aug 2018 16:55:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -11042,7 +11042,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11053,9 +11053,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e7b6e54c-02d9-45e8-a20f-0d9209c2352c
+      - req-0c0c2855-23bf-4220-a827-081d9375071a
       Date:
-      - Fri, 03 Aug 2018 19:43:01 GMT
+      - Mon, 06 Aug 2018 16:55:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11082,7 +11082,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -11097,7 +11097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11108,9 +11108,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0c2c7472-0664-4f98-88da-9909022f34b8
+      - req-f20ee693-d7bd-4b18-9521-ef6c2971c7ff
       Date:
-      - Fri, 03 Aug 2018 19:43:02 GMT
+      - Mon, 06 Aug 2018 16:55:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11137,7 +11137,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -11152,7 +11152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11163,9 +11163,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-48fd6409-490a-46ef-aa71-79e288007577
+      - req-47fd395c-b709-4c22-b057-f634703f5c52
       Date:
-      - Fri, 03 Aug 2018 19:43:03 GMT
+      - Mon, 06 Aug 2018 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11192,7 +11192,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -11207,7 +11207,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11218,9 +11218,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4f17250f-7f09-4fd4-942d-69c85c3c12f4
+      - req-191bb4d7-5f78-4bb0-a013-d8497577357c
       Date:
-      - Fri, 03 Aug 2018 19:43:03 GMT
+      - Mon, 06 Aug 2018 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11232,7 +11232,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -11247,7 +11247,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11258,9 +11258,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c9a46f91-8e15-47d0-a01f-14fd00181ba1
+      - req-71b8c4c5-dd5d-4b64-9108-01148bc9272e
       Date:
-      - Fri, 03 Aug 2018 19:43:03 GMT
+      - Mon, 06 Aug 2018 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11272,7 +11272,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -11287,7 +11287,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f89969e57ea4eaabc15f69a5abba04c
+      - 35d2d1ae675e424c9f2dae623addb719
   response:
     status:
       code: 200
@@ -11298,9 +11298,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4cb0973d-a23c-4629-96c9-b5e8eb147d99
+      - req-63ccf029-b43d-4ca5-96e9-c09359726dd2
       Date:
-      - Fri, 03 Aug 2018 19:43:03 GMT
+      - Mon, 06 Aug 2018 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11312,7 +11312,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -11327,7 +11327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -11338,9 +11338,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-84e946cf-925a-436c-a782-893cff5ee260
+      - req-7cf3d042-8d5e-478a-a4f7-8ed2d42a7d6e
       Date:
-      - Fri, 03 Aug 2018 19:43:04 GMT
+      - Mon, 06 Aug 2018 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -11354,127 +11354,7 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:04 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d7d8e556-d360-4a27-9bcd-3462e86d658c
-      Date:
-      - Fri, 03 Aug 2018 19:43:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -11551,8 +11431,52 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '09c8fbc8592047a0a06645c95389368b'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-113ff078-df3d-4f9b-942d-7d7c01b43c4c
+      Date:
+      - Mon, 06 Aug 2018 16:55:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -11562,20 +11486,97 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -11590,7 +11591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -11601,9 +11602,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8b03eedb-b3de-4624-882d-37ffa95c6e0d
+      - req-3141812e-d54f-44a6-93aa-8a7878eeeeaa
       Date:
-      - Fri, 03 Aug 2018 19:43:04 GMT
+      - Mon, 06 Aug 2018 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11645,7 +11646,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -11660,7 +11661,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -11671,9 +11672,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-902e6b1b-ac3f-4f2e-8176-7cba6b0bbe43
+      - req-2b209c11-0eaa-4522-ab65-576ad5cdefb0
       Date:
-      - Fri, 03 Aug 2018 19:43:04 GMT
+      - Mon, 06 Aug 2018 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11715,7 +11716,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -11730,7 +11731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -11741,9 +11742,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6c6236b4-fdaa-4ab5-87be-127e6181e041
+      - req-a7156b92-6f57-4e56-9fd8-4da1da753868
       Date:
-      - Fri, 03 Aug 2018 19:43:04 GMT
+      - Mon, 06 Aug 2018 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12146,7 +12147,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -12161,7 +12162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12172,9 +12173,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-10d060fa-fdc7-4080-bca9-11d13acb54fb
+      - req-06a86ecc-ad45-468b-ba8c-5d04cc90ac86
       Date:
-      - Fri, 03 Aug 2018 19:43:05 GMT
+      - Mon, 06 Aug 2018 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12577,7 +12578,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -12592,7 +12593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12603,9 +12604,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f05739f7-6b4b-47ef-902b-1bfd020f8ec1
+      - req-9ff91ef7-7963-4821-8e86-6773ea449d91
       Date:
-      - Fri, 03 Aug 2018 19:43:05 GMT
+      - Mon, 06 Aug 2018 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12637,7 +12638,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -12652,7 +12653,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12663,9 +12664,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-7e9d0396-c593-42c1-aa44-1a491209d62a
+      - req-e700b547-20f9-4943-8f44-3cff811179d1
       Date:
-      - Fri, 03 Aug 2018 19:43:05 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12697,7 +12698,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -12712,7 +12713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12723,9 +12724,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-3f89008f-9c43-43f7-8c3b-c53f00a28f2b
+      - req-1b4d4d74-f90e-4317-89f3-33357e618855
       Date:
-      - Fri, 03 Aug 2018 19:43:05 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -12760,7 +12761,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -12775,7 +12776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12786,9 +12787,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-4de7ff1c-5c60-431d-8565-8d08a8ac5817
+      - req-086edc60-2d9c-49f4-bdaa-254784981ec6
       Date:
-      - Fri, 03 Aug 2018 19:43:05 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -12831,7 +12832,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -12846,7 +12847,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12857,9 +12858,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-be69c792-8720-4165-b97e-fa733764e066
+      - req-fb1565ce-bd38-4f13-990f-6c9a559344e1
       Date:
-      - Fri, 03 Aug 2018 19:43:06 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -12902,7 +12903,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -12917,7 +12918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -12928,9 +12929,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-ad8aa104-4ebb-452b-925f-e42f081f23f9
+      - req-f98e86b6-3a5b-4695-879f-6fad24a718c0
       Date:
-      - Fri, 03 Aug 2018 19:43:06 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -13037,7 +13038,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -13052,7 +13053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -13063,9 +13064,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-ac4054bb-b373-46af-80f8-97b2a2437fe1
+      - req-e18f1a93-7d55-492e-bc54-a9254f15285f
       Date:
-      - Fri, 03 Aug 2018 19:43:06 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -13107,7 +13108,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -13122,7 +13123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d5ecf1f3d8e4a5f9fc55be3ee5cd4b4
+      - '09c8fbc8592047a0a06645c95389368b'
   response:
     status:
       code: 200
@@ -13133,15 +13134,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-59d56e7f-96e9-4e85-b468-04bf3482518a
+      - req-6f8246dd-c529-4eed-aaf6-ff64285c8562
       Date:
-      - Fri, 03 Aug 2018 19:43:06 GMT
+      - Mon, 06 Aug 2018 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13159,15 +13160,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:07 GMT
+      - Mon, 06 Aug 2018 16:55:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a97ba38a8dd44fc2823df4bf8b3e22b0
+      - 4b6e8541e18a440ea7c6367ad9bff2ad
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3abbf445-ecaf-4f86-8c75-725d1a2c6da7
+      - req-2de96f34-8232-4f66-a49b-4abf73902802
       Content-Length:
       - '7311'
       Connection:
@@ -13179,7 +13180,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:43:07.414352Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:46.787322Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13258,10 +13259,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u3ts7km5QhqEEpSSsIXr5g"],
-        "issued_at": "2018-08-03T19:43:07.414418Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["57Exgp37QsW9v1l0LZPxxg"],
+        "issued_at": "2018-08-06T16:55:46.787402Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13279,15 +13280,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:07 GMT
+      - Mon, 06 Aug 2018 16:55:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-975ac146-6fba-4c0c-bf9e-bb96f1c131aa
+      - req-332fbd20-8754-41a8-b278-accd0215efff
       Content-Length:
       - '7311'
       Connection:
@@ -13299,7 +13300,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:43:07.764741Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:47.142694Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13378,10 +13379,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fpOflILmTg--bocv2ADjAQ"],
-        "issued_at": "2018-08-03T19:43:07.764813Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oHNHJpiXR4q9Blk2f71Qqg"],
+        "issued_at": "2018-08-06T16:55:47.142766Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13399,15 +13400,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:07 GMT
+      - Mon, 06 Aug 2018 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6088f0dfce064ba3b8e6b89fa553f39e
+      - 6672b8c747c84d99b3db18475da581a2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-28761db8-aa57-44f2-8f84-e1c53edcbea1
+      - req-92895b9d-139d-49e6-ab3f-de55ce786953
       Content-Length:
       - '297'
       Connection:
@@ -13416,12 +13417,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:43:08.068517Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:55:47.373680Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R8Ml7q8-QtGLHyyv-mTaWw"],
-        "issued_at": "2018-08-03T19:43:08.068597Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cwLS_LycTQaz0Wod7qabCA"],
+        "issued_at": "2018-08-06T16:55:47.373739Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -13436,20 +13437,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6088f0dfce064ba3b8e6b89fa553f39e
+      - 6672b8c747c84d99b3db18475da581a2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:08 GMT
+      - Mon, 06 Aug 2018 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-08d662b5-82d2-4361-ae1b-ffac5d083875
+      - req-13770e27-f69b-4a72-babf-a373a099e7f2
       Content-Length:
       - '2457'
       Connection:
@@ -13482,13 +13483,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"6088f0dfce064ba3b8e6b89fa553f39e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"6672b8c747c84d99b3db18475da581a2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13500,15 +13501,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:08 GMT
+      - Mon, 06 Aug 2018 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 76db4297c8f640f7926ca2354bc91c82
+      - be5194b1a15c49d2b9d647a8d54a7806
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a7608a4-c592-4893-b17b-7b1cd7207938
+      - req-1b0b4669-db18-41a6-a962-c6aad94df16f
       Content-Length:
       - '7313'
       Connection:
@@ -13520,7 +13521,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:08.068517Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:47.373680Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13599,10 +13600,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1UdoMiU5TSSNcolMYGE02w",
-        "R8Ml7q8-QtGLHyyv-mTaWw"], "issued_at": "2018-08-03T19:43:08.654065Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y7sUMCgFQe25odMLkXR67Q",
+        "cwLS_LycTQaz0Wod7qabCA"], "issued_at": "2018-08-06T16:55:47.834474Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -13617,20 +13618,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76db4297c8f640f7926ca2354bc91c82
+      - be5194b1a15c49d2b9d647a8d54a7806
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:08 GMT
+      - Mon, 06 Aug 2018 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d8ad67cb-8d58-4d96-b438-097d8070f4e9
+      - req-ab77d34a-6aae-427a-9f39-267446361ca1
       Content-Length:
       - '2179'
       Connection:
@@ -13663,7 +13664,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13681,15 +13682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:08 GMT
+      - Mon, 06 Aug 2018 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 68df8dd4910542c789c614d07c5c36dc
+      - 0a7320677dc548098f66330cd513a0ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ab268d7d-34d5-4c53-b546-a86feab8e15f
+      - req-ecd47644-838b-4df5-8363-af0f58259189
       Content-Length:
       - '7278'
       Connection:
@@ -13701,7 +13702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:09.283574Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:48.301413Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13780,10 +13781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cNOaHtOeTdWBic-FRvg0jA"],
-        "issued_at": "2018-08-03T19:43:09.283676Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oVamdsp2ScK8k202nHIiVQ"],
+        "issued_at": "2018-08-06T16:55:48.301482Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13801,15 +13802,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:09 GMT
+      - Mon, 06 Aug 2018 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dc96e3a7cd614d74860ee6d615838b0f
+      - 9ab08d6d843641ceb194f2e8f4dcb4c9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-26954d6d-acb6-454d-acda-92c2e2f85caf
+      - req-92e2cbea-e8ff-4cd6-bda3-a896ddaeffd9
       Content-Length:
       - '7278'
       Connection:
@@ -13821,7 +13822,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:09.731956Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:48.949935Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13900,10 +13901,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ui6VgorYQXCq7qKp-geDBA"],
-        "issued_at": "2018-08-03T19:43:09.732035Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sSqI-K-zQV2e6SorTFx_aw"],
+        "issued_at": "2018-08-06T16:55:48.950022Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13921,15 +13922,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:09 GMT
+      - Mon, 06 Aug 2018 16:55:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 172bbdcf68df474fbaa658e850c4421e
+      - 32f209de173f446ca1042e68263fdd7f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f1bb45ca-4a50-4221-a4e5-5735a60a213c
+      - req-a99c954f-7678-4e1c-ad6e-f9596c26b8b3
       Content-Length:
       - '7264'
       Connection:
@@ -13941,7 +13942,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:10.139825Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:49.247454Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14020,10 +14021,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dC-nFg7pRq6F3Bqd1hDYHg"],
-        "issued_at": "2018-08-03T19:43:10.139903Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BjkmKYWqTNewyygdHjo7Sw"],
+        "issued_at": "2018-08-06T16:55:49.247509Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14041,15 +14042,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:10 GMT
+      - Mon, 06 Aug 2018 16:55:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5f3a5838476e4f58a1687c8b27393f3a
+      - b38fb76198be4331844071fccc0b4468
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ae16914f-d8fe-49a9-8ef2-e9b66e4c3fd0
+      - req-b6563445-0064-457f-ae13-b17207090c5d
       Content-Length:
       - '7278'
       Connection:
@@ -14061,7 +14062,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:10.626713Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:49.563439Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14140,10 +14141,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4_gXEQLxTWWaRv8YizzZag"],
-        "issued_at": "2018-08-03T19:43:10.626778Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1_3emxHjQ6mY8us-Lp3oZA"],
+        "issued_at": "2018-08-06T16:55:49.563515Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14161,15 +14162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:10 GMT
+      - Mon, 06 Aug 2018 16:55:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aece6535378d4d489fc592119ddef4a3
+      - ef07ee22b878413aa6a60ebaf21d3aab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eb34f71d-4834-45c0-b521-33811bff444c
+      - req-d024f3c1-2f7d-4ad7-95cc-9c60e0c75db1
       Content-Length:
       - '7265'
       Connection:
@@ -14181,7 +14182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:10.998071Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:49.894801Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14260,10 +14261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fjw0Z2MsSWOqtTJPrIR5ow"],
-        "issued_at": "2018-08-03T19:43:10.998260Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sCE3A9CXTeuyiHI7yeMYtQ"],
+        "issued_at": "2018-08-06T16:55:49.894866Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14281,15 +14282,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:11 GMT
+      - Mon, 06 Aug 2018 16:55:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 97a6bf59543446f4a4c53a96d500b0d0
+      - e0b27c6528f0443695705755906cb023
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-be403ea6-4dcd-45ed-8c14-adedf93b06c7
+      - req-57100f62-f556-4b14-907f-74935990ae6b
       Content-Length:
       - '7278'
       Connection:
@@ -14301,7 +14302,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:11.408785Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:50.233942Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14380,10 +14381,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_a_jukwVSZWMr9isBX6w6w"],
-        "issued_at": "2018-08-03T19:43:11.408873Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t8T9hObWSXejWk-9KP4eMw"],
+        "issued_at": "2018-08-06T16:55:50.234036Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14401,15 +14402,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:11 GMT
+      - Mon, 06 Aug 2018 16:55:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-27ee3bb6-b32b-4671-810e-eb7af89c8733
+      - req-851fbf83-a292-4df6-a961-20ead69d8cce
       Content-Length:
       - '7278'
       Connection:
@@ -14421,7 +14422,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:11.745686Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:50.608002Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14500,10 +14501,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qD3pOXCDSGia1pvh52m4rg"],
-        "issued_at": "2018-08-03T19:43:11.745752Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rPqcnUw7R5GKfuktCsaOLg"],
+        "issued_at": "2018-08-06T16:55:50.608082Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -14518,27 +14519,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70873adb-f9fa-44d0-8f37-805dc65baaf1
+      - req-d0e38e6f-a603-417e-a382-005b1fe13f7e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-70873adb-f9fa-44d0-8f37-805dc65baaf1
+      - req-d0e38e6f-a603-417e-a382-005b1fe13f7e
       Date:
-      - Fri, 03 Aug 2018 19:43:12 GMT
+      - Mon, 06 Aug 2018 16:55:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14556,15 +14557,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:12 GMT
+      - Mon, 06 Aug 2018 16:55:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-13a302d6-db6d-47e8-b243-b89c59634263
+      - req-d0ca1fef-ab59-4632-a256-d5b03acfd075
       Content-Length:
       - '7278'
       Connection:
@@ -14576,7 +14577,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:12.383655Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:51.276348Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14655,10 +14656,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KhLKcghyTkKdvJ44e7P2UA"],
-        "issued_at": "2018-08-03T19:43:12.383749Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qGumuEQrQUyTQsXABKq_JA"],
+        "issued_at": "2018-08-06T16:55:51.276429Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -14673,27 +14674,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-32f244ec-f438-4c1a-bfb1-9ad7a7c7dde4
+      - req-a4e1a8f7-578c-4daa-bffa-072e036e6163
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-32f244ec-f438-4c1a-bfb1-9ad7a7c7dde4
+      - req-a4e1a8f7-578c-4daa-bffa-072e036e6163
       Date:
-      - Fri, 03 Aug 2018 19:43:12 GMT
+      - Mon, 06 Aug 2018 16:55:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14711,15 +14712,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:12 GMT
+      - Mon, 06 Aug 2018 16:55:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5206a158-4fdd-4ff4-b1bb-2139ca4b9ba6
+      - req-bdb1e659-8e80-432a-a913-c1e4c88c0cc0
       Content-Length:
       - '7264'
       Connection:
@@ -14731,7 +14732,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:13.044467Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:51.907475Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14810,10 +14811,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tLrZaZpTTl6xXBPBkQPvmQ"],
-        "issued_at": "2018-08-03T19:43:13.044550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AAiui3feRUaCR6jJ-kRKFw"],
+        "issued_at": "2018-08-06T16:55:51.907549Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -14828,22 +14829,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-387cadb4-64b3-414b-a372-7e2818371186
+      - req-a7b84aa6-affa-4e2f-9c8b-0295268b2d55
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-387cadb4-64b3-414b-a372-7e2818371186
+      - req-a7b84aa6-affa-4e2f-9c8b-0295268b2d55
       Date:
-      - Fri, 03 Aug 2018 19:43:13 GMT
+      - Mon, 06 Aug 2018 16:55:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -14876,7 +14877,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -14891,22 +14892,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7abba81e-b232-44da-afde-0a03ba382f4a
+      - req-cc7ca1da-2b0e-4c73-9eb1-c9de28ee07e2
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-7abba81e-b232-44da-afde-0a03ba382f4a
+      - req-cc7ca1da-2b0e-4c73-9eb1-c9de28ee07e2
       Date:
-      - Fri, 03 Aug 2018 19:43:13 GMT
+      - Mon, 06 Aug 2018 16:55:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -14947,7 +14948,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -14962,22 +14963,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9eb8b6f1-46dc-49d2-9fa3-deb28fd96c87
+      - req-0e3b2ccc-31ce-40d9-89bb-a9575498d99d
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-9eb8b6f1-46dc-49d2-9fa3-deb28fd96c87
+      - req-0e3b2ccc-31ce-40d9-89bb-a9575498d99d
       Date:
-      - Fri, 03 Aug 2018 19:43:14 GMT
+      - Mon, 06 Aug 2018 16:55:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -15011,7 +15012,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -15026,27 +15027,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f7a8c12-40bf-495e-8130-409ea7c404ff
+      - req-e0e5c42a-8e87-47c1-9995-786df4321a58
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4f7a8c12-40bf-495e-8130-409ea7c404ff
+      - req-e0e5c42a-8e87-47c1-9995-786df4321a58
       Date:
-      - Fri, 03 Aug 2018 19:43:14 GMT
+      - Mon, 06 Aug 2018 16:55:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15064,15 +15065,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:14 GMT
+      - Mon, 06 Aug 2018 16:55:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e76b5c0f-117c-4474-babf-8ed27fefcab3
+      - req-3c19e0f4-d100-4fd0-b2df-548c50695093
       Content-Length:
       - '7278'
       Connection:
@@ -15084,7 +15085,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:14.783188Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:53.734364Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15163,10 +15164,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tTa0fxabRgicePNKdVBLtQ"],
-        "issued_at": "2018-08-03T19:43:14.783272Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WaA_5mqyQPitu5N76fyYGg"],
+        "issued_at": "2018-08-06T16:55:53.734438Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -15181,27 +15182,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eafcc6d7-46ab-4bd0-b199-b184b089a61a
+      - req-582febda-a64c-4942-a416-20e4d34eb1dc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-eafcc6d7-46ab-4bd0-b199-b184b089a61a
+      - req-582febda-a64c-4942-a416-20e4d34eb1dc
       Date:
-      - Fri, 03 Aug 2018 19:43:15 GMT
+      - Mon, 06 Aug 2018 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -15216,27 +15217,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b4ca98a6-d5a2-43aa-9b51-ea7b7fd728bd
+      - req-3eae4429-80f9-4e62-8c40-c346de01a101
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b4ca98a6-d5a2-43aa-9b51-ea7b7fd728bd
+      - req-3eae4429-80f9-4e62-8c40-c346de01a101
       Date:
-      - Fri, 03 Aug 2018 19:43:15 GMT
+      - Mon, 06 Aug 2018 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15254,15 +15255,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:15 GMT
+      - Mon, 06 Aug 2018 16:55:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dd4956ba-4e90-47f6-a744-7fb8880013c8
+      - req-9198728b-7609-438e-affa-3283bca0051e
       Content-Length:
       - '7265'
       Connection:
@@ -15274,7 +15275,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:15.696846Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:54.682188Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15353,10 +15354,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EG2XMuxBSKauHLzNAkQtww"],
-        "issued_at": "2018-08-03T19:43:15.696912Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vGD3z6AYTtSOrsEi_REHjw"],
+        "issued_at": "2018-08-06T16:55:54.682271Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -15371,27 +15372,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f46f6217-3405-4c17-9fe4-723ab0234cd4
+      - req-3aa8fccc-5c20-4c81-85ba-549a53df6b7d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f46f6217-3405-4c17-9fe4-723ab0234cd4
+      - req-3aa8fccc-5c20-4c81-85ba-549a53df6b7d
       Date:
-      - Fri, 03 Aug 2018 19:43:15 GMT
+      - Mon, 06 Aug 2018 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15409,15 +15410,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:16 GMT
+      - Mon, 06 Aug 2018 16:55:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f4179cd3-2e8d-4bb6-9462-36bd5fc7936a
+      - req-e5f98e7a-482c-406a-8a71-f95da314e6fd
       Content-Length:
       - '7278'
       Connection:
@@ -15429,7 +15430,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:16.261806Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:55:55.375382Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15508,10 +15509,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ShgbQsBIQhWEn-PHKaJjwA"],
-        "issued_at": "2018-08-03T19:43:16.261872Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O4D_b0tKSTeoAYBt8Za9OQ"],
+        "issued_at": "2018-08-06T16:55:55.375466Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -15526,27 +15527,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-66ba1619-afde-4659-8768-815a28d84592
+      - req-c2895541-5fa8-4907-84cc-a2083b716dea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-66ba1619-afde-4659-8768-815a28d84592
+      - req-c2895541-5fa8-4907-84cc-a2083b716dea
       Date:
-      - Fri, 03 Aug 2018 19:43:16 GMT
+      - Mon, 06 Aug 2018 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -15561,27 +15562,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46a3ab08-1eb6-4d01-8d05-25c5246612e9
+      - req-2059a09c-9fa9-4a65-918a-c952a18e3b71
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-46a3ab08-1eb6-4d01-8d05-25c5246612e9
+      - req-2059a09c-9fa9-4a65-918a-c952a18e3b71
       Date:
-      - Fri, 03 Aug 2018 19:43:16 GMT
+      - Mon, 06 Aug 2018 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -15596,27 +15597,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1329de8-07a3-4538-bca0-3a82b99f834f
+      - req-1e3aa08e-d5d0-40e5-bdcc-eefec2cf286d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a1329de8-07a3-4538-bca0-3a82b99f834f
+      - req-1e3aa08e-d5d0-40e5-bdcc-eefec2cf286d
       Date:
-      - Fri, 03 Aug 2018 19:43:16 GMT
+      - Mon, 06 Aug 2018 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -15631,27 +15632,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2a68809-9355-4d9a-8371-628f31f7a583
+      - req-97aae816-4b11-40e4-b2f9-521005af166f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f2a68809-9355-4d9a-8371-628f31f7a583
+      - req-97aae816-4b11-40e4-b2f9-521005af166f
       Date:
-      - Fri, 03 Aug 2018 19:43:16 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -15666,27 +15667,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7289ccde-8d6c-472e-8fc7-1c7e8035cf3c
+      - req-e9991a67-ae6f-4a07-a9b1-aa22b9cd7be1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7289ccde-8d6c-472e-8fc7-1c7e8035cf3c
+      - req-e9991a67-ae6f-4a07-a9b1-aa22b9cd7be1
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -15701,22 +15702,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3bae286-d289-44fe-8750-b990cc957e55
+      - req-7bfb8976-1c4e-4c81-b043-5da820439314
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-d3bae286-d289-44fe-8750-b990cc957e55
+      - req-7bfb8976-1c4e-4c81-b043-5da820439314
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15731,7 +15732,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -15746,22 +15747,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c605bbfd-280b-4d8b-846a-7b97447ea238
+      - req-184d8541-409e-496a-b420-9db94e9d13d0
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-c605bbfd-280b-4d8b-846a-7b97447ea238
+      - req-184d8541-409e-496a-b420-9db94e9d13d0
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15776,7 +15777,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -15791,27 +15792,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1f5cc778-1622-4054-97f3-fcc5f076b4af
+      - req-46fcfe47-7413-41f6-ad1a-ee2d4245a62f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1f5cc778-1622-4054-97f3-fcc5f076b4af
+      - req-46fcfe47-7413-41f6-ad1a-ee2d4245a62f
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -15826,27 +15827,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ba5a785b-ecea-4cc0-a7b0-e543aec37aa6
+      - req-7ed588f1-b759-410f-a101-f0babe4eb386
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ba5a785b-ecea-4cc0-a7b0-e543aec37aa6
+      - req-7ed588f1-b759-410f-a101-f0babe4eb386
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -15861,27 +15862,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b06b77a-f1fe-4596-ae76-afd7ee56b3be
+      - req-7c24089c-32d1-4265-a2c6-c90923127ec4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9b06b77a-f1fe-4596-ae76-afd7ee56b3be
+      - req-7c24089c-32d1-4265-a2c6-c90923127ec4
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -15896,27 +15897,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-43a16915-46c6-4139-9a2b-dc9493d5d299
+      - req-2b60b487-3fdd-4b72-9ae3-1454e3c0d26d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-43a16915-46c6-4139-9a2b-dc9493d5d299
+      - req-2b60b487-3fdd-4b72-9ae3-1454e3c0d26d
       Date:
-      - Fri, 03 Aug 2018 19:43:17 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -15931,27 +15932,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-320508e0-7752-4905-a5d2-2305ebb8b53c
+      - req-c35f1169-8124-4f9a-95e3-061836f3e785
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-320508e0-7752-4905-a5d2-2305ebb8b53c
+      - req-c35f1169-8124-4f9a-95e3-061836f3e785
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -15966,27 +15967,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-537afb11-2605-4502-82c5-f895674d69c4
+      - req-c7d5cbff-eeed-4a43-af78-084318658aa3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-537afb11-2605-4502-82c5-f895674d69c4
+      - req-c7d5cbff-eeed-4a43-af78-084318658aa3
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -16001,27 +16002,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2f87677-8cf3-4d5c-9973-57b9fbb80e32
+      - req-45950aee-18a1-40af-ade7-a358f8faa8f7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2f87677-8cf3-4d5c-9973-57b9fbb80e32
+      - req-45950aee-18a1-40af-ade7-a358f8faa8f7
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -16036,27 +16037,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7adfbabf-0a0f-4170-914b-a63bbaa7fdd3
+      - req-619a230d-89da-45c2-973f-72d6f5ca4e15
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7adfbabf-0a0f-4170-914b-a63bbaa7fdd3
+      - req-619a230d-89da-45c2-973f-72d6f5ca4e15
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -16071,27 +16072,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0edcdb28-5711-4840-8f51-46ad2231d8af
+      - req-3cb23f05-6b2e-43f7-b77e-2cf5af451d2c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0edcdb28-5711-4840-8f51-46ad2231d8af
+      - req-3cb23f05-6b2e-43f7-b77e-2cf5af451d2c
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -16106,27 +16107,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-863f994b-7a51-4092-b213-1582b5adc90c
+      - req-8d442141-6f07-4e31-9af7-101fb7bb94d3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-863f994b-7a51-4092-b213-1582b5adc90c
+      - req-8d442141-6f07-4e31-9af7-101fb7bb94d3
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -16141,27 +16142,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41be1b4c-0fc2-45ee-9052-ff69b7da9175
+      - req-347dac5a-1bd0-4c0b-8b2a-f3f513e22e04
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-41be1b4c-0fc2-45ee-9052-ff69b7da9175
+      - req-347dac5a-1bd0-4c0b-8b2a-f3f513e22e04
       Date:
-      - Fri, 03 Aug 2018 19:43:18 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -16176,27 +16177,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b633f98-c24b-4e3a-bf6e-a16fe845576a
+      - req-f0c5ac61-58e8-4743-9c93-b6ce9927ff7c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2b633f98-c24b-4e3a-bf6e-a16fe845576a
+      - req-f0c5ac61-58e8-4743-9c93-b6ce9927ff7c
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -16211,27 +16212,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4dd37d42-abef-4b92-91a7-ae9a54206ebc
+      - req-a85d9715-0c44-4743-bb05-923ae1be8498
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4dd37d42-abef-4b92-91a7-ae9a54206ebc
+      - req-a85d9715-0c44-4743-bb05-923ae1be8498
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -16246,27 +16247,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52d8a9e5-13cd-48c5-b66c-3a6c6df812b0
+      - req-d08e6b21-1548-4e15-9a04-85410b246e07
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-52d8a9e5-13cd-48c5-b66c-3a6c6df812b0
+      - req-d08e6b21-1548-4e15-9a04-85410b246e07
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -16281,27 +16282,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f20e3a92-cd0c-42d8-b173-7746b247742d
+      - req-f322ea5d-a966-4f43-88ff-9a3993aeb8eb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f20e3a92-cd0c-42d8-b173-7746b247742d
+      - req-f322ea5d-a966-4f43-88ff-9a3993aeb8eb
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -16316,27 +16317,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eefb1429-18fb-4223-8d1a-cf1d0dbd1400
+      - req-4c3e1ef8-54e7-4dc5-a1d3-e9013adb6049
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-eefb1429-18fb-4223-8d1a-cf1d0dbd1400
+      - req-4c3e1ef8-54e7-4dc5-a1d3-e9013adb6049
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -16351,27 +16352,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f4d401a-2bb9-448b-9f8a-d35f8a0626f1
+      - req-c086e2c0-d1eb-44f0-9171-9003da5594b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2f4d401a-2bb9-448b-9f8a-d35f8a0626f1
+      - req-c086e2c0-d1eb-44f0-9171-9003da5594b5
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -16386,27 +16387,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e11c5941-b238-4e0c-8535-207ee1dcbad2
+      - req-fbb6528d-248d-460e-8ecc-13335d295fc3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e11c5941-b238-4e0c-8535-207ee1dcbad2
+      - req-fbb6528d-248d-460e-8ecc-13335d295fc3
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -16421,27 +16422,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e5260f3-21cb-402e-909e-9860d1fb0fd2
+      - req-c4d0f405-3c80-46a1-8f78-9d0eed00f580
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6e5260f3-21cb-402e-909e-9860d1fb0fd2
+      - req-c4d0f405-3c80-46a1-8f78-9d0eed00f580
       Date:
-      - Fri, 03 Aug 2018 19:43:19 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -16456,27 +16457,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6898f138-4607-469c-8234-eb8f01e4280c
+      - req-2361c0de-b2fc-48d3-a495-1621be365425
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6898f138-4607-469c-8234-eb8f01e4280c
+      - req-2361c0de-b2fc-48d3-a495-1621be365425
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -16491,27 +16492,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3d78d043-d8e4-4411-91d9-6404e8d56445
+      - req-2e690320-6124-49e6-b6f7-aeacc9462a96
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3d78d043-d8e4-4411-91d9-6404e8d56445
+      - req-2e690320-6124-49e6-b6f7-aeacc9462a96
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -16526,27 +16527,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63a427ae-db76-4bae-bec1-648bfbc5ca0b
+      - req-553bc65b-329e-4630-8517-e28fdd673262
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-63a427ae-db76-4bae-bec1-648bfbc5ca0b
+      - req-553bc65b-329e-4630-8517-e28fdd673262
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -16561,22 +16562,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c36fb3a-a6d6-4bef-95ad-7dfed7667739
+      - req-0e47ecaa-ee2b-461c-8705-db8728e2094b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6c36fb3a-a6d6-4bef-95ad-7dfed7667739
+      - req-0e47ecaa-ee2b-461c-8705-db8728e2094b
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16588,7 +16589,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16603,22 +16604,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef195d9531bc460eb997a9566547a222
+      - b795dd70ee1142c3a7f0f11e7524cd6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e63db3c-be3b-4f8e-a4da-b8c47720978a
+      - req-46fde644-9a91-4734-a8ae-88ff51ef19ac
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8e63db3c-be3b-4f8e-a4da-b8c47720978a
+      - req-46fde644-9a91-4734-a8ae-88ff51ef19ac
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16630,7 +16631,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -16645,22 +16646,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e11b55c1-02c7-44fe-875b-ff2e98d2204c
+      - req-7da1fa52-42ff-49bd-8a8c-918249703485
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e11b55c1-02c7-44fe-875b-ff2e98d2204c
+      - req-7da1fa52-42ff-49bd-8a8c-918249703485
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16672,7 +16673,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16687,22 +16688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5cfe2c40647444b98eefe9144c49b183
+      - 825cf74329eb4e2cb578a34f1bae69c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d46c2651-88fa-4fe8-a7c3-555ed90030a0
+      - req-8d5cdec4-d357-49ff-9c3c-89a448890643
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d46c2651-88fa-4fe8-a7c3-555ed90030a0
+      - req-8d5cdec4-d357-49ff-9c3c-89a448890643
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16714,7 +16715,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -16729,22 +16730,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-872fb432-be39-486b-8aeb-b8994c2561c2
+      - req-7db53982-3be0-4591-b485-a2a2fab912f9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-872fb432-be39-486b-8aeb-b8994c2561c2
+      - req-7db53982-3be0-4591-b485-a2a2fab912f9
       Date:
-      - Fri, 03 Aug 2018 19:43:20 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16756,7 +16757,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16771,22 +16772,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c9cd3fafed04943bc6961014c1d593e
+      - 21afc3be0884495ab311d6e550dee000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad103ebe-556b-4e65-aa24-08278c02d54a
+      - req-71ed0f1c-9eae-4b11-9fc0-d1c23bbe3e8b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ad103ebe-556b-4e65-aa24-08278c02d54a
+      - req-71ed0f1c-9eae-4b11-9fc0-d1c23bbe3e8b
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16798,7 +16799,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -16813,22 +16814,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97f54277-b261-4dfc-be60-1a3f2e879de9
+      - req-ef7e2dac-f8ff-422c-a2be-780da1d30aa3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-97f54277-b261-4dfc-be60-1a3f2e879de9
+      - req-ef7e2dac-f8ff-422c-a2be-780da1d30aa3
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16840,7 +16841,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16855,22 +16856,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 101b9a97101d4f25ab965eb1c3f01dab
+      - ed5f37e2ae5941e39d363c5d6fbf384f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-456741c9-e704-4e6f-9c9d-ab467e86ebf8
+      - req-89cd8eac-5768-469d-b280-530946fdb2d7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-456741c9-e704-4e6f-9c9d-ab467e86ebf8
+      - req-89cd8eac-5768-469d-b280-530946fdb2d7
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16882,7 +16883,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -16897,22 +16898,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d89964c0-3671-4f83-8ab5-5f07fb9ab523
+      - req-92ac25be-c183-4f90-91f9-22924e98b31c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d89964c0-3671-4f83-8ab5-5f07fb9ab523
+      - req-92ac25be-c183-4f90-91f9-22924e98b31c
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16924,7 +16925,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16939,22 +16940,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a03def41a04b0c994710446859afbe
+      - 702f82d6ebc740ad8b94249f37699456
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cad6b529-a1f3-4b57-b36f-a0d293a783de
+      - req-65c9b489-3fb7-46e6-a790-1151d357c755
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cad6b529-a1f3-4b57-b36f-a0d293a783de
+      - req-65c9b489-3fb7-46e6-a790-1151d357c755
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16966,7 +16967,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -16981,22 +16982,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d623538f-c75e-4005-b19e-0ddc8d75cb28
+      - req-797d47e5-02b2-493f-a305-a8616a76ef35
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d623538f-c75e-4005-b19e-0ddc8d75cb28
+      - req-797d47e5-02b2-493f-a305-a8616a76ef35
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17008,7 +17009,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -17023,22 +17024,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d666b2ee1de24e8391a425fc7aeacff5
+      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b5c0619-7b95-4bd9-a493-0e184e2c0dec
+      - req-32fd0eac-d05f-4381-8f15-b1c98f3eb391
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-2b5c0619-7b95-4bd9-a493-0e184e2c0dec
+      - req-32fd0eac-d05f-4381-8f15-b1c98f3eb391
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17050,7 +17051,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -17065,22 +17066,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fb64d67-b218-46cf-889a-3e8f905b56b0
+      - req-9d83367d-9e96-418b-aaff-ea7b5dff27d1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0fb64d67-b218-46cf-889a-3e8f905b56b0
+      - req-9d83367d-9e96-418b-aaff-ea7b5dff27d1
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17092,7 +17093,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -17107,22 +17108,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0b78fbebc364fee894fb3351d866dc4
+      - 0a611dc3229141c08c4a69a9b0bc18ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-270b584c-e7e1-48f2-9454-eb25acfd9d6f
+      - req-7a1d1548-ceb4-4f0c-86c4-7bffa2754272
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-270b584c-e7e1-48f2-9454-eb25acfd9d6f
+      - req-7a1d1548-ceb4-4f0c-86c4-7bffa2754272
       Date:
-      - Fri, 03 Aug 2018 19:43:21 GMT
+      - Mon, 06 Aug 2018 16:56:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17134,7 +17135,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17152,15 +17153,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:22 GMT
+      - Mon, 06 Aug 2018 16:56:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ffc23fb95ba440fb84acfaba208315ba
+      - ea2b8f7a5ed442fa844c253bdd2e2e9c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47a56315-5e5b-405d-be4f-94e78254f8cc
+      - req-43014e4b-fee4-453a-9c2d-9c3cb183c047
       Content-Length:
       - '7311'
       Connection:
@@ -17172,7 +17173,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:43:22.329665Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:56:01.624633Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17251,10 +17252,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XhQ8pbmPTN6FRhjAje5yEg"],
-        "issued_at": "2018-08-03T19:43:22.329729Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bT8yKcJZTwiUEUACgiuj8g"],
+        "issued_at": "2018-08-06T16:56:01.624699Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17272,15 +17273,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:22 GMT
+      - Mon, 06 Aug 2018 16:56:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 776b7b24168a4e69a16b0944b2538e8b
+      - da2a10ab77f240fdb946d0d8a809bc63
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-30e1aa18-e138-45d0-a5ab-0dfc0c76d10b
+      - req-1f6aa80a-8b85-4e71-83c6-bcdf6a068966
       Content-Length:
       - '7311'
       Connection:
@@ -17292,7 +17293,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:43:22.679627Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:56:01.969541Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17371,10 +17372,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["36yzAKJnTEeVf9F-4vex-w"],
-        "issued_at": "2018-08-03T19:43:22.679700Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["68CsGWYnSbqvcvXogk0Y4g"],
+        "issued_at": "2018-08-06T16:56:01.969609Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17392,15 +17393,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:22 GMT
+      - Mon, 06 Aug 2018 16:56:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9d39d00863947a2b33dca4549556c62
+      - 444e693c069c47b285bdf612e4706d17
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-177286f2-aa89-4188-bfe4-43eba4a33016
+      - req-dbf22e71-be06-4f5c-a1af-7582b6911dc4
       Content-Length:
       - '297'
       Connection:
@@ -17409,12 +17410,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:43:22.908386Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:56:02.215053Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oDxQKhatS3exhPVzGux7XQ"],
-        "issued_at": "2018-08-03T19:43:22.908452Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z9TFsW2KSO6DtSo1G9CAIQ"],
+        "issued_at": "2018-08-06T16:56:02.215211Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -17429,20 +17430,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9d39d00863947a2b33dca4549556c62
+      - 444e693c069c47b285bdf612e4706d17
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:23 GMT
+      - Mon, 06 Aug 2018 16:56:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c15e208b-0aad-4257-9fac-b33d0b144d64
+      - req-7d0678a5-936b-4bd8-b850-7c9a95cf3f41
       Content-Length:
       - '2457'
       Connection:
@@ -17475,13 +17476,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"b9d39d00863947a2b33dca4549556c62"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"444e693c069c47b285bdf612e4706d17"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17493,15 +17494,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:23 GMT
+      - Mon, 06 Aug 2018 16:56:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e405d7fce0204f508f8a9135b1802e78
+      - 7da36a16a30e44b483cb5b5685e38621
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0a792cc-750e-4569-993e-157d687ca7b7
+      - req-d437f47b-2e18-49ed-871d-e8eb9c20494e
       Content-Length:
       - '7313'
       Connection:
@@ -17513,7 +17514,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:22.908386Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:02.215053Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17592,10 +17593,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M3DfANG_TQ2bY1oZ_OBXXA",
-        "oDxQKhatS3exhPVzGux7XQ"], "issued_at": "2018-08-03T19:43:23.609836Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Z2cMsy4RTGa_wO6j__d0g",
+        "Z9TFsW2KSO6DtSo1G9CAIQ"], "issued_at": "2018-08-06T16:56:02.792525Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -17610,20 +17611,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e405d7fce0204f508f8a9135b1802e78
+      - 7da36a16a30e44b483cb5b5685e38621
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:23 GMT
+      - Mon, 06 Aug 2018 16:56:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ffc9b804-3b30-4d44-b854-e7207741cfb9
+      - req-782a0ffd-2510-4d26-a1d8-3e0662d61922
       Content-Length:
       - '2179'
       Connection:
@@ -17656,7 +17657,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17674,15 +17675,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:23 GMT
+      - Mon, 06 Aug 2018 16:56:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4f9350de4c9645bb986aa91148348fa7
+      - 41eb0b23cf05463e99182cd5b806454e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eaa26030-f7fc-4f2d-9a4b-a4cb91c29ae5
+      - req-2275054c-a715-4871-9b90-4809cd1be7d4
       Content-Length:
       - '7278'
       Connection:
@@ -17694,7 +17695,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:24.050150Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:03.277147Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17773,10 +17774,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4iLBA-gaS5qV_mxxTD84MA"],
-        "issued_at": "2018-08-03T19:43:24.050227Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6hKzWlGSQDi3_vI9YzZiOg"],
+        "issued_at": "2018-08-06T16:56:03.277216Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17794,15 +17795,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:24 GMT
+      - Mon, 06 Aug 2018 16:56:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95df4113310e432da2d673bef389f3c1
+      - 166abb0ce464469ab2362bf1725060ca
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0a898e71-aed7-427f-877d-7f60c9eec832
+      - req-896c0522-e989-49e7-8ba9-23316036bd24
       Content-Length:
       - '7278'
       Connection:
@@ -17814,7 +17815,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:24.440218Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:03.611961Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17893,10 +17894,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gZy1_cGeQ5i7mTOkzhfWow"],
-        "issued_at": "2018-08-03T19:43:24.440276Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qdqp5OrdTmy4gZEO3VfoSA"],
+        "issued_at": "2018-08-06T16:56:03.612026Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17914,15 +17915,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:24 GMT
+      - Mon, 06 Aug 2018 16:56:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 448ac22f78344d87b8413228bd2fff9a
+      - e74a4c58149547ada66a2ad161907fe4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2dd650e6-02e6-47c6-8e82-152acc6467ff
+      - req-f53fdd33-f714-45b5-bfea-9195a01be312
       Content-Length:
       - '7264'
       Connection:
@@ -17934,7 +17935,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:24.778714Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:03.943514Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18013,10 +18014,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9z9yCBQLQGuHIzf4c3SSQA"],
-        "issued_at": "2018-08-03T19:43:24.778809Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-HUzqtpXT7OinB12Zcp0Tg"],
+        "issued_at": "2018-08-06T16:56:03.943580Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18034,15 +18035,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:24 GMT
+      - Mon, 06 Aug 2018 16:56:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c3b97f919caf47b08abfb1248c6a7118
+      - a7fd5b89a81248878a61b0dc26a07e84
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5165d99f-64b5-4949-b174-59d9f1018611
+      - req-48a0c514-baa4-4a53-8942-99cac444dc22
       Content-Length:
       - '7278'
       Connection:
@@ -18054,7 +18055,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:25.365601Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:04.297743Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18133,10 +18134,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lqngz20IRdKqAHAhlCWNlw"],
-        "issued_at": "2018-08-03T19:43:25.365698Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rn57vNl1RpCZKJJMu7PR0g"],
+        "issued_at": "2018-08-06T16:56:04.297825Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18154,15 +18155,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:25 GMT
+      - Mon, 06 Aug 2018 16:56:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8ad1eaeba20641f1b7843fddb00cd242
+      - f80efebdef7944919fe863aec7a38dfb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d2b43031-3e39-41f2-8b81-8d806c0f8745
+      - req-c43cc009-3831-4c23-a84b-b1e8f4016ad8
       Content-Length:
       - '7265'
       Connection:
@@ -18174,7 +18175,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:25.811361Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:04.665380Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18253,10 +18254,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dyU-vPODTEy3LMRN8g0EYw"],
-        "issued_at": "2018-08-03T19:43:25.811426Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gHgrjv4GRtmDqWVvpRZG9Q"],
+        "issued_at": "2018-08-06T16:56:04.665464Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18274,15 +18275,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:25 GMT
+      - Mon, 06 Aug 2018 16:56:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b5eeb99196c54ce2a1efdd66f5fb4dc2
+      - c6d9285c53184ffeba880c03117b451a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4706cb59-4c18-4f82-bbeb-f874dba6b93b
+      - req-bc55d699-8fac-4faa-84ae-1b033efc7544
       Content-Length:
       - '7278'
       Connection:
@@ -18294,7 +18295,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:26.256064Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:05.032829Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18373,10 +18374,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zrLcx_3TTTCfjiL8VdqMAg"],
-        "issued_at": "2018-08-03T19:43:26.256175Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SR4Y2LHITDGcPGdZ6-e09A"],
+        "issued_at": "2018-08-06T16:56:05.032917Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18394,15 +18395,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:26 GMT
+      - Mon, 06 Aug 2018 16:56:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f5e1fce810354423999f1e151de8a130
+      - 7c686ac46db948f9bec09b71dff5d67d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f0ca0ecf-9bba-4769-8efc-ff30b4d7c014
+      - req-e9059cbb-7740-4c71-93a4-6a3e29d12eb6
       Content-Length:
       - '7278'
       Connection:
@@ -18414,7 +18415,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:26.723087Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:05.360589Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18493,10 +18494,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PAajsmUMQB-_S_BWl5yKaA"],
-        "issued_at": "2018-08-03T19:43:26.723193Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w2IQEWtBS8C4xK9HJR8J0g"],
+        "issued_at": "2018-08-06T16:56:05.360655Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -18511,7 +18512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5e1fce810354423999f1e151de8a130
+      - 7c686ac46db948f9bec09b71dff5d67d
   response:
     status:
       code: 200
@@ -18524,22 +18525,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325407.06940'
+      - '1533574565.56854'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325407.06940'
+      - '1533574565.56854'
       X-Trans-Id:
-      - tx1638f4bfe3a447db91ad3-005b64b05e
+      - txe3dc9b3e404949078cf62-005b687da5
       Date:
-      - Fri, 03 Aug 2018 19:43:27 GMT
+      - Mon, 06 Aug 2018 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18557,15 +18558,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:27 GMT
+      - Mon, 06 Aug 2018 16:56:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 78f529c3c26d4000a3b7d1ef96669500
+      - 452d230d4ea74e25a08200377ebf30bf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-36d13ff9-6b88-46d8-bb52-61a228ecbc2e
+      - req-308c2350-bd8b-4c31-880f-a4401c2ac022
       Content-Length:
       - '7278'
       Connection:
@@ -18577,7 +18578,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:27.645986Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:05.913546Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18656,10 +18657,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["StzvIG6OTjGLQnQpu_BY1g"],
-        "issued_at": "2018-08-03T19:43:27.646065Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tOJqQcmnSWWHCCq7aS71PA"],
+        "issued_at": "2018-08-06T16:56:05.913614Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -18674,7 +18675,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78f529c3c26d4000a3b7d1ef96669500
+      - 452d230d4ea74e25a08200377ebf30bf
   response:
     status:
       code: 200
@@ -18687,22 +18688,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325407.85505'
+      - '1533574566.11765'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325407.85505'
+      - '1533574566.11765'
       X-Trans-Id:
-      - txa3f7b77184b94a31978c5-005b64b05f
+      - tx6028e1c3f45f4b1ca3e8c-005b687da6
       Date:
-      - Fri, 03 Aug 2018 19:43:27 GMT
+      - Mon, 06 Aug 2018 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18720,15 +18721,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:27 GMT
+      - Mon, 06 Aug 2018 16:56:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d50fec28-68e5-401d-9154-02882e774e48
+      - req-224fc2b0-4bf3-4fa0-9763-4eea0339c152
       Content-Length:
       - '7264'
       Connection:
@@ -18740,7 +18741,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:28.205707Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:06.454305Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18819,10 +18820,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PMa80ftUSdW2oi9w9vyOlw"],
-        "issued_at": "2018-08-03T19:43:28.205781Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["adqLBEhXR4KPOGirLddfIg"],
+        "issued_at": "2018-08-06T16:56:06.454391Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -18837,7 +18838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
   response:
     status:
       code: 200
@@ -18866,15 +18867,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb0bc0cc4627f4a858a73d-005b64b060
+      - tx3d2f39eb49cc4b4480ecb-005b687da6
       Date:
-      - Fri, 03 Aug 2018 19:43:28 GMT
+      - Mon, 06 Aug 2018 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -18889,7 +18890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
   response:
     status:
       code: 200
@@ -18918,14 +18919,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txdbad7f5376a74be1adc67-005b64b060
+      - tx817425db07194ee2bd389-005b687da6
       Date:
-      - Fri, 03 Aug 2018 19:43:28 GMT
+      - Mon, 06 Aug 2018 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18943,15 +18944,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:28 GMT
+      - Mon, 06 Aug 2018 16:56:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 254da31ba3e340358d11071467dbb456
+      - ece3318f39a741718b2d52053aecdb1f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ae2c6469-1ed8-4056-833f-d5b4d6ed9e9b
+      - req-dffe389a-bd79-4835-b653-80923bd14a02
       Content-Length:
       - '7278'
       Connection:
@@ -18963,7 +18964,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:28.950430Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:07.118387Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19042,10 +19043,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iO3vrasETP-Vv3vkKBsEhQ"],
-        "issued_at": "2018-08-03T19:43:28.950491Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GcdzgIV2Q--C9hDIQ-9yBw"],
+        "issued_at": "2018-08-06T16:56:07.118456Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -19060,7 +19061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 254da31ba3e340358d11071467dbb456
+      - ece3318f39a741718b2d52053aecdb1f
   response:
     status:
       code: 200
@@ -19073,22 +19074,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325409.23335'
+      - '1533574567.31890'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325409.23335'
+      - '1533574567.31890'
       X-Trans-Id:
-      - tx639765fcc64640e1823d6-005b64b061
+      - tx7ea7f4667bf748d7ab052-005b687da7
       Date:
-      - Fri, 03 Aug 2018 19:43:29 GMT
+      - Mon, 06 Aug 2018 16:56:07 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -19103,7 +19104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776b7b24168a4e69a16b0944b2538e8b
+      - da2a10ab77f240fdb946d0d8a809bc63
   response:
     status:
       code: 200
@@ -19116,22 +19117,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325409.41572'
+      - '1533574567.48760'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325409.41572'
+      - '1533574567.48760'
       X-Trans-Id:
-      - tx41bf528321a649e385fa3-005b64b061
+      - txdb99eac86e1944b8b1655-005b687da7
       Date:
-      - Fri, 03 Aug 2018 19:43:29 GMT
+      - Mon, 06 Aug 2018 16:56:07 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -19149,15 +19150,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:29 GMT
+      - Mon, 06 Aug 2018 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fde471bbd820476e8d408aa53aa4c95b
+      - 2b352ff2c3734975b7b5790c63b724ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e7646398-374a-4119-823b-31d602b6ceff
+      - req-73c13d95-e833-45bd-974c-486ab16287be
       Content-Length:
       - '7265'
       Connection:
@@ -19169,7 +19170,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:29.674960Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:07.804384Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -19248,10 +19249,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fUTlbW27Qsywoxu-gYc7xQ"],
-        "issued_at": "2018-08-03T19:43:29.675021Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WbfNVDRIQRadhh8T2JQD3w"],
+        "issued_at": "2018-08-06T16:56:07.804453Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -19266,7 +19267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fde471bbd820476e8d408aa53aa4c95b
+      - 2b352ff2c3734975b7b5790c63b724ae
   response:
     status:
       code: 200
@@ -19279,22 +19280,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325409.87659'
+      - '1533574568.01378'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325409.87659'
+      - '1533574568.01378'
       X-Trans-Id:
-      - tx4eac8277573649d39c155-005b64b061
+      - txc67fc6c37c774e87aecc3-005b687da7
       Date:
-      - Fri, 03 Aug 2018 19:43:29 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -19312,15 +19313,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:43:29 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 711da94d761a4dacb777b8ad56661b73
+      - 71ec82192321436198ca521bdbd3f542
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b819725d-8849-48c0-829d-194164e6fa37
+      - req-fc2a66b9-0756-46eb-b17b-e83891ac22b7
       Content-Length:
       - '7278'
       Connection:
@@ -19332,7 +19333,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:43:30.258503Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:56:08.323383Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19411,10 +19412,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_2Dk5BJ1SX6hS7NTDE0USQ"],
-        "issued_at": "2018-08-03T19:43:30.258584Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["B1OKHoLxTySI8rBUuydqgg"],
+        "issued_at": "2018-08-06T16:56:08.323449Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -19429,7 +19430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 711da94d761a4dacb777b8ad56661b73
+      - 71ec82192321436198ca521bdbd3f542
   response:
     status:
       code: 200
@@ -19442,22 +19443,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325410.55426'
+      - '1533574568.53497'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325410.55426'
+      - '1533574568.53497'
       X-Trans-Id:
-      - txd643549c7bc7422392bff-005b64b062
+      - txacf23e771b6f4c8cb8fe1-005b687da8
       Date:
-      - Fri, 03 Aug 2018 19:43:30 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -19472,7 +19473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
   response:
     status:
       code: 200
@@ -19493,9 +19494,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8291ca339292424fae9c8-005b64b062
+      - tx598f0ae131894df084ada-005b687da8
       Date:
-      - Fri, 03 Aug 2018 19:43:30 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -19505,7 +19506,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -19520,7 +19521,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
   response:
     status:
       code: 200
@@ -19541,14 +19542,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx95d1284b2520484c91cbc-005b64b062
+      - tx4e5f0bb571f34cc58913d-005b687da8
       Date:
-      - Fri, 03 Aug 2018 19:43:30 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -19563,7 +19564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3d5ed9d436c46119c56a3e256e74a53
+      - 0607f50d78e14c16b0be97c64c047c15
   response:
     status:
       code: 200
@@ -19584,12 +19585,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx18b12eb7a6ed4ce18b2a0-005b64b062
+      - tx9573bb5b13224d0ea1d86-005b687da8
       Date:
-      - Fri, 03 Aug 2018 19:43:30 GMT
+      - Mon, 06 Aug 2018 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:43:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:58 GMT
+      - Mon, 06 Aug 2018 16:51:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bef307bc-aae6-4dc5-a930-4967d5a76397
+      - req-ad07e002-6ab5-4f00-8b76-f23f7b765a3e
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:58.497688Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:14.998560Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5t7lCcokRm6NZ8WIB5Grxg"],
-        "issued_at": "2018-08-03T19:40:58.497781Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["55ouX-L0Q3ux4AVKBelf4Q"],
+        "issued_at": "2018-08-06T16:51:14.998641Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:40:58 GMT
+      - Mon, 06 Aug 2018 16:51:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:58 GMT
+      - Mon, 06 Aug 2018 16:51:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b6800e2a8f6541b4aa732602beafad78
+      - 5afb80388c364351920a8c00059d383b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b14bf134-48fa-40bd-8620-0a599d979c1b
+      - req-9c155979-de97-4990-8897-61b11de811ff
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:59.081563Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:15.642461Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["591fXNMqRMGKEISJkFCqJA"],
-        "issued_at": "2018-08-03T19:40:59.081653Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u6czasPKT9CxTXzcx2cr9A"],
+        "issued_at": "2018-08-06T16:51:15.642525Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -289,7 +289,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6800e2a8f6541b4aa732602beafad78
+      - 5afb80388c364351920a8c00059d383b
   response:
     status:
       code: 200
@@ -300,13 +300,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:40:59 GMT
+      - Mon, 06 Aug 2018 16:51:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -324,15 +324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:59 GMT
+      - Mon, 06 Aug 2018 16:51:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a512c1ff10464356a227748a4b09d837
+      - 4cae24d6a26c43c3b94e549ae08a2bfa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7dcff478-28aa-4507-800c-336d2e959f2f
+      - req-35991ce6-9a62-4cb5-8dca-f70f1d590d7f
       Content-Length:
       - '7311'
       Connection:
@@ -344,7 +344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:59.501054Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.093507Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -423,16 +423,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S7VlURlWT8W6V3FF1sX_Ig"],
-        "issued_at": "2018-08-03T19:40:59.501167Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vpyGr2OfQOKCuAfsFLW3Tg"],
+        "issued_at": "2018-08-06T16:51:16.093575Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"a512c1ff10464356a227748a4b09d837"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"4cae24d6a26c43c3b94e549ae08a2bfa"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -444,15 +444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:59 GMT
+      - Mon, 06 Aug 2018 16:51:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4a1075aa47f4d2cb076b5d5e7cc07ef
+      - 4edb5cdba6d744a48a952a4b9d69ca46
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79193c95-e538-487d-8a4b-5de76bf40254
+      - req-072c17be-a042-4b6f-af53-6623d787b044
       Content-Length:
       - '7346'
       Connection:
@@ -464,7 +464,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:40:59.501054Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.093507Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -543,10 +543,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G0MCZEvOTZ-NfFAiD7oY8Q",
-        "S7VlURlWT8W6V3FF1sX_Ig"], "issued_at": "2018-08-03T19:40:59.803441Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aHyHuV8OQaW3HVgcFzWIpA",
+        "vpyGr2OfQOKCuAfsFLW3Tg"], "issued_at": "2018-08-06T16:51:16.422477Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:40:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -564,15 +564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:40:59 GMT
+      - Mon, 06 Aug 2018 16:51:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79928cad-36a5-455b-9909-ccaad94511c6
+      - req-a29989ca-c637-45f4-915f-e99d397f8d2c
       Content-Length:
       - '7311'
       Connection:
@@ -584,7 +584,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:00.135698Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.845856Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -663,10 +663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8EWweTxsRUiusxcMUbjRzQ"],
-        "issued_at": "2018-08-03T19:41:00.135788Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iIxfhJbGSsqjF1bTkBB6MQ"],
+        "issued_at": "2018-08-06T16:51:16.845922Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -681,7 +681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 300
@@ -692,7 +692,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:41:00 GMT
+      - Mon, 06 Aug 2018 16:51:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -705,7 +705,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -723,15 +723,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:00 GMT
+      - Mon, 06 Aug 2018 16:51:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2ff125309ce5433da2866674137c0187
+      - 2eb09bb5278346cab6250bfeb145eeef
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-005faa17-2d90-4c43-bc4a-fa95a86595fd
+      - req-1c02cccc-f41f-4c1e-929d-0ed394b0525a
       Content-Length:
       - '7311'
       Connection:
@@ -743,7 +743,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:00.584019Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:17.469757Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -822,10 +822,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SBXUtsg0Ra-fGuIrwHJflw"],
-        "issued_at": "2018-08-03T19:41:00.584090Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WtUsZOoJQKqt98XCQ5TX-Q"],
+        "issued_at": "2018-08-06T16:51:17.469821Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -843,15 +843,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:00 GMT
+      - Mon, 06 Aug 2018 16:51:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '018427fb6cea477db214e4860633d620'
+      - 8597692d218248faa2ba406a9bd1d598
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d5a692e2-fb70-4b7c-b5ea-181c0bc240a0
+      - req-87ff927f-acba-4b9d-80cb-f1818a8ba1ed
       Content-Length:
       - '7311'
       Connection:
@@ -863,7 +863,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:00.978972Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:17.867590Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -942,10 +942,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nixRwuWVQvqsyPcwXbuYSQ"],
-        "issued_at": "2018-08-03T19:41:00.979056Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BdvsIuDBQN-Qr6cqTkVuCg"],
+        "issued_at": "2018-08-06T16:51:17.867662Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -963,15 +963,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:01 GMT
+      - Mon, 06 Aug 2018 16:51:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a7e8baae82ef4218870d7b6d149536f9
+      - e4613e4a1e294c9e971e337bb9c8ce9e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22f588e8-a405-41de-94b8-16b8d7a1dc93
+      - req-60fca623-879b-4155-9e04-f5db94e15097
       Content-Length:
       - '7311'
       Connection:
@@ -983,7 +983,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:01.364234Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:18.352039Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1062,10 +1062,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7482MONPQI-iRsI9zLdT5w"],
-        "issued_at": "2018-08-03T19:41:01.364303Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f8DXWbGyQVWfCkIcW7LbrQ"],
+        "issued_at": "2018-08-06T16:51:18.352165Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1083,15 +1083,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:01 GMT
+      - Mon, 06 Aug 2018 16:51:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dcc4968fa34c4d4693858c94ae0910f8
+      - ffeb21de6dfd45cd832ee12507701c88
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b20386c-13e8-44e0-904b-aced68f4ddee
+      - req-9932913c-7d3c-4a18-aa67-0ced771114ce
       Content-Length:
       - '7311'
       Connection:
@@ -1103,7 +1103,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:01.711486Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:18.782918Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1182,10 +1182,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oMaFX2MISUuJz2HujNcoPw"],
-        "issued_at": "2018-08-03T19:41:01.711559Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-WOluu-XSWyf9v2mFR2yXw"],
+        "issued_at": "2018-08-06T16:51:18.783008Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1203,15 +1203,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:01 GMT
+      - Mon, 06 Aug 2018 16:51:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4e4bc58b9c74fe18c52887a2e5f5efb
+      - ea85a452fb3e43d6a6369aef1b9062ed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f11fcace-a78d-4ece-bbf0-54ad0993bb76
+      - req-17b5dbaf-4f1a-4480-b7db-34b72ea57782
       Content-Length:
       - '297'
       Connection:
@@ -1220,12 +1220,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:41:01.941711Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:51:19.017244Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PsVRoNoTRFuXErixPefJrg"],
-        "issued_at": "2018-08-03T19:41:01.941773Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JXM0rdp3S_KGKjxJLwsm9Q"],
+        "issued_at": "2018-08-06T16:51:19.017307Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1240,20 +1240,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e4bc58b9c74fe18c52887a2e5f5efb
+      - ea85a452fb3e43d6a6369aef1b9062ed
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:02 GMT
+      - Mon, 06 Aug 2018 16:51:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e99d875e-edfb-4887-81a4-912741fbba58
+      - req-957b390f-6b63-43b7-9e86-c96e00aba4ce
       Content-Length:
       - '2457'
       Connection:
@@ -1286,13 +1286,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"a4e4bc58b9c74fe18c52887a2e5f5efb"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"ea85a452fb3e43d6a6369aef1b9062ed"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1304,15 +1304,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:02 GMT
+      - Mon, 06 Aug 2018 16:51:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a05be68b950a4322ae1f0dd11127d7e5
+      - 793543e083c3462bab0104088b572fcc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb4fb7b8-2bdd-48cd-8f3b-3edf51b923c0
+      - req-a944c98e-4aea-414b-9e85-10b2f39aff6a
       Content-Length:
       - '7313'
       Connection:
@@ -1324,7 +1324,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:01.941711Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:19.017244Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1403,10 +1403,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zwpzc6gkQuWEwZCUSZeVbg",
-        "PsVRoNoTRFuXErixPefJrg"], "issued_at": "2018-08-03T19:41:02.391400Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ceWI7pmvSjSIc3d1Ue_IRw",
+        "JXM0rdp3S_KGKjxJLwsm9Q"], "issued_at": "2018-08-06T16:51:19.491249Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1421,20 +1421,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a05be68b950a4322ae1f0dd11127d7e5
+      - 793543e083c3462bab0104088b572fcc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:02 GMT
+      - Mon, 06 Aug 2018 16:51:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d9df4faa-d9a8-463d-b172-62b7507f0276
+      - req-4ef361b4-106a-48bd-b507-29bbabb3fb15
       Content-Length:
       - '2179'
       Connection:
@@ -1467,7 +1467,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1485,15 +1485,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:02 GMT
+      - Mon, 06 Aug 2018 16:51:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 47a4a8e9d23f447388c5179faf6877ec
+      - b10e4202d1df463c9dcb4b68f1281197
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c93ccf67-73fe-4fd1-8bef-02490c44d9e8
+      - req-b0784049-f3a3-4652-8691-1d611c131c6a
       Content-Length:
       - '7278'
       Connection:
@@ -1505,7 +1505,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:02.873283Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:19.994747Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1584,10 +1584,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RyR7dnPWTmueOtZpAa2giA"],
-        "issued_at": "2018-08-03T19:41:02.873356Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XJH-8RZ-SCWDJXcx87vDqA"],
+        "issued_at": "2018-08-06T16:51:19.994810Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1602,7 +1602,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 47a4a8e9d23f447388c5179faf6877ec
+      - b10e4202d1df463c9dcb4b68f1281197
   response:
     status:
       code: 200
@@ -1613,7 +1613,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:02 GMT
+      - Mon, 06 Aug 2018 16:51:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1622,7 +1622,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1640,15 +1640,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:03 GMT
+      - Mon, 06 Aug 2018 16:51:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2c1534f9ecff4470be51e54cb2f56a62
+      - 431d46868c6c4bb1a94a329391f76758
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7c5da1fc-0ea5-409a-9ba1-9e515083a1fc
+      - req-374ebd38-d7d5-46c7-8a22-4aaab73970a4
       Content-Length:
       - '7278'
       Connection:
@@ -1660,7 +1660,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:03.404771Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:20.581437Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1739,10 +1739,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0xlpRljvS6yAAxGRkzkGrA"],
-        "issued_at": "2018-08-03T19:41:03.404845Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M8pJDR9AQR-_pDVavo1NMg"],
+        "issued_at": "2018-08-06T16:51:20.581538Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1757,7 +1757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c1534f9ecff4470be51e54cb2f56a62
+      - 431d46868c6c4bb1a94a329391f76758
   response:
     status:
       code: 200
@@ -1768,7 +1768,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:03 GMT
+      - Mon, 06 Aug 2018 16:51:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1777,7 +1777,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1795,15 +1795,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:03 GMT
+      - Mon, 06 Aug 2018 16:51:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bacafb7b4d634ef58861902e8b8073c5
+      - 01be2b6f849f4487bf2b238975d34eb8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7c8c76d-4377-4f34-8b12-f955bff26ebe
+      - req-c82be32d-9797-4f27-91f5-0c0270452ece
       Content-Length:
       - '7264'
       Connection:
@@ -1815,7 +1815,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:03.845303Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:21.124217Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1894,10 +1894,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KHs5Rj_qRUi1ewc3F0SM-w"],
-        "issued_at": "2018-08-03T19:41:03.845377Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VVLNGjeVT2K3JWyKhWBcPQ"],
+        "issued_at": "2018-08-06T16:51:21.124279Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1912,7 +1912,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bacafb7b4d634ef58861902e8b8073c5
+      - 01be2b6f849f4487bf2b238975d34eb8
   response:
     status:
       code: 200
@@ -1923,7 +1923,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:03 GMT
+      - Mon, 06 Aug 2018 16:51:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1932,7 +1932,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1950,15 +1950,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:04 GMT
+      - Mon, 06 Aug 2018 16:51:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c3b5e1ef5ef41ac8a4b61d08b541810
+      - 49e5a5b8957a4b079338f21d6ceadc7d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d37f87f5-573d-48d2-b411-1232014176e5
+      - req-33681612-662b-4df7-b15f-f7c334ad7c00
       Content-Length:
       - '7278'
       Connection:
@@ -1970,7 +1970,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:04.271505Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:21.529142Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2049,10 +2049,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0qPlhvO8Q2Cz2ovdL5IP2w"],
-        "issued_at": "2018-08-03T19:41:04.271576Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WB8NxrKmTSutEoijPT9c2w"],
+        "issued_at": "2018-08-06T16:51:21.529213Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2067,7 +2067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c3b5e1ef5ef41ac8a4b61d08b541810
+      - 49e5a5b8957a4b079338f21d6ceadc7d
   response:
     status:
       code: 200
@@ -2078,7 +2078,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:04 GMT
+      - Mon, 06 Aug 2018 16:51:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2087,7 +2087,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2105,15 +2105,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:04 GMT
+      - Mon, 06 Aug 2018 16:51:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e41ec10ff60b4b09ad29b09f43e50999
+      - ca54f20a8a2245a8b4b76f044dbd12c7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-20571c4f-9f02-4fdd-9f0f-9cfad3e28ae3
+      - req-d2bc4dad-e0cd-4627-bc1f-caca3e3c2540
       Content-Length:
       - '7265'
       Connection:
@@ -2125,7 +2125,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:04.692634Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:21.963994Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2204,10 +2204,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6g4SHIPhSQmCmdQypJsNdQ"],
-        "issued_at": "2018-08-03T19:41:04.692716Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pCjc1bWDQgeRsbRB7c0Zzg"],
+        "issued_at": "2018-08-06T16:51:21.964063Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2222,7 +2222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e41ec10ff60b4b09ad29b09f43e50999
+      - ca54f20a8a2245a8b4b76f044dbd12c7
   response:
     status:
       code: 200
@@ -2233,7 +2233,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:04 GMT
+      - Mon, 06 Aug 2018 16:51:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2242,7 +2242,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2260,15 +2260,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:04 GMT
+      - Mon, 06 Aug 2018 16:51:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0b05c08babbe4e06abf771c35b64ab45
+      - 38e58f1ba0c546aeb33bb2b73b3d8380
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-51267e48-96b4-4bb3-9019-bccacf0503a4
+      - req-deb1a021-7b86-4ce3-ac9b-3c903707ad8c
       Content-Length:
       - '7278'
       Connection:
@@ -2280,7 +2280,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:05.233009Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:22.394069Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2359,10 +2359,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dpqK4nqPRjiEdf0g1d998w"],
-        "issued_at": "2018-08-03T19:41:05.233089Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L9hzpvFZSu2wwXqU7v7y_Q"],
+        "issued_at": "2018-08-06T16:51:22.394176Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2377,7 +2377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b05c08babbe4e06abf771c35b64ab45
+      - 38e58f1ba0c546aeb33bb2b73b3d8380
   response:
     status:
       code: 200
@@ -2388,7 +2388,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:41:05 GMT
+      - Mon, 06 Aug 2018 16:51:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2397,7 +2397,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2412,7 +2412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2425,9 +2425,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-34ae9784-3824-48fb-8910-31f085edcb6c
+      - req-047499bb-bf52-4a09-9505-71845c2ce9a3
       Date:
-      - Fri, 03 Aug 2018 19:41:05 GMT
+      - Mon, 06 Aug 2018 16:51:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2441,7 +2441,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2456,7 +2456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2469,9 +2469,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-b81aee76-407b-41cd-aead-5c40a98dfba5
+      - req-1d33bd09-9461-470e-8bbd-60839a2e74e5
       Date:
-      - Fri, 03 Aug 2018 19:41:05 GMT
+      - Mon, 06 Aug 2018 16:51:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2485,7 +2485,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2500,7 +2500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2513,9 +2513,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-3e0773fa-dff1-49ca-9bba-d286f2754ddd
+      - req-b9cf88ee-b44a-4dc3-a5e0-a24977a34d1c
       Date:
-      - Fri, 03 Aug 2018 19:41:05 GMT
+      - Mon, 06 Aug 2018 16:51:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2530,7 +2530,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2545,7 +2545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2558,9 +2558,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-8a9e2adc-23dd-4309-82c0-2c33b3dfb271
+      - req-fa4077ea-c6bc-4544-80fb-ff6a992ba022
       Date:
-      - Fri, 03 Aug 2018 19:41:06 GMT
+      - Mon, 06 Aug 2018 16:51:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2570,7 +2570,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2585,7 +2585,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2598,15 +2598,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-0253da19-4a21-430f-9209-db923851a645
+      - req-eefa8448-89f9-461d-8795-cfefd0bdc708
       Date:
-      - Fri, 03 Aug 2018 19:41:06 GMT
+      - Mon, 06 Aug 2018 16:51:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2634,15 +2634,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-6cd64973-24ec-46f8-9a8d-b04363b7cb4f
+      - req-16d86395-7a52-4070-b51b-5a9aa2e19339
       Date:
-      - Fri, 03 Aug 2018 19:41:06 GMT
+      - Mon, 06 Aug 2018 16:51:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -2657,28 +2657,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff125309ce5433da2866674137c0187
+      - 2eb09bb5278346cab6250bfeb145eeef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6eec144-f935-45df-b858-43d50f48236f
+      - req-0b9d12d9-b377-44e2-b744-6b58f1ae2ee2
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-f6eec144-f935-45df-b858-43d50f48236f
+      - req-0b9d12d9-b377-44e2-b744-6b58f1ae2ee2
       Date:
-      - Fri, 03 Aug 2018 19:41:07 GMT
+      - Mon, 06 Aug 2018 16:51:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -2693,7 +2693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2706,14 +2706,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-925fa544-8e1e-4820-8858-86ad47245856
+      - req-2537d33f-2359-4643-a700-de261e248037
       Date:
-      - Fri, 03 Aug 2018 19:41:07 GMT
+      - Mon, 06 Aug 2018 16:51:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2728,7 +2728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 47a4a8e9d23f447388c5179faf6877ec
+      - b10e4202d1df463c9dcb4b68f1281197
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2741,9 +2741,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c6f945ce-a018-4e14-bde6-03e2024f206c
+      - req-de760479-cee5-4952-8f57-6786e765dbbe
       Date:
-      - Fri, 03 Aug 2018 19:41:07 GMT
+      - Mon, 06 Aug 2018 16:51:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2752,7 +2752,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2767,7 +2767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c1534f9ecff4470be51e54cb2f56a62
+      - 431d46868c6c4bb1a94a329391f76758
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2780,9 +2780,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a9aa4d4c-783f-4b39-b3e5-1c6525f9bc57
+      - req-c8b88a25-d541-46f5-8b97-84b3c909b515
       Date:
-      - Fri, 03 Aug 2018 19:41:07 GMT
+      - Mon, 06 Aug 2018 16:51:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2791,7 +2791,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2806,7 +2806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bacafb7b4d634ef58861902e8b8073c5
+      - 01be2b6f849f4487bf2b238975d34eb8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2819,9 +2819,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-44c6ce8d-3d4b-4d15-85bc-6fc15b158b08
+      - req-c4d8d08c-e850-4274-b0b2-cab352e17d38
       Date:
-      - Fri, 03 Aug 2018 19:41:07 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2830,7 +2830,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2845,7 +2845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c3b5e1ef5ef41ac8a4b61d08b541810
+      - 49e5a5b8957a4b079338f21d6ceadc7d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2858,9 +2858,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c2abe893-444c-4100-8b45-a68aa52961d2
+      - req-d727f997-d7dd-4400-bca3-7c3e6e724c27
       Date:
-      - Fri, 03 Aug 2018 19:41:08 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2869,7 +2869,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2897,9 +2897,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bdd8b7a2-46cf-4e7c-b002-8a5bf23732b7
+      - req-aaba1991-9809-4187-a7c3-b41545c59e0c
       Date:
-      - Fri, 03 Aug 2018 19:41:08 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2908,7 +2908,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2923,7 +2923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e41ec10ff60b4b09ad29b09f43e50999
+      - ca54f20a8a2245a8b4b76f044dbd12c7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2936,9 +2936,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-49269668-8fda-45e4-9270-afa4725f0b19
+      - req-96c0c00e-ee81-4115-8830-bdf7eca7701d
       Date:
-      - Fri, 03 Aug 2018 19:41:08 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2947,7 +2947,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2962,7 +2962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b05c08babbe4e06abf771c35b64ab45
+      - 38e58f1ba0c546aeb33bb2b73b3d8380
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2975,9 +2975,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f3fd7e4c-55cf-4edb-ad92-e10a9735cdf0
+      - req-961538ee-8b1f-4588-9e65-185844d96ef6
       Date:
-      - Fri, 03 Aug 2018 19:41:08 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2986,7 +2986,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3004,15 +3004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:08 GMT
+      - Mon, 06 Aug 2018 16:51:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6aa65841b17743cdabfb6c6e911c6e73
+      - 9f904fa7d6994c83a96abd2aec46ffa6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80122826-d040-4d41-b8f0-465f98af8850
+      - req-581e2436-2092-45a6-82dd-4739c1aba520
       Content-Length:
       - '7278'
       Connection:
@@ -3024,7 +3024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:08.847636Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:26.143872Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3103,10 +3103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JZM1lE4MTOGVSYJeelAJsA"],
-        "issued_at": "2018-08-03T19:41:08.847738Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIRzInrIQ7SaIN7rQVI0eQ"],
+        "issued_at": "2018-08-06T16:51:26.143936Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3121,22 +3121,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6aa65841b17743cdabfb6c6e911c6e73
+      - 9f904fa7d6994c83a96abd2aec46ffa6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5bd5f48a-80ab-43cd-bf46-64486e56e9a8
+      - req-81a1c7e9-a82f-476d-bd45-4dfc4ba1737c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5bd5f48a-80ab-43cd-bf46-64486e56e9a8
+      - req-81a1c7e9-a82f-476d-bd45-4dfc4ba1737c
       Date:
-      - Fri, 03 Aug 2018 19:41:09 GMT
+      - Mon, 06 Aug 2018 16:51:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3146,7 +3146,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3164,15 +3164,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:09 GMT
+      - Mon, 06 Aug 2018 16:51:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fe283c4213a74442b703be32a57a990d
+      - e23869c87f9b4e60bddfa0e89bf2432f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c9df110-00eb-4579-850d-64b295c614f7
+      - req-df77790c-1d5c-4155-acfa-1d168531bdb4
       Content-Length:
       - '7278'
       Connection:
@@ -3184,7 +3184,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:09.909069Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:27.326235Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3263,10 +3263,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-wyyG4V_QYGGLeSqBJ8GVA"],
-        "issued_at": "2018-08-03T19:41:09.909171Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M_qfJ6GvR0qpREoZgCfJIQ"],
+        "issued_at": "2018-08-06T16:51:27.326287Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3281,22 +3281,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe283c4213a74442b703be32a57a990d
+      - e23869c87f9b4e60bddfa0e89bf2432f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b693c8f-2786-43e9-ac00-139863b08fe8
+      - req-a621ad06-47c4-4a1e-96eb-665842be471b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7b693c8f-2786-43e9-ac00-139863b08fe8
+      - req-a621ad06-47c4-4a1e-96eb-665842be471b
       Date:
-      - Fri, 03 Aug 2018 19:41:10 GMT
+      - Mon, 06 Aug 2018 16:51:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3306,7 +3306,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3324,15 +3324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:10 GMT
+      - Mon, 06 Aug 2018 16:51:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 976b0b8512124ce4a4f0840dd2e538d7
+      - 2b75cefcbbb74a3ebf73bd11adadece5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b1594c1a-b710-43ac-a467-42a4b17a304a
+      - req-189a9729-164f-4dd7-a02d-5ea45688b349
       Content-Length:
       - '7264'
       Connection:
@@ -3344,7 +3344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:10.877904Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:28.456815Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3423,10 +3423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yoz3kECVS-aUbUU9IiC5mA"],
-        "issued_at": "2018-08-03T19:41:10.877970Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KRDXWG_bTDi_I5pxQf9CtA"],
+        "issued_at": "2018-08-06T16:51:28.456856Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3441,22 +3441,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 976b0b8512124ce4a4f0840dd2e538d7
+      - 2b75cefcbbb74a3ebf73bd11adadece5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9df307a-5360-4d1e-b46d-ce74ab048b53
+      - req-1b13f903-a007-4000-a29e-76b1dbf44c6c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e9df307a-5360-4d1e-b46d-ce74ab048b53
+      - req-1b13f903-a007-4000-a29e-76b1dbf44c6c
       Date:
-      - Fri, 03 Aug 2018 19:41:11 GMT
+      - Mon, 06 Aug 2018 16:51:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3466,7 +3466,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3484,15 +3484,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:11 GMT
+      - Mon, 06 Aug 2018 16:51:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95b38f65f37146d38e80f9c7e9b3f012
+      - e4ed6de5c79147a9bc382766c6abbefe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0fd84fdb-5dc7-4708-9961-72af79e90cc8
+      - req-e94f037b-47a5-42d3-af14-db27570806b0
       Content-Length:
       - '7278'
       Connection:
@@ -3504,7 +3504,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:11.900464Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:29.428748Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3583,10 +3583,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KGN5rA7yR4-VzGe7TtJV0A"],
-        "issued_at": "2018-08-03T19:41:11.900539Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m9LCNLQ7R4e82VYr4oBYCw"],
+        "issued_at": "2018-08-06T16:51:29.428811Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3601,22 +3601,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95b38f65f37146d38e80f9c7e9b3f012
+      - e4ed6de5c79147a9bc382766c6abbefe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95298adc-e33b-4501-8505-96d99897dd13
+      - req-533339df-0554-41b5-bec5-1b24ec2d74a9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-95298adc-e33b-4501-8505-96d99897dd13
+      - req-533339df-0554-41b5-bec5-1b24ec2d74a9
       Date:
-      - Fri, 03 Aug 2018 19:41:12 GMT
+      - Mon, 06 Aug 2018 16:51:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3626,7 +3626,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3641,22 +3641,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff125309ce5433da2866674137c0187
+      - 2eb09bb5278346cab6250bfeb145eeef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d5d51cec-ade0-41cf-90d0-739e0393cc2e
+      - req-9a7e139c-05f4-401e-95c3-604ca84bfadc
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d5d51cec-ade0-41cf-90d0-739e0393cc2e
+      - req-9a7e139c-05f4-401e-95c3-604ca84bfadc
       Date:
-      - Fri, 03 Aug 2018 19:41:13 GMT
+      - Mon, 06 Aug 2018 16:51:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3666,7 +3666,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3684,15 +3684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:13 GMT
+      - Mon, 06 Aug 2018 16:51:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5b40b156f1f047209eba1ffe44c724e1
+      - be37f9becf2a45ea8c468e42649f1e85
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c0ba957f-dffa-4f77-9e76-c133709b895f
+      - req-6d4e9712-b8b6-4e04-bc48-758b5b8fea0a
       Content-Length:
       - '7265'
       Connection:
@@ -3704,7 +3704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:13.657103Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:31.228312Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3783,10 +3783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0T7D_rLYQfKjUD9YZFisWw"],
-        "issued_at": "2018-08-03T19:41:13.657203Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6C-Zh-dDQYGYzQznxWQh8g"],
+        "issued_at": "2018-08-06T16:51:31.228373Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3801,22 +3801,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b40b156f1f047209eba1ffe44c724e1
+      - be37f9becf2a45ea8c468e42649f1e85
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3aa2744-d6ab-4324-a0fb-ce0e42562a20
+      - req-d7e6da9c-e522-4e30-97b4-14f7bf00a9d6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d3aa2744-d6ab-4324-a0fb-ce0e42562a20
+      - req-d7e6da9c-e522-4e30-97b4-14f7bf00a9d6
       Date:
-      - Fri, 03 Aug 2018 19:41:14 GMT
+      - Mon, 06 Aug 2018 16:51:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3826,7 +3826,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3844,15 +3844,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:14 GMT
+      - Mon, 06 Aug 2018 16:51:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a6e1b6fb74da4ed28793753e3a35e0cf
+      - c06e33d2d3c041fbad524b8187423614
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-816bc3b5-045e-4fcc-82fb-b03b9aadb2d0
+      - req-06ea22e3-2c06-41f3-942b-e051c4c1f5c7
       Content-Length:
       - '7278'
       Connection:
@@ -3864,7 +3864,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:14.638609Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:32.195562Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3943,10 +3943,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D-Z4uz8IRrSfWldF7vmYkg"],
-        "issued_at": "2018-08-03T19:41:14.638676Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dnInQTygRDyj4UW4DDz2YQ"],
+        "issued_at": "2018-08-06T16:51:32.195621Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3961,22 +3961,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6e1b6fb74da4ed28793753e3a35e0cf
+      - c06e33d2d3c041fbad524b8187423614
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0062960d-18c5-4889-8f50-c9457ba70529
+      - req-ab027094-b071-4529-9a73-dff41ef2a35a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-0062960d-18c5-4889-8f50-c9457ba70529
+      - req-ab027094-b071-4529-9a73-dff41ef2a35a
       Date:
-      - Fri, 03 Aug 2018 19:41:15 GMT
+      - Mon, 06 Aug 2018 16:51:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3986,7 +3986,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4004,15 +4004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:15 GMT
+      - Mon, 06 Aug 2018 16:51:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 30432fc32f8b4192b3cc205895a1f8d2
+      - a4110357d3664748ad216dc8d38efb37
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a7f8517a-8695-418b-ad4b-71d99fb812d1
+      - req-7f51d211-f861-4a53-91b9-74aad5928fca
       Content-Length:
       - '7278'
       Connection:
@@ -4024,7 +4024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:15.781995Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:33.318791Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4103,10 +4103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jlczwB_YSrm2iOqx_7cwnQ"],
-        "issued_at": "2018-08-03T19:41:15.782070Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SS4pBJoRT3C2Uk-zH3E8Rw"],
+        "issued_at": "2018-08-06T16:51:33.318855Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4121,7 +4121,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30432fc32f8b4192b3cc205895a1f8d2
+      - a4110357d3664748ad216dc8d38efb37
   response:
     status:
       code: 200
@@ -4132,16 +4132,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c79d63df-d3bf-431d-b8cf-49fb68049d2b
+      - req-8269964e-953c-49df-b97e-e4a65c7781ec
       Date:
-      - Fri, 03 Aug 2018 19:41:15 GMT
+      - Mon, 06 Aug 2018 16:51:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4159,15 +4159,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:16 GMT
+      - Mon, 06 Aug 2018 16:51:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - abb9cb3fe3254ec184f4e889a8c51b05
+      - 62e474d28339400b809b8e4b159e3b3c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fd70cf03-1bf3-4cfa-8825-fc520a59e301
+      - req-d22fe3f1-2a1f-4ca8-bc65-d24cc4ca724d
       Content-Length:
       - '7278'
       Connection:
@@ -4179,7 +4179,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:16.299509Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:33.855775Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4258,10 +4258,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["92GZUag8TJWm29Edw3H4WQ"],
-        "issued_at": "2018-08-03T19:41:16.299596Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dobKwiZsTemm61GnJf-p_g"],
+        "issued_at": "2018-08-06T16:51:33.855846Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4276,7 +4276,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abb9cb3fe3254ec184f4e889a8c51b05
+      - 62e474d28339400b809b8e4b159e3b3c
   response:
     status:
       code: 200
@@ -4287,16 +4287,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3468e22b-8515-401c-8914-0374916efda1
+      - req-2e59daeb-04ec-4eaa-a44e-c79f04d2e599
       Date:
-      - Fri, 03 Aug 2018 19:41:16 GMT
+      - Mon, 06 Aug 2018 16:51:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4314,15 +4314,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:16 GMT
+      - Mon, 06 Aug 2018 16:51:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3b6ef0e31b9c48578b05d46c60216fc6
+      - c5c1919867084e7fa25f34b88b6677a9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-445d390e-8219-44fc-b06d-ede9dbb811d5
+      - req-a5e8c871-b13c-4ee4-95fb-85c8d12488ae
       Content-Length:
       - '7264'
       Connection:
@@ -4334,7 +4334,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:16.814468Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:34.377028Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4413,10 +4413,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yV44FX6eRK2yZDB9AVUDiA"],
-        "issued_at": "2018-08-03T19:41:16.814538Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jr5RGH1TQpG0me-BMk2PMw"],
+        "issued_at": "2018-08-06T16:51:34.377147Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:16 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4431,7 +4431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b6ef0e31b9c48578b05d46c60216fc6
+      - c5c1919867084e7fa25f34b88b6677a9
   response:
     status:
       code: 200
@@ -4442,16 +4442,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f0759b4e-d201-4309-8fca-661cf74efb70
+      - req-34bfce99-e04b-420c-bd92-5d1bb824a103
       Date:
-      - Fri, 03 Aug 2018 19:41:17 GMT
+      - Mon, 06 Aug 2018 16:51:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4469,15 +4469,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:17 GMT
+      - Mon, 06 Aug 2018 16:51:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7793473abb984d13b20e17038c460074
+      - 290afa4732bb4380a6d1161cfbd44698
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7dd98269-6a70-4b35-80e8-32f8368128fa
+      - req-936ec931-79f2-46a5-bee0-1c5ac1039b7b
       Content-Length:
       - '7278'
       Connection:
@@ -4489,7 +4489,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:17.402737Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:34.962942Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4568,10 +4568,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QeCaZbFXSKW40OcC28Cncg"],
-        "issued_at": "2018-08-03T19:41:17.402821Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cNe_YDr5RiOP0YyUCAnV8A"],
+        "issued_at": "2018-08-06T16:51:34.963029Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4586,7 +4586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7793473abb984d13b20e17038c460074
+      - 290afa4732bb4380a6d1161cfbd44698
   response:
     status:
       code: 200
@@ -4597,16 +4597,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1af89b83-5988-4bb7-91db-397230fd19a9
+      - req-bde51391-2871-4ba0-91e2-b2f2881fd094
       Date:
-      - Fri, 03 Aug 2018 19:41:17 GMT
+      - Mon, 06 Aug 2018 16:51:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4621,7 +4621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6800e2a8f6541b4aa732602beafad78
+      - 5afb80388c364351920a8c00059d383b
   response:
     status:
       code: 200
@@ -4632,16 +4632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9800e0ae-e653-416e-a858-965e1b01744b
+      - req-341977ea-e469-40da-a23f-56be052a03d6
       Date:
-      - Fri, 03 Aug 2018 19:41:17 GMT
+      - Mon, 06 Aug 2018 16:51:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:17 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4659,15 +4659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:17 GMT
+      - Mon, 06 Aug 2018 16:51:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 65288734f707484fbd0fcb81c6f0b70f
+      - c2406e14f2c44e42a28b83248a086b37
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c2506ee-29f3-4b34-a4b3-c67f78a4c0e1
+      - req-64af0ae9-fd1d-465a-b6bd-a21e5f4e0a8a
       Content-Length:
       - '7265'
       Connection:
@@ -4679,7 +4679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:18.075058Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:35.666889Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4758,10 +4758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UYMJsGZbRIKuzzJp1zfwLg"],
-        "issued_at": "2018-08-03T19:41:18.075165Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GwsbhYcEQxKsshQtliMWDQ"],
+        "issued_at": "2018-08-06T16:51:35.666972Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65288734f707484fbd0fcb81c6f0b70f
+      - c2406e14f2c44e42a28b83248a086b37
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-af11468c-fc5b-4108-81e2-6988e63b0237
+      - req-0a104bdb-bf68-4154-882c-8bbe2630c152
       Date:
-      - Fri, 03 Aug 2018 19:41:18 GMT
+      - Mon, 06 Aug 2018 16:51:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4814,15 +4814,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:18 GMT
+      - Mon, 06 Aug 2018 16:51:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ed33e63f7a9f425190e6f04703f04930
+      - 1db5e4ffdfbc43b5848fba63c4dcab94
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e89ac517-8480-403e-94ef-07c235026170
+      - req-cf71bf30-b813-4d02-88a1-14c4a7e0ce0c
       Content-Length:
       - '7278'
       Connection:
@@ -4834,7 +4834,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:18.628564Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:36.221884Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4913,10 +4913,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3mY-8dy_QxiChwhSzVFxLQ"],
-        "issued_at": "2018-08-03T19:41:18.628636Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["os07ppsfS0mdlO5-32-KFw"],
+        "issued_at": "2018-08-06T16:51:36.222007Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4931,7 +4931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed33e63f7a9f425190e6f04703f04930
+      - 1db5e4ffdfbc43b5848fba63c4dcab94
   response:
     status:
       code: 200
@@ -4942,16 +4942,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-04f42a0f-3282-4ab3-a232-03162681b901
+      - req-89dddf39-ef36-479d-acf5-a4964823439d
       Date:
-      - Fri, 03 Aug 2018 19:41:18 GMT
+      - Mon, 06 Aug 2018 16:51:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4966,7 +4966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4979,9 +4979,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-004040d0-39cc-4485-a725-de691bb363f7
+      - req-751f8977-2d82-43dd-9fab-a280836d2a38
       Date:
-      - Fri, 03 Aug 2018 19:41:18 GMT
+      - Mon, 06 Aug 2018 16:51:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4991,7 +4991,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:18 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5006,7 +5006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5019,9 +5019,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-fd62b5ef-98c3-4a44-9b9c-d6a1875e776c
+      - req-9806d495-5dc1-4607-b426-50fb3c2a8b88
       Date:
-      - Fri, 03 Aug 2018 19:41:19 GMT
+      - Mon, 06 Aug 2018 16:51:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5031,7 +5031,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5049,15 +5049,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:19 GMT
+      - Mon, 06 Aug 2018 16:51:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 524d7f558f824e5e895f6514bff4063c
+      - 0ccefa67982f4fc0a557b977ab3db8b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e94f4615-3ee1-4aed-949b-359608357bbd
+      - req-8e668668-f150-4228-aaa5-adbfe90efa15
       Content-Length:
       - '7278'
       Connection:
@@ -5069,7 +5069,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:19.373620Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:36.942370Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5148,10 +5148,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L7hhR10CSQedFYsyKn_8QA"],
-        "issued_at": "2018-08-03T19:41:19.373691Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h5hUEAGOTL-o4L7HX_ZCxg"],
+        "issued_at": "2018-08-06T16:51:36.942433Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5166,7 +5166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 524d7f558f824e5e895f6514bff4063c
+      - 0ccefa67982f4fc0a557b977ab3db8b7
   response:
     status:
       code: 200
@@ -5177,14 +5177,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4b63143e-1663-4779-ba8e-7e91de43409d
+      - req-12ea4ca9-1792-4102-a1e7-b07655588aa1
       Date:
-      - Fri, 03 Aug 2018 19:41:19 GMT
+      - Mon, 06 Aug 2018 16:51:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5202,15 +5202,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:19 GMT
+      - Mon, 06 Aug 2018 16:51:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63e8fb4769034e60a34c03db39a87c56
+      - 6ab1aa65bd144492a98e2d0b39dd5262
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78309361-f609-4680-a61b-34250c577a54
+      - req-df8e8ae6-c7a8-4f59-9e6e-c6484d243a3e
       Content-Length:
       - '7278'
       Connection:
@@ -5222,7 +5222,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:19.935656Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:37.720845Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5301,10 +5301,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ujcyJu7fROmYLwCogFVQrw"],
-        "issued_at": "2018-08-03T19:41:19.935748Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r3Oz1RJ6QHmU6mcb2wVnIg"],
+        "issued_at": "2018-08-06T16:51:37.720910Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:19 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5319,7 +5319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63e8fb4769034e60a34c03db39a87c56
+      - 6ab1aa65bd144492a98e2d0b39dd5262
   response:
     status:
       code: 200
@@ -5330,14 +5330,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8e1b007a-7d64-4f96-bdf1-3f2a0e58a0ee
+      - req-6dd4ce75-4536-408b-9c15-938311fe0445
       Date:
-      - Fri, 03 Aug 2018 19:41:20 GMT
+      - Mon, 06 Aug 2018 16:51:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5355,15 +5355,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:20 GMT
+      - Mon, 06 Aug 2018 16:51:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8789da2c-42f1-4476-ac2d-850a0995cc71
+      - req-622c394b-58ea-46ce-95cf-df6dbdb90079
       Content-Length:
       - '7264'
       Connection:
@@ -5375,7 +5375,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:20.533364Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:38.389848Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5454,10 +5454,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MXAHMS5CS_GskvJR45Vm4A"],
-        "issued_at": "2018-08-03T19:41:20.533445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w5URE9ZsQwmzDSeGYv1UIw"],
+        "issued_at": "2018-08-06T16:51:38.389930Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5472,7 +5472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -5483,9 +5483,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-c7913f13-f8b6-4db3-a82d-22695210d379
+      - req-c1de4878-cf57-470a-9b7b-211eb1b7ead7
       Date:
-      - Fri, 03 Aug 2018 19:41:20 GMT
+      - Mon, 06 Aug 2018 16:51:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5519,7 +5519,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5534,7 +5534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -5545,14 +5545,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3f79547a-3a8a-4da3-b04c-675bc1acce54
+      - req-cb212502-179f-46d8-b625-1ddd0e91d56d
       Date:
-      - Fri, 03 Aug 2018 19:41:21 GMT
+      - Mon, 06 Aug 2018 16:51:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5570,15 +5570,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:21 GMT
+      - Mon, 06 Aug 2018 16:51:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e20bdd3c745a4607b6828f84ec7d9c79
+      - 9a1e6f4b9af84f5690d103a4ed7661a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ea8b871f-82a8-410a-a414-825475a494aa
+      - req-3953e6ff-1e6e-41ca-aa14-62a3c16eda77
       Content-Length:
       - '7278'
       Connection:
@@ -5590,7 +5590,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:21.334025Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:39.236829Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5669,10 +5669,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lFIca8mLRUKqt6pQBzKFPg"],
-        "issued_at": "2018-08-03T19:41:21.334094Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UvmlI7TJR7Kzt9Bu5gL4eA"],
+        "issued_at": "2018-08-06T16:51:39.236893Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e20bdd3c745a4607b6828f84ec7d9c79
+      - 9a1e6f4b9af84f5690d103a4ed7661a6
   response:
     status:
       code: 200
@@ -5698,14 +5698,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-452d94a9-6cb7-41ce-b5ca-b94dc29c9d92
+      - req-ea8cb772-534b-4c6f-b785-64be18a5152c
       Date:
-      - Fri, 03 Aug 2018 19:41:21 GMT
+      - Mon, 06 Aug 2018 16:51:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5720,7 +5720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dcc4968fa34c4d4693858c94ae0910f8
+      - ffeb21de6dfd45cd832ee12507701c88
   response:
     status:
       code: 200
@@ -5731,14 +5731,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9b6e6c66-34c6-4df7-ac1e-08cd1fd0d322
+      - req-8f5e277a-6bf3-4227-99db-c03ec7e71628
       Date:
-      - Fri, 03 Aug 2018 19:41:21 GMT
+      - Mon, 06 Aug 2018 16:51:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5756,15 +5756,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:21 GMT
+      - Mon, 06 Aug 2018 16:51:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b364cc6133994fc4865d905b95a58337
+      - 532b12047d5a4e0aa7a8ba39c5244fba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f836e73b-38b4-42d5-b47a-90322e5b57dd
+      - req-da792dca-f8e4-408d-861d-b6cfadf9ec27
       Content-Length:
       - '7265'
       Connection:
@@ -5776,7 +5776,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:22.138446Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:39.969404Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5855,10 +5855,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oX4O9yGYRQCLFhB9erTA7g"],
-        "issued_at": "2018-08-03T19:41:22.138561Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b60GEdvoS1KR4W17dE7R3Q"],
+        "issued_at": "2018-08-06T16:51:39.969471Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5873,7 +5873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b364cc6133994fc4865d905b95a58337
+      - 532b12047d5a4e0aa7a8ba39c5244fba
   response:
     status:
       code: 200
@@ -5884,14 +5884,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3ae56b37-2e18-4bce-81ff-c0143e8ff52b
+      - req-4d559e8a-9828-4101-a043-aab4f6c69434
       Date:
-      - Fri, 03 Aug 2018 19:41:22 GMT
+      - Mon, 06 Aug 2018 16:51:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5909,15 +5909,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:22 GMT
+      - Mon, 06 Aug 2018 16:51:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e65c76c3684645e483a63cd90c933995
+      - 9c0da6759bbd4dc28ac914a63c807d1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1acbd574-8f08-4b4f-8f99-ca9a6b1421bc
+      - req-80cb9bc3-ea57-47b7-8856-83d3195547d2
       Content-Length:
       - '7278'
       Connection:
@@ -5929,7 +5929,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:22.807796Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:51:40.577098Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6008,10 +6008,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d7EyQ3Z0TfGrFE2D16j0_A"],
-        "issued_at": "2018-08-03T19:41:22.807863Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PtEyDJnTRcSC23i9gvkycw"],
+        "issued_at": "2018-08-06T16:51:40.577222Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -6026,7 +6026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e65c76c3684645e483a63cd90c933995
+      - 9c0da6759bbd4dc28ac914a63c807d1e
   response:
     status:
       code: 200
@@ -6037,14 +6037,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3581784a-9e18-4f9e-862a-4bbe18a79bce
+      - req-81910c6e-d1c0-4037-81dc-348a3e90185e
       Date:
-      - Fri, 03 Aug 2018 19:41:23 GMT
+      - Mon, 06 Aug 2018 16:51:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -6059,7 +6059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6070,9 +6070,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bee82995-443b-4cae-b57a-78e1d2c25301
+      - req-d2bd73f6-093b-46c1-be99-8e8550712032
       Date:
-      - Fri, 03 Aug 2018 19:41:23 GMT
+      - Mon, 06 Aug 2018 16:51:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6099,7 +6099,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -6114,7 +6114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6125,9 +6125,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c2692845-51e5-4707-8dfe-cb0470483213
+      - req-0998f22e-4f3d-469b-9f5c-375527246edd
       Date:
-      - Fri, 03 Aug 2018 19:41:24 GMT
+      - Mon, 06 Aug 2018 16:51:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6154,7 +6154,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -6169,7 +6169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6180,9 +6180,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1ae31bef-659f-4a6f-bc3f-83982bce8027
+      - req-9f8eeb01-d4b3-41b1-aad4-166d28b8cd95
       Date:
-      - Fri, 03 Aug 2018 19:41:25 GMT
+      - Mon, 06 Aug 2018 16:51:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6209,7 +6209,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6235,9 +6235,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c2a314fd-bc51-4995-a613-d96f40d62fba
+      - req-9260fe88-ed12-409f-bc1f-e952728b68ed
       Date:
-      - Fri, 03 Aug 2018 19:41:25 GMT
+      - Mon, 06 Aug 2018 16:51:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6249,7 +6249,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -6264,7 +6264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6275,9 +6275,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-879416e5-7d16-4b5c-ab32-64d7ed8cd618
+      - req-d0427ce1-0829-48be-90e1-8d1c85f2686e
       Date:
-      - Fri, 03 Aug 2018 19:41:25 GMT
+      - Mon, 06 Aug 2018 16:51:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6333,7 +6333,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6348,7 +6348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6359,9 +6359,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-81dfec8e-29a8-4a49-8ec7-ab53802dbaf2
+      - req-1a5a407b-94af-4d8c-890a-0394ff86fbea
       Date:
-      - Fri, 03 Aug 2018 19:41:25 GMT
+      - Mon, 06 Aug 2018 16:51:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6373,7 +6373,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6388,7 +6388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6399,9 +6399,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f80cdbbd-04b3-47dc-8369-cf72b3df271f
+      - req-7ad1eb5a-7f20-45a1-94c1-5d4791cb90de
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6457,7 +6457,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6472,7 +6472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6483,9 +6483,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fd4d70f3-e767-4a65-a5ea-04f5c5e0b99d
+      - req-7454ea07-616a-433e-8537-b404e6919725
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6497,7 +6497,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6512,7 +6512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55488825bf774099b98945e7219a2e5e
+      - 63a9fa8c296447bc92c4166e9b932d83
   response:
     status:
       code: 200
@@ -6523,9 +6523,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9fa6e76d-81a6-42db-9704-945e40b54164
+      - req-6094e7ce-8861-4004-a28e-a5a2a56a33dc
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6581,7 +6581,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6596,7 +6596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6607,14 +6607,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5ba7dd52-b96e-4465-9380-285fb94e9e98
+      - req-4eedd2eb-8512-4b39-8976-fdef4421d630
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6629,7 +6629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6640,9 +6640,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0acef3eb-d4eb-40fe-b597-24a747478ae8
+      - req-1b51cfee-60bc-485f-9391-2ea66ee96072
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6684,7 +6684,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6699,7 +6699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6710,14 +6710,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-82319bb1-710e-454b-ab55-1eebde40104a
+      - req-828cac20-f8da-4a89-9b4b-4d23bf1baf64
       Date:
-      - Fri, 03 Aug 2018 19:41:26 GMT
+      - Mon, 06 Aug 2018 16:51:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:26 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6732,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6743,14 +6743,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c9dee152-1cfa-40a0-a08d-5bca3387381f
+      - req-da83d015-94fe-4106-acef-2bbf5ec28d02
       Date:
-      - Fri, 03 Aug 2018 19:41:27 GMT
+      - Mon, 06 Aug 2018 16:51:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6765,7 +6765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6776,14 +6776,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-34d48a66-89dd-4641-b412-76cff78357ee
+      - req-0d93543f-8b59-4a7b-a415-9e9ff68317e2
       Date:
-      - Fri, 03 Aug 2018 19:41:27 GMT
+      - Mon, 06 Aug 2018 16:51:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6798,7 +6798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c50d487e3c4d484c95da4eae718f98d5
+      - 5a568efa0cc0473e97f05ff5679c3a92
   response:
     status:
       code: 200
@@ -6809,14 +6809,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c65b8697-931a-4187-b47d-45352654c39f
+      - req-0333ad11-de2b-4f82-9a05-aa1aa147eef0
       Date:
-      - Fri, 03 Aug 2018 19:41:27 GMT
+      - Mon, 06 Aug 2018 16:51:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:27 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6831,7 +6831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6844,9 +6844,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-48165ee4-57e7-4678-943d-ac14eb839e4a
+      - req-e76fce9f-eba7-4130-8d96-64f3217540be
       Date:
-      - Fri, 03 Aug 2018 19:41:28 GMT
+      - Mon, 06 Aug 2018 16:51:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6892,7 +6892,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6907,7 +6907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6920,9 +6920,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-f29e81d7-47c7-4dae-9972-45525d281f4b
+      - req-75467e34-39b3-4ae2-b987-ca5b3d00e4e0
       Date:
-      - Fri, 03 Aug 2018 19:41:28 GMT
+      - Mon, 06 Aug 2018 16:51:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6968,7 +6968,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:28 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6983,7 +6983,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6996,9 +6996,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-f7f1857c-1457-4756-b9ca-946e41489796
+      - req-9100033f-0d8b-425d-b048-496090b31e28
       Date:
-      - Fri, 03 Aug 2018 19:41:29 GMT
+      - Mon, 06 Aug 2018 16:51:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -7046,7 +7046,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:29 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -7061,7 +7061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7074,9 +7074,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-6e5add93-56ef-45a6-8c8d-f1ba66e08372
+      - req-87304f61-5a6e-4273-b3f7-9b4c2f6f306a
       Date:
-      - Fri, 03 Aug 2018 19:41:30 GMT
+      - Mon, 06 Aug 2018 16:51:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -7118,7 +7118,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -7133,7 +7133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7146,9 +7146,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-2129ed32-075a-4438-af4e-cd9fc9e7051d
+      - req-284f01e9-67d6-4c52-900c-fa4cff3e7218
       Date:
-      - Fri, 03 Aug 2018 19:41:30 GMT
+      - Mon, 06 Aug 2018 16:51:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -7171,7 +7171,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7186,7 +7186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7199,14 +7199,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a67cc706-1b78-494a-a7a5-cd278bfde74e
+      - req-6056b383-0ac4-4cd7-bb89-29d1e415f76c
       Date:
-      - Fri, 03 Aug 2018 19:41:30 GMT
+      - Mon, 06 Aug 2018 16:51:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7221,7 +7221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7234,14 +7234,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ca1e01cc-40fe-4135-a46c-37b1da1f307b
+      - req-fc8af774-dded-4637-93ab-4d95b3402408
       Date:
-      - Fri, 03 Aug 2018 19:41:30 GMT
+      - Mon, 06 Aug 2018 16:51:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:30 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7256,7 +7256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7269,14 +7269,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-be6855a6-77ac-4b71-9da5-07004db6e2e6
+      - req-5a95f940-5e38-4c1c-9639-a66618fd05cf
       Date:
-      - Fri, 03 Aug 2018 19:41:31 GMT
+      - Mon, 06 Aug 2018 16:51:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7291,7 +7291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7304,14 +7304,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-973787a5-4e5f-4605-acdc-61544bfde725
+      - req-91b3c8b2-a0cc-4ea1-92a5-9fc526a83d20
       Date:
-      - Fri, 03 Aug 2018 19:41:31 GMT
+      - Mon, 06 Aug 2018 16:51:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7326,7 +7326,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7339,14 +7339,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a08eaab0-47fc-439c-8baf-829604f877c7
+      - req-ae9f19c1-b125-4cc2-8e2d-161dbb3bd924
       Date:
-      - Fri, 03 Aug 2018 19:41:31 GMT
+      - Mon, 06 Aug 2018 16:51:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:31 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7361,7 +7361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7374,14 +7374,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f0a43899-4c00-45f0-a2c7-c2b447bae786
+      - req-7e51f541-c0e9-41d0-99e8-a7fb6d0c26d6
       Date:
-      - Fri, 03 Aug 2018 19:41:31 GMT
+      - Mon, 06 Aug 2018 16:51:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7396,7 +7396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7409,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5a092df8-c386-4a23-a572-a23f49d9a7b5
+      - req-314c19db-1b8e-453e-8ad6-3628edbb267c
       Date:
-      - Fri, 03 Aug 2018 19:41:32 GMT
+      - Mon, 06 Aug 2018 16:51:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7431,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7444,14 +7444,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5f11ed54-887f-49e3-88ec-e60102ffdd9a
+      - req-656f8afc-36dc-45ba-84a0-090901552923
       Date:
-      - Fri, 03 Aug 2018 19:41:32 GMT
+      - Mon, 06 Aug 2018 16:51:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7466,7 +7466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7479,14 +7479,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0d13accd-a4e0-4440-99a6-df3647f5ba1c
+      - req-0e7fa7d3-8f2b-43d8-b5e6-36c13ab57810
       Date:
-      - Fri, 03 Aug 2018 19:41:32 GMT
+      - Mon, 06 Aug 2018 16:51:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7501,7 +7501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7514,26 +7514,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c17082d7-8403-4526-a4d5-62b9a47b7fbd
+      - req-66921e59-0f34-4526-ae94-560fac4ed43d
       Date:
-      - Fri, 03 Aug 2018 19:41:32 GMT
+      - Mon, 06 Aug 2018 16:51:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:41:23.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:51:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:41:28.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:51:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:41:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:51:55.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:41:23.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:51:48.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:41:23.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:51:48.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7548,7 +7548,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf4f0ba56ed947458fabe5ead6bd34a7
+      - f7873263d6df437f9b29a17e90463fdb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7561,26 +7561,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d8b47049-6905-4c74-b538-53edbff7f5b5
+      - req-d64fefca-3957-4992-9c01-8b14f4b95320
       Date:
-      - Fri, 03 Aug 2018 19:41:32 GMT
+      - Mon, 06 Aug 2018 16:51:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:41:23.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:51:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:41:28.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:51:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:41:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:51:55.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-03T19:41:23.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:51:48.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-03T19:41:23.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:51:48.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:32 GMT
+  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7598,15 +7598,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:34 GMT
+      - Mon, 06 Aug 2018 16:52:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dc1342a851a046b9ba76d66d3f1663fa
+      - 15523f98a0374352911c4a41e0dfa078
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-45d14c0c-2d4e-4f7c-b4ca-8297ca98617f
+      - req-6b5587de-38df-4e21-b061-bc2f931635fa
       Content-Length:
       - '7311'
       Connection:
@@ -7618,7 +7618,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:34.420808Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:01.609231Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7697,10 +7697,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HYJH0nNpTjSHM9NXHKTsvA"],
-        "issued_at": "2018-08-03T19:41:34.420882Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lxXGAJkPTCKcOJ935xcWTg"],
+        "issued_at": "2018-08-06T16:52:01.609299Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7718,15 +7718,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:34 GMT
+      - Mon, 06 Aug 2018 16:52:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad31a20e-16ad-4389-8365-496789e56bd0
+      - req-7f16d4a6-a1d7-49ea-a58a-fcbaa6179693
       Content-Length:
       - '7311'
       Connection:
@@ -7738,7 +7738,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:34.765945Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:01.959742Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7817,10 +7817,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KoJj8b-2QCK5Ekjt5xUOlg"],
-        "issued_at": "2018-08-03T19:41:34.766012Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0uPZnlh6QPOsZ41del4z8g"],
+        "issued_at": "2018-08-06T16:52:01.959810Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7835,7 +7835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -7846,9 +7846,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-5b8f9253-067a-4c39-a436-6f999e96d2d4
+      - req-aa2a3c22-b6ca-4203-8466-472d6675fc07
       Date:
-      - Fri, 03 Aug 2018 19:41:35 GMT
+      - Mon, 06 Aug 2018 16:52:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7883,7 +7883,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7898,7 +7898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -7909,9 +7909,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-20b7e9a4-fa51-425f-8d36-097bf7ab18b4
+      - req-cc254b16-9b58-4e0b-a9fc-22fb8da4918d
       Date:
-      - Fri, 03 Aug 2018 19:41:35 GMT
+      - Mon, 06 Aug 2018 16:52:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7954,7 +7954,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7969,7 +7969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -7980,9 +7980,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-67d7b60f-85ea-4ef0-9e52-0e175de7a087
+      - req-e8e039d8-abfe-4ad3-80a1-39e8fb38e22c
       Date:
-      - Fri, 03 Aug 2018 19:41:35 GMT
+      - Mon, 06 Aug 2018 16:52:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -8025,7 +8025,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -8040,7 +8040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8051,9 +8051,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-41a4ebf5-9e0f-41c3-a4f8-7ccb29b4d5cd
+      - req-7113e72b-6d5c-4057-a8ce-9382a65e6844
       Date:
-      - Fri, 03 Aug 2018 19:41:35 GMT
+      - Mon, 06 Aug 2018 16:52:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -8160,7 +8160,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -8175,7 +8175,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8186,9 +8186,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-ca97f27a-e4bf-40e7-9dd5-623e2ba14618
+      - req-66df0057-983b-485f-b5f7-ee52da92b35e
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -8230,7 +8230,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -8245,7 +8245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8256,15 +8256,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-0cfe901c-e1f8-43e2-a32a-3fd483590b36
+      - req-034e131f-5f23-4e99-96cf-8bda6e2272bc
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8279,7 +8279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8290,32 +8290,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-f684988d-5a5d-4ccf-8a44-2e89b3f8f547
+      - req-0643ae1f-d72d-4dc6-8900-1e6fedc0000e
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -8325,12 +8310,12 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -8345,24 +8330,39 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8377,7 +8377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8388,12 +8388,23 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e4140b6a-a4b9-4d9b-ab83-01158f577cbc
+      - req-829e947a-355b-440f-b99d-f1483c9e4e75
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -8470,34 +8481,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -8509,7 +8509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8520,9 +8520,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9453679d-5401-4682-ab7e-d5bba6afc6aa
+      - req-a536d0ef-c05b-4004-83f8-986d30795827
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -8536,30 +8536,24 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -8578,21 +8572,22 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
@@ -8606,26 +8601,32 @@ http_interactions:
         "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
         "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
         {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8640,7 +8641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8651,9 +8652,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a5e71186-e05c-4077-a73d-61f85b73807d
+      - req-2f4a7272-b519-440c-850b-051c1617252d
       Date:
-      - Fri, 03 Aug 2018 19:41:36 GMT
+      - Mon, 06 Aug 2018 16:52:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8685,7 +8686,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8700,7 +8701,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8711,9 +8712,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3d95c4f4-69b8-4edd-a633-abcb129b7e06
+      - req-3738d89a-ccb6-4f8a-a25f-6ef630042f16
       Date:
-      - Fri, 03 Aug 2018 19:41:37 GMT
+      - Mon, 06 Aug 2018 16:52:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8745,7 +8746,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8760,7 +8761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -8771,9 +8772,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d134ca31-ec9d-4d0f-b181-858e7fdb201e
+      - req-5dbd8ff8-5d54-4a41-9f96-ed65cf24cae4
       Date:
-      - Fri, 03 Aug 2018 19:41:37 GMT
+      - Mon, 06 Aug 2018 16:52:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9176,7 +9177,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9191,7 +9192,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -9202,9 +9203,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9b771b6b-562c-44a2-8408-2efbb84ab0da
+      - req-c8549ca2-6fcf-40c4-9562-883e1ce788ac
       Date:
-      - Fri, 03 Aug 2018 19:41:37 GMT
+      - Mon, 06 Aug 2018 16:52:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9607,7 +9608,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9622,7 +9623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -9633,9 +9634,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e2d05937-f818-4603-aba9-eb2549ae2751
+      - req-6a85074c-4b16-4eaa-b01f-bb2afb60f5c2
       Date:
-      - Fri, 03 Aug 2018 19:41:37 GMT
+      - Mon, 06 Aug 2018 16:52:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9677,7 +9678,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9692,7 +9693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75248c3275948caafa8dae7e28727a7
+      - 5af2456753a34051ab830b15b62cfab5
   response:
     status:
       code: 200
@@ -9703,9 +9704,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-65ac17a0-a86b-4e69-9e2d-c3b84126055a
+      - req-28974418-f79f-4f18-9929-3fb5d6d189ad
       Date:
-      - Fri, 03 Aug 2018 19:41:37 GMT
+      - Mon, 06 Aug 2018 16:52:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9747,7 +9748,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9765,15 +9766,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:38 GMT
+      - Mon, 06 Aug 2018 16:52:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6fe5a5400fc94c1ead5f4b92c8dfa6d3
+      - 66df1714399143038749d7cdf4b60272
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0fc6c9d-e346-4b4c-9674-a35e83772ec2
+      - req-bdc51ca1-8ad4-4a1c-9c75-18258e8a732f
       Content-Length:
       - '7311'
       Connection:
@@ -9785,7 +9786,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:38.825612Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:06.670899Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9864,10 +9865,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QPeaSl6FSoq23L5seV_3Rg"],
-        "issued_at": "2018-08-03T19:41:38.825692Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UhNyFah8Q42NO1m799hGcw"],
+        "issued_at": "2018-08-06T16:52:06.670982Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9885,15 +9886,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:38 GMT
+      - Mon, 06 Aug 2018 16:52:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-53f6d9e3-c42e-4de0-b912-dbfb905a6df2
+      - req-84ad5844-477c-43f4-935e-0b860aef2fc1
       Content-Length:
       - '7311'
       Connection:
@@ -9905,7 +9906,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:39.257535Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:07.028832Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9984,10 +9985,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qot6C2mfS8qaE76xD0chkg"],
-        "issued_at": "2018-08-03T19:41:39.257618Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["18UuaCOYTf6mLRtYtpchlg"],
+        "issued_at": "2018-08-06T16:52:07.028896Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10005,15 +10006,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:39 GMT
+      - Mon, 06 Aug 2018 16:52:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e2a73d1260a14385b9a09f42bfb4db61
+      - aa82b495017d44c6a7579e523942e37e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b8ee8485-eac5-4df0-84cb-e2b0ecb59408
+      - req-6c958dc4-a68b-4ab5-9106-92636b64de1e
       Content-Length:
       - '297'
       Connection:
@@ -10022,12 +10023,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:41:39.498242Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:07.289668Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8wKV70ZLQyCQIGC4IuS23w"],
-        "issued_at": "2018-08-03T19:41:39.498305Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kX-wJR1JTn2tkYvoBWr2vA"],
+        "issued_at": "2018-08-06T16:52:07.289731Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -10042,20 +10043,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2a73d1260a14385b9a09f42bfb4db61
+      - aa82b495017d44c6a7579e523942e37e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:39 GMT
+      - Mon, 06 Aug 2018 16:52:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d91a2f85-e731-4f3a-9359-1ee085ff2235
+      - req-d826cbcc-1a9f-4011-98d7-b7ec044d86af
       Content-Length:
       - '2457'
       Connection:
@@ -10088,13 +10089,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"e2a73d1260a14385b9a09f42bfb4db61"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"aa82b495017d44c6a7579e523942e37e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10106,15 +10107,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:39 GMT
+      - Mon, 06 Aug 2018 16:52:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d87d662a8d504066987d86649bb0d92a
+      - 5786841e9b744ad7a9b96cdb0d51bc48
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7796f65d-1893-4484-a779-6010efc2d19d
+      - req-505890a2-75af-47db-8765-3d11e650124e
       Content-Length:
       - '7313'
       Connection:
@@ -10126,7 +10127,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:39.498242Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:07.289668Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10205,10 +10206,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y8jAwXjuTMqVEIBjq-lrHw",
-        "8wKV70ZLQyCQIGC4IuS23w"], "issued_at": "2018-08-03T19:41:39.946272Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v95VpXNjSomSFUqGHssbLg",
+        "kX-wJR1JTn2tkYvoBWr2vA"], "issued_at": "2018-08-06T16:52:07.731624Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -10223,20 +10224,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87d662a8d504066987d86649bb0d92a
+      - 5786841e9b744ad7a9b96cdb0d51bc48
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:40 GMT
+      - Mon, 06 Aug 2018 16:52:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ecc70bf-d185-4161-9ddb-9b8ca255d3da
+      - req-5ca71d86-4325-4758-9c41-1f167897fc61
       Content-Length:
       - '2179'
       Connection:
@@ -10269,7 +10270,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10287,15 +10288,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:40 GMT
+      - Mon, 06 Aug 2018 16:52:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a5c9bfd32b6b4065b0517869d7ebebd6
+      - d5f5317d53b5499ba8a4b0872f791fa3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2e145a18-d67a-423f-bfb1-6e4aaec80a20
+      - req-9399010a-73e6-4d22-af7b-ebf2c9b97496
       Content-Length:
       - '7278'
       Connection:
@@ -10307,7 +10308,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:40.414654Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:08.209275Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10386,10 +10387,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ksnJUyMcS2yl_fi_0U5-sg"],
-        "issued_at": "2018-08-03T19:41:40.414744Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8cWzwyJMS4qgJ5E-0uvtHg"],
+        "issued_at": "2018-08-06T16:52:08.209357Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10407,15 +10408,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:40 GMT
+      - Mon, 06 Aug 2018 16:52:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a8383d03667f4222a2a6f09b7e4fb483
+      - 5c415779d5d04b5abdc5f90dd4d987d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a00014a3-0ccb-4ca9-8f05-4c2dcbc08264
+      - req-c88e34e1-c937-4b10-b893-584e7b388dc4
       Content-Length:
       - '7278'
       Connection:
@@ -10427,7 +10428,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:40.752923Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:08.653371Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10506,10 +10507,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LLBPmW3wRD-kp6IXvmBCHw"],
-        "issued_at": "2018-08-03T19:41:40.752990Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e-6Xvm7sRfGdR90XbVlDMw"],
+        "issued_at": "2018-08-06T16:52:08.653452Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10527,15 +10528,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:40 GMT
+      - Mon, 06 Aug 2018 16:52:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 920eae1fe83b4ea6874a07d5f2bd8975
+      - d45509c9ba06457b81c9f4718da53429
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a33487c-bf91-4339-a280-61aeae6dc679
+      - req-2bd01763-eccf-4d4b-b288-725bc7e55736
       Content-Length:
       - '7264'
       Connection:
@@ -10547,7 +10548,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:41.118100Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:09.031777Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10626,10 +10627,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5h5dxIeBTzmQCG56nxnOmg"],
-        "issued_at": "2018-08-03T19:41:41.118225Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OOyew8IfQOyRWS-t_nse1w"],
+        "issued_at": "2018-08-06T16:52:09.031842Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10647,15 +10648,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:41 GMT
+      - Mon, 06 Aug 2018 16:52:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33a89de97d6b4ef08efa2563ba8c3046
+      - 108bcda74ba74b5f96c9866780041ef1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-531de3a7-9948-4217-bff6-ee64efd30de5
+      - req-8a7e1489-3ade-4dfb-bca7-b1b15adb232b
       Content-Length:
       - '7278'
       Connection:
@@ -10667,7 +10668,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:41.464796Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:09.364059Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10746,10 +10747,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UAE95L_hRu2oonK7aNCFwQ"],
-        "issued_at": "2018-08-03T19:41:41.464873Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Lfo7a-H0RxOBi3x2ORIgLA"],
+        "issued_at": "2018-08-06T16:52:09.364178Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10767,15 +10768,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:41 GMT
+      - Mon, 06 Aug 2018 16:52:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ca1b63a2ab754421a52fcbc9e78543fe
+      - 6228b4120c494d7ca2decaa0daf2dd48
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2ee22c3f-7576-46eb-ad5a-8fee7099cdd4
+      - req-536e68de-48c7-4968-acd4-a0fbf42bdbe2
       Content-Length:
       - '7265'
       Connection:
@@ -10787,7 +10788,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:41.852925Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:09.709861Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10866,10 +10867,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4kQqle6yR9SLFnhaQKXbqA"],
-        "issued_at": "2018-08-03T19:41:41.853012Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gdVcHc84SQq9xvuVHTkUuA"],
+        "issued_at": "2018-08-06T16:52:09.709926Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10887,15 +10888,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:41 GMT
+      - Mon, 06 Aug 2018 16:52:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c9983d4e7fdc477ba046962fc00a10af
+      - b7053bf492eb43cb8bfecefe6f383754
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59218fbf-4a92-467c-bed3-3c1e0340eb35
+      - req-2ff3d885-80ae-40dd-84b6-597d8da731d3
       Content-Length:
       - '7278'
       Connection:
@@ -10907,7 +10908,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:42.202050Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:10.038743Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10986,10 +10987,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hOtynUAFSFSG7xwklUsx5Q"],
-        "issued_at": "2018-08-03T19:41:42.202172Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IaGrMEnAQviW1yD6YfZlwQ"],
+        "issued_at": "2018-08-06T16:52:10.038807Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11007,15 +11008,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:42 GMT
+      - Mon, 06 Aug 2018 16:52:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50107357-837f-44a7-af7e-3cba9bcab60b
+      - req-aa42b330-6f3e-4333-9539-dcace3579c7b
       Content-Length:
       - '7278'
       Connection:
@@ -11027,7 +11028,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:42.535557Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:10.364792Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11106,10 +11107,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bCrx7yNjRz69W_QDpol6ew"],
-        "issued_at": "2018-08-03T19:41:42.535638Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pr826tVVTNiAXahdEXQiHw"],
+        "issued_at": "2018-08-06T16:52:10.364874Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11124,27 +11125,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-960e0da1-e878-4ff4-9214-a8485ed96d3a
+      - req-519e8b9d-70af-4eee-aa1c-7aa5ce620670
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-960e0da1-e878-4ff4-9214-a8485ed96d3a
+      - req-519e8b9d-70af-4eee-aa1c-7aa5ce620670
       Date:
-      - Fri, 03 Aug 2018 19:41:42 GMT
+      - Mon, 06 Aug 2018 16:52:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11162,15 +11163,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:42 GMT
+      - Mon, 06 Aug 2018 16:52:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2173df6d-c19b-470d-93d9-74b9a61b9bdd
+      - req-fcf35f34-532d-44af-a1f1-438653164854
       Content-Length:
       - '7278'
       Connection:
@@ -11182,7 +11183,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:43.325762Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:11.080511Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11261,10 +11262,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mLVdzf55SzKYZahOHUc0_Q"],
-        "issued_at": "2018-08-03T19:41:43.325853Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1fY3xYSySa-z2uTTZ5yQDA"],
+        "issued_at": "2018-08-06T16:52:11.080579Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11279,27 +11280,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4310f927-8bd8-4ff6-a908-0c990954cf1a
+      - req-c6336dec-e732-4c0c-ab65-2ddcd0db2be8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4310f927-8bd8-4ff6-a908-0c990954cf1a
+      - req-c6336dec-e732-4c0c-ab65-2ddcd0db2be8
       Date:
-      - Fri, 03 Aug 2018 19:41:43 GMT
+      - Mon, 06 Aug 2018 16:52:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11317,15 +11318,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:43 GMT
+      - Mon, 06 Aug 2018 16:52:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d0bd8189-f551-4987-b897-ed653a8528ae
+      - req-347e6dcc-1a83-4bad-8484-2e567a400228
       Content-Length:
       - '7264'
       Connection:
@@ -11337,7 +11338,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:43.912697Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:11.686400Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11416,10 +11417,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WIPXckENQUCO2shmQb38Cg"],
-        "issued_at": "2018-08-03T19:41:43.912778Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wu8uH0jXR5e9nVRuqqx0lw"],
+        "issued_at": "2018-08-06T16:52:11.686464Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11434,22 +11435,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dce6f2fa-8a07-4f9c-bf54-38050dcd9977
+      - req-e391cf9b-fffe-46ad-97e6-7de3c37d669d
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-dce6f2fa-8a07-4f9c-bf54-38050dcd9977
+      - req-e391cf9b-fffe-46ad-97e6-7de3c37d669d
       Date:
-      - Fri, 03 Aug 2018 19:41:44 GMT
+      - Mon, 06 Aug 2018 16:52:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11482,7 +11483,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11497,22 +11498,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbeb0e23-d2d3-4d23-b476-7b0a38cad79e
+      - req-97694de3-ac96-4e04-8996-40bcd8503dea
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-cbeb0e23-d2d3-4d23-b476-7b0a38cad79e
+      - req-97694de3-ac96-4e04-8996-40bcd8503dea
       Date:
-      - Fri, 03 Aug 2018 19:41:44 GMT
+      - Mon, 06 Aug 2018 16:52:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11553,7 +11554,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11568,22 +11569,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4c0f802-0999-4109-9409-02f6af5a241b
+      - req-baa3f566-aa17-4cb6-beb5-2cc86fbe4d2c
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a4c0f802-0999-4109-9409-02f6af5a241b
+      - req-baa3f566-aa17-4cb6-beb5-2cc86fbe4d2c
       Date:
-      - Fri, 03 Aug 2018 19:41:45 GMT
+      - Mon, 06 Aug 2018 16:52:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11617,7 +11618,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11632,27 +11633,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b93bf083-a4c0-42cb-be70-774e02edcd70
+      - req-5fa3a30b-3b5b-4ecb-8c06-532ed633a1ea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b93bf083-a4c0-42cb-be70-774e02edcd70
+      - req-5fa3a30b-3b5b-4ecb-8c06-532ed633a1ea
       Date:
-      - Fri, 03 Aug 2018 19:41:45 GMT
+      - Mon, 06 Aug 2018 16:52:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11670,15 +11671,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:45 GMT
+      - Mon, 06 Aug 2018 16:52:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-007e19ea-f836-4454-9fa2-ca6b93083af6
+      - req-24f1186a-5940-4b16-ac6b-75e096d21cd5
       Content-Length:
       - '7278'
       Connection:
@@ -11690,7 +11691,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:45.748438Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:13.583019Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11769,10 +11770,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6esgFlkOT4mncapv2n8rVw"],
-        "issued_at": "2018-08-03T19:41:45.748492Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AZvmHlwtQ16ZiEUqtY1Ouw"],
+        "issued_at": "2018-08-06T16:52:13.583083Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11787,27 +11788,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-064c90f1-c025-48c9-9163-8ec360930ed1
+      - req-65415d85-3e40-4d6b-9ac3-479715044593
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-064c90f1-c025-48c9-9163-8ec360930ed1
+      - req-65415d85-3e40-4d6b-9ac3-479715044593
       Date:
-      - Fri, 03 Aug 2018 19:41:46 GMT
+      - Mon, 06 Aug 2018 16:52:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11822,27 +11823,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39d6f1d5-98d0-4bff-9f2f-94ddd9f0f0e9
+      - req-c780c966-31a1-4d9e-a8f5-7ab76e3a2823
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-39d6f1d5-98d0-4bff-9f2f-94ddd9f0f0e9
+      - req-c780c966-31a1-4d9e-a8f5-7ab76e3a2823
       Date:
-      - Fri, 03 Aug 2018 19:41:46 GMT
+      - Mon, 06 Aug 2018 16:52:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11860,15 +11861,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:46 GMT
+      - Mon, 06 Aug 2018 16:52:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-320abe1e-f444-44bd-82c2-01b036dad4de
+      - req-7277e9d3-f558-4a20-aff9-55ba3caf9069
       Content-Length:
       - '7265'
       Connection:
@@ -11880,7 +11881,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:46.646265Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:14.440256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11959,10 +11960,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I-m54ylkS8GjMk0xc3IaTQ"],
-        "issued_at": "2018-08-03T19:41:46.646329Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iGLEj9fLTeiv54EheZ4YPQ"],
+        "issued_at": "2018-08-06T16:52:14.440328Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11977,27 +11978,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ec2735a-2fe5-4507-9224-f83e39a4495e
+      - req-3a09aa28-3fba-4036-b73b-53f54b9b6127
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ec2735a-2fe5-4507-9224-f83e39a4495e
+      - req-3a09aa28-3fba-4036-b73b-53f54b9b6127
       Date:
-      - Fri, 03 Aug 2018 19:41:46 GMT
+      - Mon, 06 Aug 2018 16:52:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12015,15 +12016,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:47 GMT
+      - Mon, 06 Aug 2018 16:52:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4c1c807b-8c43-404b-8a42-15c22af5b52a
+      - req-f2ec099a-f6bd-472e-b1da-93f121e56c88
       Content-Length:
       - '7278'
       Connection:
@@ -12035,7 +12036,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:47.308328Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:15.225848Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12114,10 +12115,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FKXkDltgRAuN5c8wBwqjXw"],
-        "issued_at": "2018-08-03T19:41:47.308412Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJzt640SSP29-Nav4daUWQ"],
+        "issued_at": "2018-08-06T16:52:15.225925Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -12132,27 +12133,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b602cb6-ef57-4a76-8ae4-5bd53c34ef98
+      - req-8d571db3-76ba-458d-950a-0b0fe3feff6b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7b602cb6-ef57-4a76-8ae4-5bd53c34ef98
+      - req-8d571db3-76ba-458d-950a-0b0fe3feff6b
       Date:
-      - Fri, 03 Aug 2018 19:41:47 GMT
+      - Mon, 06 Aug 2018 16:52:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -12167,27 +12168,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1420fb03-272b-4bed-b93b-c85054378313
+      - req-47ba9cf1-826b-4b68-acb0-ed3c11f031df
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1420fb03-272b-4bed-b93b-c85054378313
+      - req-47ba9cf1-826b-4b68-acb0-ed3c11f031df
       Date:
-      - Fri, 03 Aug 2018 19:41:47 GMT
+      - Mon, 06 Aug 2018 16:52:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -12202,27 +12203,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9f2b83c-3d49-4f59-891d-c3066e889add
+      - req-dd667826-5d51-4a72-88e1-d67be2d82436
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b9f2b83c-3d49-4f59-891d-c3066e889add
+      - req-dd667826-5d51-4a72-88e1-d67be2d82436
       Date:
-      - Fri, 03 Aug 2018 19:41:47 GMT
+      - Mon, 06 Aug 2018 16:52:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -12237,27 +12238,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb827447-0905-476e-a2f7-b62d167ee311
+      - req-a212f713-da79-443d-aad1-ce7bd4e87f08
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bb827447-0905-476e-a2f7-b62d167ee311
+      - req-a212f713-da79-443d-aad1-ce7bd4e87f08
       Date:
-      - Fri, 03 Aug 2018 19:41:47 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -12272,27 +12273,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-606a76d8-1373-4025-8c07-81bd401f9e24
+      - req-b80d35ae-a0ae-44f0-aabb-8367b9e37bc5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-606a76d8-1373-4025-8c07-81bd401f9e24
+      - req-b80d35ae-a0ae-44f0-aabb-8367b9e37bc5
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12307,22 +12308,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d4bbf40-8659-4638-806c-1738bd6f5c99
+      - req-b537b6ea-0a19-4607-abad-3103360e94e9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-0d4bbf40-8659-4638-806c-1738bd6f5c99
+      - req-b537b6ea-0a19-4607-abad-3103360e94e9
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12337,7 +12338,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12352,22 +12353,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c639929c-200d-4837-a8c7-354945fd2403
+      - req-97c8d892-475e-488f-8523-0a4d68081ff3
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-c639929c-200d-4837-a8c7-354945fd2403
+      - req-97c8d892-475e-488f-8523-0a4d68081ff3
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12382,7 +12383,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12397,27 +12398,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-355feb9a-7a00-4419-8212-fb9b61d295ae
+      - req-65e32e67-8853-47a4-b1f8-5950bf686063
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-355feb9a-7a00-4419-8212-fb9b61d295ae
+      - req-65e32e67-8853-47a4-b1f8-5950bf686063
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12432,27 +12433,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71cc87b4-9312-4b16-8034-ef278222af81
+      - req-2b3ade5d-9b9c-452d-9c18-83bda22273cb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-71cc87b4-9312-4b16-8034-ef278222af81
+      - req-2b3ade5d-9b9c-452d-9c18-83bda22273cb
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12467,27 +12468,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-289d55bf-ca7f-4b5e-b33d-43828f6c9c7e
+      - req-39917fd9-587d-4f74-9ad2-d1960fe78e55
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-289d55bf-ca7f-4b5e-b33d-43828f6c9c7e
+      - req-39917fd9-587d-4f74-9ad2-d1960fe78e55
       Date:
-      - Fri, 03 Aug 2018 19:41:48 GMT
+      - Mon, 06 Aug 2018 16:52:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12502,27 +12503,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc4d0d9e-679c-4e52-8bed-6ad96d168f93
+      - req-4ecc46a8-1a99-4cb4-84e8-48456dd51013
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cc4d0d9e-679c-4e52-8bed-6ad96d168f93
+      - req-4ecc46a8-1a99-4cb4-84e8-48456dd51013
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12537,27 +12538,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c550b653-d695-412f-9734-91e8bd5dc27d
+      - req-4e1eb4d1-a2d4-4aa7-8993-f339405982c8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c550b653-d695-412f-9734-91e8bd5dc27d
+      - req-4e1eb4d1-a2d4-4aa7-8993-f339405982c8
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12572,27 +12573,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31e91ecb-ddb5-49af-807f-5b0577170315
+      - req-72faf593-cacc-4e56-9099-e1bc4d901079
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-31e91ecb-ddb5-49af-807f-5b0577170315
+      - req-72faf593-cacc-4e56-9099-e1bc4d901079
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12607,27 +12608,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6ced1b7-dbf7-4ae5-afb8-18a441b030fc
+      - req-7234c564-83d7-47fa-9894-f109dc415f9a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c6ced1b7-dbf7-4ae5-afb8-18a441b030fc
+      - req-7234c564-83d7-47fa-9894-f109dc415f9a
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12642,27 +12643,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6a1077a-29bf-4bb4-b806-03b358e1b9ab
+      - req-898c26f8-b2ab-4ad6-a4d7-b8a02e0e89ae
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d6a1077a-29bf-4bb4-b806-03b358e1b9ab
+      - req-898c26f8-b2ab-4ad6-a4d7-b8a02e0e89ae
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12677,27 +12678,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ebf7505-26aa-4d12-8edb-0f0831289d0e
+      - req-98f62d61-c37e-4ed1-8841-0db1a73b8a21
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0ebf7505-26aa-4d12-8edb-0f0831289d0e
+      - req-98f62d61-c37e-4ed1-8841-0db1a73b8a21
       Date:
-      - Fri, 03 Aug 2018 19:41:49 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12712,27 +12713,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f8e3d7c-d79a-4e48-8456-10df5c26898f
+      - req-867f3c74-f81c-4a9a-ac62-80e5b1196cdf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9f8e3d7c-d79a-4e48-8456-10df5c26898f
+      - req-867f3c74-f81c-4a9a-ac62-80e5b1196cdf
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -12747,27 +12748,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9e2d916e-dc33-415d-b584-28e37c4446ea
+      - req-4c763c45-b05d-45ab-ba87-71dd6cf857ed
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9e2d916e-dc33-415d-b584-28e37c4446ea
+      - req-4c763c45-b05d-45ab-ba87-71dd6cf857ed
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -12782,27 +12783,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-57c97946-fe71-474e-9cfb-c42b961bdfb4
+      - req-77627871-fb68-4eb2-ac82-22eb9bad08c4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-57c97946-fe71-474e-9cfb-c42b961bdfb4
+      - req-77627871-fb68-4eb2-ac82-22eb9bad08c4
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -12817,27 +12818,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f89a1e98-9f9c-4664-be02-950ad5bc59b0
+      - req-16a7f231-95d2-48bf-a429-a6ea618202bd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f89a1e98-9f9c-4664-be02-950ad5bc59b0
+      - req-16a7f231-95d2-48bf-a429-a6ea618202bd
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -12852,27 +12853,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc28431e-aa78-4535-b8bb-f12b9a59e582
+      - req-f35f9f4f-1945-4c09-8dba-770b817e4497
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cc28431e-aa78-4535-b8bb-f12b9a59e582
+      - req-f35f9f4f-1945-4c09-8dba-770b817e4497
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -12887,27 +12888,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1272d278-7820-4b93-831a-a49d85816401
+      - req-13ad7b6e-a29c-48a0-a0b2-6f55f486dc51
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1272d278-7820-4b93-831a-a49d85816401
+      - req-13ad7b6e-a29c-48a0-a0b2-6f55f486dc51
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -12922,27 +12923,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99c41be0-de7d-4e75-8802-f9cc141dc478
+      - req-8166d54c-41d3-426c-8101-de38d0f867ea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-99c41be0-de7d-4e75-8802-f9cc141dc478
+      - req-8166d54c-41d3-426c-8101-de38d0f867ea
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -12957,27 +12958,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-75636071-08b2-4a7c-ad98-46c65f5683e9
+      - req-4ba1a77e-bd8b-4073-a49b-91e3511b2031
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-75636071-08b2-4a7c-ad98-46c65f5683e9
+      - req-4ba1a77e-bd8b-4073-a49b-91e3511b2031
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -12992,27 +12993,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2291a56f-21f7-45bd-a0ee-5e2032e317d6
+      - req-41ab7cb6-d655-4638-a042-8629091b3a3e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2291a56f-21f7-45bd-a0ee-5e2032e317d6
+      - req-41ab7cb6-d655-4638-a042-8629091b3a3e
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -13027,27 +13028,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6152bb4a-4e26-4387-b54b-5263d517f4e1
+      - req-ec445f8f-8938-4385-98d1-5c2be6bfc334
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6152bb4a-4e26-4387-b54b-5263d517f4e1
+      - req-ec445f8f-8938-4385-98d1-5c2be6bfc334
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -13062,27 +13063,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b4d8ac41-a8b0-422b-a6cb-889b44037fcc
+      - req-960a103b-02b4-4803-97a9-e3c294bb5e12
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b4d8ac41-a8b0-422b-a6cb-889b44037fcc
+      - req-960a103b-02b4-4803-97a9-e3c294bb5e12
       Date:
-      - Fri, 03 Aug 2018 19:41:50 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -13097,27 +13098,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e64dda71-b033-435c-98fb-431d4a92d7e0
+      - req-772f5fd3-337d-4dc6-be0e-4f1d11c8e47c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e64dda71-b033-435c-98fb-431d4a92d7e0
+      - req-772f5fd3-337d-4dc6-be0e-4f1d11c8e47c
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -13132,27 +13133,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39ff0998-5b81-4d03-b5a2-0817d07b8735
+      - req-7269ff3d-fea7-4ad5-af61-628ab602850d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-39ff0998-5b81-4d03-b5a2-0817d07b8735
+      - req-7269ff3d-fea7-4ad5-af61-628ab602850d
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -13167,22 +13168,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d4f10f2e-4efc-4602-b59a-27eb296a010a
+      - req-1600a5ae-c444-48d5-af6f-6ef6d9cd2f50
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d4f10f2e-4efc-4602-b59a-27eb296a010a
+      - req-1600a5ae-c444-48d5-af6f-6ef6d9cd2f50
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13194,7 +13195,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13209,22 +13210,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef18c5509f2b4e43ac3d795a796b1f38
+      - 941aa8c8560b4777b00d7cd3b42f6b20
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8ca64424-65b9-46a5-9b5b-a06b563aef2c
+      - req-985032b9-77d5-4341-a839-f79fa02810f9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8ca64424-65b9-46a5-9b5b-a06b563aef2c
+      - req-985032b9-77d5-4341-a839-f79fa02810f9
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13236,7 +13237,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -13251,22 +13252,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c089953-7b5b-400f-b675-198abed56565
+      - req-00ce4e97-8373-41ad-bc15-c0016be84505
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3c089953-7b5b-400f-b675-198abed56565
+      - req-00ce4e97-8373-41ad-bc15-c0016be84505
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13278,7 +13279,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13293,22 +13294,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 313ddec6564a466f96ba10bb6ba583cb
+      - d1c4cdf6f930444d99d8b5e1bbf7ba51
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c20fcd14-2a3a-41d7-9d4e-ac94a736c793
+      - req-0352811a-ed3f-4c1e-98a8-ed00014de5c0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c20fcd14-2a3a-41d7-9d4e-ac94a736c793
+      - req-0352811a-ed3f-4c1e-98a8-ed00014de5c0
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13320,7 +13321,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -13335,22 +13336,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b749e4b-9c8d-491a-9f46-1430f74a8f80
+      - req-6b0ebe32-daf1-45e5-b577-56f85628111b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9b749e4b-9c8d-491a-9f46-1430f74a8f80
+      - req-6b0ebe32-daf1-45e5-b577-56f85628111b
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13362,7 +13363,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13377,22 +13378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec5739dba23f4350997ffd5fcf5d797a
+      - 48f522786c194f4d89e4f8b7acdc7389
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac316552-c679-4c41-92ce-f1a26e87b665
+      - req-6e513773-e92d-463f-87cf-08df562b2af3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ac316552-c679-4c41-92ce-f1a26e87b665
+      - req-6e513773-e92d-463f-87cf-08df562b2af3
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13404,7 +13405,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -13419,22 +13420,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-17b68c27-f365-45df-801f-eef1ffd45e8c
+      - req-54c1593f-8c68-41f1-8513-eba3bd8398de
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-17b68c27-f365-45df-801f-eef1ffd45e8c
+      - req-54c1593f-8c68-41f1-8513-eba3bd8398de
       Date:
-      - Fri, 03 Aug 2018 19:41:51 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13446,7 +13447,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13461,22 +13462,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 136d8ff37ac64842a6b0fa55ac0f0306
+      - 42c29441bce94751bfd1383bc543b7ab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-215ea7af-341c-4b3e-92bd-3b10def23bfc
+      - req-992fc9af-1345-40f5-a86a-ae97de75b2aa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-215ea7af-341c-4b3e-92bd-3b10def23bfc
+      - req-992fc9af-1345-40f5-a86a-ae97de75b2aa
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13488,7 +13489,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -13503,22 +13504,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7f5c5f7-8bda-4e21-b884-b9b22efbf4e4
+      - req-59e30d26-4d9b-4127-a444-9e4235b2e204
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d7f5c5f7-8bda-4e21-b884-b9b22efbf4e4
+      - req-59e30d26-4d9b-4127-a444-9e4235b2e204
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13530,7 +13531,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13545,22 +13546,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e973be580b7498688ff94f80b715021
+      - cb0da74022e54c56909945f366edff91
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a90772e4-e4f0-4e88-93cc-98a69b0ef7e1
+      - req-5870264e-15fb-45a9-9121-e2136c8db350
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a90772e4-e4f0-4e88-93cc-98a69b0ef7e1
+      - req-5870264e-15fb-45a9-9121-e2136c8db350
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13572,7 +13573,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13587,22 +13588,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00839639-0a07-45a6-b6d6-91301684a3e3
+      - req-4f0c8677-70cd-4e8d-97ec-433b34ceb752
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-00839639-0a07-45a6-b6d6-91301684a3e3
+      - req-4f0c8677-70cd-4e8d-97ec-433b34ceb752
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13614,7 +13615,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13629,22 +13630,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4dfc6e981a0401086abf3e2c47bd21f
+      - 978a124780744bdcb84b40efe817293d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5b4c060-5a5d-4701-9cc0-1c6467beb8f8
+      - req-088a1cc0-a01e-47f4-99b5-3ef83e45ef89
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a5b4c060-5a5d-4701-9cc0-1c6467beb8f8
+      - req-088a1cc0-a01e-47f4-99b5-3ef83e45ef89
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13656,7 +13657,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13671,22 +13672,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6e84589-76d0-4f55-acc7-3d45753c050d
+      - req-280429da-c085-4a19-a76b-996348227772
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c6e84589-76d0-4f55-acc7-3d45753c050d
+      - req-280429da-c085-4a19-a76b-996348227772
       Date:
-      - Fri, 03 Aug 2018 19:41:52 GMT
+      - Mon, 06 Aug 2018 16:52:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13698,7 +13699,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13713,22 +13714,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4362125a33ca466a962bc121235d5305
+      - 1033914dc9034f5eb1033e94c44e98ce
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-877173c9-23ca-4c3b-9b91-e07c34d6eb77
+      - req-b6b1e31b-4acc-42b6-bda5-ec74629929ae
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-877173c9-23ca-4c3b-9b91-e07c34d6eb77
+      - req-b6b1e31b-4acc-42b6-bda5-ec74629929ae
       Date:
-      - Fri, 03 Aug 2018 19:41:53 GMT
+      - Mon, 06 Aug 2018 16:52:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13740,7 +13741,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13758,15 +13759,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:53 GMT
+      - Mon, 06 Aug 2018 16:52:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7658902b520f4e498d7756371bd49b0e
+      - c3e93ae97b0540939c0e3acfceecde27
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6aece7c1-f10f-456d-9bb2-7a23b65fd196
+      - req-cfd49c81-f0a4-4c05-913c-9bb69b7da4ce
       Content-Length:
       - '7311'
       Connection:
@@ -13778,7 +13779,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:53.451145Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:24.123252Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13857,10 +13858,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KErsMJeCSf2M2Bw_ok293g"],
-        "issued_at": "2018-08-03T19:41:53.451218Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BqTdMzaUT_2R5GvnsglG7w"],
+        "issued_at": "2018-08-06T16:52:24.123330Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13878,15 +13879,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:53 GMT
+      - Mon, 06 Aug 2018 16:52:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d6d4729cca4040999ec0ca55be763644
+      - 25ac68b239ab410897568559652e6fd3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9d4ab83d-3a4a-48a1-898b-73280986611a
+      - req-ca89e27f-197d-4d53-9def-3242d1b97471
       Content-Length:
       - '7311'
       Connection:
@@ -13898,7 +13899,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-03T20:41:53.798605Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:24.485418Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13977,10 +13978,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Oq3z9mQQjisTtMXiYolrg"],
-        "issued_at": "2018-08-03T19:41:53.798670Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FbzU0fTiST2s7_NhayB9tQ"],
+        "issued_at": "2018-08-06T16:52:24.485500Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13998,15 +13999,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:53 GMT
+      - Mon, 06 Aug 2018 16:52:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 893efae058c0428e9cb38437280a25a2
+      - 9f3482e3d4b94d8aaa782b554af427ef
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-72b58a8e-5ffc-4c26-9599-4ede2e4c7c86
+      - req-0d07b18f-cc78-4f7f-ae62-31451fb3cc19
       Content-Length:
       - '297'
       Connection:
@@ -14015,12 +14016,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-03T20:41:54.037960Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:24.794505Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_mjc6DxBQouuJ3QIa0GYGA"],
-        "issued_at": "2018-08-03T19:41:54.038020Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmGrj7rwSDGJ_xoIKInf4w"],
+        "issued_at": "2018-08-06T16:52:24.794660Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -14035,20 +14036,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 893efae058c0428e9cb38437280a25a2
+      - 9f3482e3d4b94d8aaa782b554af427ef
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:54 GMT
+      - Mon, 06 Aug 2018 16:52:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a497521a-3f8c-48fb-831b-0505a6ee3d60
+      - req-d6ddf3dd-90da-4ac3-8c6d-1702d53f0a32
       Content-Length:
       - '2457'
       Connection:
@@ -14081,13 +14082,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"893efae058c0428e9cb38437280a25a2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"9f3482e3d4b94d8aaa782b554af427ef"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14099,15 +14100,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:54 GMT
+      - Mon, 06 Aug 2018 16:52:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 855822f4f35742bfa33dcd90ed1b0cf6
+      - 439076a415d7494f83ce1a691d29db03
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-426f7b26-1dcd-4ff8-8296-3178e9ff15cd
+      - req-d42dd8a2-24d8-4eb1-8b8f-2306d485ddd3
       Content-Length:
       - '7313'
       Connection:
@@ -14119,7 +14120,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:54.037960Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:24.794505Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14198,10 +14199,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pqaLCbvqT5aIUGZbDioTJA",
-        "_mjc6DxBQouuJ3QIa0GYGA"], "issued_at": "2018-08-03T19:41:54.490704Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LzpvJBk5SQCi3Hxr9xbBpw",
+        "KmGrj7rwSDGJ_xoIKInf4w"], "issued_at": "2018-08-06T16:52:25.316500Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -14216,20 +14217,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 855822f4f35742bfa33dcd90ed1b0cf6
+      - 439076a415d7494f83ce1a691d29db03
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:54 GMT
+      - Mon, 06 Aug 2018 16:52:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8062c68c-5d66-4f65-9e38-37904c30bc80
+      - req-02b1bd72-25e6-4cd5-a57b-63d59ca01f87
       Content-Length:
       - '2179'
       Connection:
@@ -14262,7 +14263,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14280,15 +14281,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:54 GMT
+      - Mon, 06 Aug 2018 16:52:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f6801aa4be5a45338a246dff4de3bfe3
+      - 4146989584574c08abcc91a11cf87dd2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3e825736-05d8-4679-81dd-f0a849fc81ed
+      - req-210b52f1-5bd1-4f18-bb89-36218534c355
       Content-Length:
       - '7278'
       Connection:
@@ -14300,7 +14301,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:55.038938Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:25.904275Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14379,10 +14380,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IJwWMoGuQLynsR4b7OGhkg"],
-        "issued_at": "2018-08-03T19:41:55.039021Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C_mFZ_gfQky8cVw4FZ2Vww"],
+        "issued_at": "2018-08-06T16:52:25.904371Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14400,15 +14401,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:55 GMT
+      - Mon, 06 Aug 2018 16:52:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 501d8c3241d243a0bb9c48be7f9094ba
+      - 5a93d1b9dfa240f1b19915b30c67601a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-12fbcc80-8694-4afe-bdc2-9df0c16ce47a
+      - req-64e073aa-ec24-49e2-a7bb-70cb8f5da151
       Content-Length:
       - '7278'
       Connection:
@@ -14420,7 +14421,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:55.427614Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:26.389477Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14499,10 +14500,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m0v_tHqcRcyXHK1RKzX1xA"],
-        "issued_at": "2018-08-03T19:41:55.427680Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UiKM2NDBSDS1M83lglYDSg"],
+        "issued_at": "2018-08-06T16:52:26.389573Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14520,15 +14521,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:55 GMT
+      - Mon, 06 Aug 2018 16:52:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3a797876b9f94cfa9928497cc4f55c0a
+      - c4fd9442c78649998ecd08e39c1a511b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d19c72bd-3da0-4f1c-83c4-638b132f80ec
+      - req-2bc1ed55-48dc-465e-8693-09cfb6eb86d9
       Content-Length:
       - '7264'
       Connection:
@@ -14540,7 +14541,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:55.757260Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:26.901756Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14619,10 +14620,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7cwIQzPYRgaO0KxL6b3rBg"],
-        "issued_at": "2018-08-03T19:41:55.757329Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3A8GdwkwQUGdUGfriAhcpw"],
+        "issued_at": "2018-08-06T16:52:26.901840Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14640,15 +14641,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:55 GMT
+      - Mon, 06 Aug 2018 16:52:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5abfc4e183e8490b8eae3728a9deea96
+      - 1c1ac1da945c4fd79dd5002ff986e71c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d720e175-2e27-4162-a2e7-f7aedb02423e
+      - req-34655849-239b-48e2-bdad-772ce5da6bf2
       Content-Length:
       - '7278'
       Connection:
@@ -14660,7 +14661,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:56.214782Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:27.282256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14739,10 +14740,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ai6EyaJ4TOW7Xw7GhhrLdQ"],
-        "issued_at": "2018-08-03T19:41:56.214866Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gZ8ysRZJQMC0wmFazYV-jg"],
+        "issued_at": "2018-08-06T16:52:27.282309Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14760,15 +14761,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:56 GMT
+      - Mon, 06 Aug 2018 16:52:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e8a499902b3b4a5f9699014029711a33
+      - 82189fc28666405080748f1d907c28f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cd2fcb1f-7ee9-4b18-adcb-594405560588
+      - req-1e7b73a8-90e7-4d46-b7b6-aa8200f8aa78
       Content-Length:
       - '7265'
       Connection:
@@ -14780,7 +14781,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:56.580661Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:27.612981Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14859,10 +14860,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q_AbLfT9RyeqojQ5FWk-ug"],
-        "issued_at": "2018-08-03T19:41:56.580763Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZaVum7qxQmKX72e6CCfGRQ"],
+        "issued_at": "2018-08-06T16:52:27.613047Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14880,15 +14881,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:56 GMT
+      - Mon, 06 Aug 2018 16:52:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a36fa82359f944ab92df944f864b6559
+      - b9d0b822192b4b3eb4dd4a1887c2cf1b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-14148393-1c70-4ec3-a445-cda372bd2788
+      - req-e96b9d36-d706-400d-ab85-6adbcdfacabc
       Content-Length:
       - '7278'
       Connection:
@@ -14900,7 +14901,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:56.922810Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:27.978258Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14979,10 +14980,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ugn8Rb6URHOV5p8sDPUnUQ"],
-        "issued_at": "2018-08-03T19:41:56.922892Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MLfwjhZuR963PQR_RHxPgg"],
+        "issued_at": "2018-08-06T16:52:27.978324Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15000,15 +15001,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:57 GMT
+      - Mon, 06 Aug 2018 16:52:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5e828fa213eb40d6aef06761782cf7bf
+      - d3869643e261478b8298cdcaa4712714
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-356f53a7-5786-4961-a7f3-6ae04afa9d85
+      - req-329b8ce1-5b3a-45db-8408-7ceac85e286e
       Content-Length:
       - '7278'
       Connection:
@@ -15020,7 +15021,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:57.289743Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:28.366299Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15099,10 +15100,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R1UK0A-SSJS44hfpnmWt1g"],
-        "issued_at": "2018-08-03T19:41:57.289813Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hXAH4G42Sw6e9YM2VEfZCg"],
+        "issued_at": "2018-08-06T16:52:28.366381Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -15117,7 +15118,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e828fa213eb40d6aef06761782cf7bf
+      - d3869643e261478b8298cdcaa4712714
   response:
     status:
       code: 200
@@ -15130,22 +15131,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325317.48529'
+      - '1533574348.96323'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325317.48529'
+      - '1533574348.96323'
       X-Trans-Id:
-      - tx86c114e395a94b30aa733-005b64b005
+      - txe81c51d7c024453fbf86e-005b687ccc
       Date:
-      - Fri, 03 Aug 2018 19:41:57 GMT
+      - Mon, 06 Aug 2018 16:52:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15163,15 +15164,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:57 GMT
+      - Mon, 06 Aug 2018 16:52:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2e2f2d0a5c594aedb388d507f998eb0c
+      - 55f549d41b74473a97aa4f888a854492
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c27cbd2-87f1-49b1-ba6f-12721793efda
+      - req-9e2e21fa-35ef-4e32-8c4c-fbafa7784597
       Content-Length:
       - '7278'
       Connection:
@@ -15183,7 +15184,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:57.789557Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:29.202965Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15262,10 +15263,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FecsI1RcRCKB50d97Fwcuw"],
-        "issued_at": "2018-08-03T19:41:57.789632Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jU2kZJfFQJyMLH5HbxvXLg"],
+        "issued_at": "2018-08-06T16:52:29.202998Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -15280,7 +15281,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e2f2d0a5c594aedb388d507f998eb0c
+      - 55f549d41b74473a97aa4f888a854492
   response:
     status:
       code: 200
@@ -15293,22 +15294,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325317.98535'
+      - '1533574349.35920'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325317.98535'
+      - '1533574349.35920'
       X-Trans-Id:
-      - txd860612110f846e2b81fc-005b64b005
+      - txbc32ba3d66a04d33bd95a-005b687ccd
       Date:
-      - Fri, 03 Aug 2018 19:41:57 GMT
+      - Mon, 06 Aug 2018 16:52:29 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15326,15 +15327,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:58 GMT
+      - Mon, 06 Aug 2018 16:52:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b5b725f4-bc81-4a03-9ada-5197ebfbdd79
+      - req-4eeab5b2-869a-4ada-b834-633d55ae2e7a
       Content-Length:
       - '7264'
       Connection:
@@ -15346,7 +15347,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:58.297062Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:29.679645Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15425,10 +15426,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["maxXvoVGREGIJeQBJFuk-g"],
-        "issued_at": "2018-08-03T19:41:58.297161Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rruV4CN-SKSkDZvzFGRxxw"],
+        "issued_at": "2018-08-06T16:52:29.679712Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -15443,7 +15444,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
   response:
     status:
       code: 200
@@ -15472,15 +15473,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx6bd9231a10994192be78f-005b64b006
+      - tx5fbf10835d5b4217b7598-005b687ccd
       Date:
-      - Fri, 03 Aug 2018 19:41:58 GMT
+      - Mon, 06 Aug 2018 16:52:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -15495,7 +15496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
   response:
     status:
       code: 200
@@ -15524,14 +15525,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx8ce459f4053c41f18acc6-005b64b006
+      - tx34c69dda6c4e4dbcb3edf-005b687ccd
       Date:
-      - Fri, 03 Aug 2018 19:41:58 GMT
+      - Mon, 06 Aug 2018 16:52:29 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15549,15 +15550,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:58 GMT
+      - Mon, 06 Aug 2018 16:52:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3204f9620f7944f2902e77cb1dd656a3
+      - 2b6f7186ccc4417e87629b0f52801674
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-82330886-1382-428a-a412-7c7d745378e8
+      - req-7a5142d6-67c6-4053-983b-fc89b7de6abc
       Content-Length:
       - '7278'
       Connection:
@@ -15569,7 +15570,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:58.917950Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:30.311713Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15648,10 +15649,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lmjZd4I5RoKvY5XOMBYccQ"],
-        "issued_at": "2018-08-03T19:41:58.918029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZMX5kPryToKwnfzVU6SpcA"],
+        "issued_at": "2018-08-06T16:52:30.311782Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -15666,7 +15667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3204f9620f7944f2902e77cb1dd656a3
+      - 2b6f7186ccc4417e87629b0f52801674
   response:
     status:
       code: 200
@@ -15679,22 +15680,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325319.15425'
+      - '1533574350.80327'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325319.15425'
+      - '1533574350.80327'
       X-Trans-Id:
-      - txfdebe7e6e0a04dc7b4e0e-005b64b007
+      - tx1d6db1a8ec9c420a8ef00-005b687cce
       Date:
-      - Fri, 03 Aug 2018 19:41:59 GMT
+      - Mon, 06 Aug 2018 16:52:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -15709,7 +15710,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6d4729cca4040999ec0ca55be763644
+      - 25ac68b239ab410897568559652e6fd3
   response:
     status:
       code: 200
@@ -15722,22 +15723,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325319.37357'
+      - '1533574350.97355'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325319.37357'
+      - '1533574350.97355'
       X-Trans-Id:
-      - txabcf0f52df024c088f6e4-005b64b007
+      - txef94f7c5ec944daf8c9d8-005b687cce
       Date:
-      - Fri, 03 Aug 2018 19:41:59 GMT
+      - Mon, 06 Aug 2018 16:52:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15755,15 +15756,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:41:59 GMT
+      - Mon, 06 Aug 2018 16:52:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b8f0d55ff1e547f085face7fc28251aa
+      - 3ce7358b1beb47bc919ff2456362f682
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-734ad985-5577-4680-a5ca-cbeaaa8a8f31
+      - req-02d493e9-8609-4592-9ba8-a46b2854560f
       Content-Length:
       - '7265'
       Connection:
@@ -15775,7 +15776,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:41:59.693326Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:31.260465Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15854,10 +15855,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FnHrHUbxQiOUScEeB2T4sw"],
-        "issued_at": "2018-08-03T19:41:59.693388Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3QluEPG0Rp2Exl06kiWn3A"],
+        "issued_at": "2018-08-06T16:52:31.260528Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -15872,7 +15873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f0d55ff1e547f085face7fc28251aa
+      - 3ce7358b1beb47bc919ff2456362f682
   response:
     status:
       code: 200
@@ -15885,22 +15886,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325319.89821'
+      - '1533574351.45556'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325319.89821'
+      - '1533574351.45556'
       X-Trans-Id:
-      - txfa8073d2071b4d77ba3c6-005b64b007
+      - txec901d86dc3146d887b6e-005b687ccf
       Date:
-      - Fri, 03 Aug 2018 19:41:59 GMT
+      - Mon, 06 Aug 2018 16:52:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:41:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15918,15 +15919,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:42:00 GMT
+      - Mon, 06 Aug 2018 16:52:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dcbd134330204e16bce563cf535c57cf
+      - 6dd35e9b739e4c3bab52905c19b8a1bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-117ca76d-395f-4a32-93a4-a2f24783b46c
+      - req-2a8053c0-bb81-48f2-8806-1265bc624be4
       Content-Length:
       - '7278'
       Connection:
@@ -15938,7 +15939,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-03T20:42:00.207076Z", "project": {"domain": {"id":
+        "expires_at": "2018-08-06T17:52:31.792310Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16017,10 +16018,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y3ztwb3BT0O4pbCwfk2f9g"],
-        "issued_at": "2018-08-03T19:42:00.207188Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2YM2-oxuRcmZX77MVvNFxQ"],
+        "issued_at": "2018-08-06T16:52:31.792380Z"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -16035,7 +16036,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dcbd134330204e16bce563cf535c57cf
+      - 6dd35e9b739e4c3bab52905c19b8a1bd
   response:
     status:
       code: 200
@@ -16048,22 +16049,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325320.41462'
+      - '1533574352.01231'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325320.41462'
+      - '1533574352.01231'
       X-Trans-Id:
-      - txcdc3c6a51d824e73bf792-005b64b008
+      - txe5ff98c329704168a207b-005b687ccf
       Date:
-      - Fri, 03 Aug 2018 19:42:00 GMT
+      - Mon, 06 Aug 2018 16:52:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -16078,7 +16079,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
   response:
     status:
       code: 200
@@ -16099,9 +16100,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txfdb93fbac6e84903b48f3-005b64b008
+      - txc8f6a21e6acd42d3a17fe-005b687cd0
       Date:
-      - Fri, 03 Aug 2018 19:42:00 GMT
+      - Mon, 06 Aug 2018 16:52:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -16111,7 +16112,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -16126,7 +16127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
   response:
     status:
       code: 200
@@ -16147,14 +16148,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx44aff0fb9ee8480d9b805-005b64b008
+      - tx7b9d094560b94f0f90020-005b687cd0
       Date:
-      - Fri, 03 Aug 2018 19:42:00 GMT
+      - Mon, 06 Aug 2018 16:52:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -16169,7 +16170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8497f1c1a55548d9ae3b47300f805b35
+      - cc357a5fcf334fcf90081ac35b384131
   response:
     status:
       code: 200
@@ -16190,12 +16191,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7da19e246cce4141bb970-005b64b008
+      - txdfa47248dd58437a9f8c4-005b687cd0
       Date:
-      - Fri, 03 Aug 2018 19:42:00 GMT
+      - Mon, 06 Aug 2018 16:52:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:42:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:34 GMT
+      - Mon, 06 Aug 2018 16:56:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-baf4d708-382b-455f-a476-6ae1b2fc7c26
+      - req-574e8dff-6246-46ce-9597-87b327babf79
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:34.441966", "expires":
-        "2018-08-03T20:34:34Z", "id": "a5cfb268534b430dab6b4553bc214a77", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:14.221904", "expires":
+        "2018-08-06T17:56:14Z", "id": "0a1c251a0a53413d860cc9c5dad0829c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1RpqbMmWR1KjihfOy3Dk6w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wrJYdAM0RuGVAMDQkG-lUg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:34:34 GMT
+      - Mon, 06 Aug 2018 16:56:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:34 GMT
+      - Mon, 06 Aug 2018 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d24f1618-2ce0-4afd-b005-b29986eabc4f
+      - req-f18ae6e9-1aa6-4358-808a-6c8d67791d97
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:34.797968", "expires":
-        "2018-08-03T20:34:34Z", "id": "1a9d991bb9c142f2b6f771a88de95134", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:14.608558", "expires":
+        "2018-08-06T17:56:14Z", "id": "3862a3a06e9047739c1cf95f9679d56b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["raoZWqIgSVKnJufoM4Qh8g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EtSFsSEBSnWCWpNIZ1re0A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a9d991bb9c142f2b6f771a88de95134
+      - 3862a3a06e9047739c1cf95f9679d56b
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:34:34 GMT
+      - Mon, 06 Aug 2018 16:56:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:34 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:35 GMT
+      - Mon, 06 Aug 2018 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2acb4796-0cde-4e74-8cca-4f97f0f404c1
+      - req-47a7fcf6-3637-40fc-8bcb-f20ee128c0d1
       Content-Length:
       - '4170'
       Connection:
@@ -261,10 +261,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:35.205198", "expires":
-        "2018-08-03T20:34:35Z", "id": "a7b12b8ed59b4e648d7d7b28bf6bd350", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.178644", "expires":
+        "2018-08-06T17:56:15Z", "id": "c4aff8dc8ab747b78d59efc1939932c8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CK7UxJzuRhKYgvsa4ppMeg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Pbs7uwuUT3KuOVHoECrU8w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -309,13 +309,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"a7b12b8ed59b4e648d7d7b28bf6bd350"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"c4aff8dc8ab747b78d59efc1939932c8"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -327,13 +327,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:35 GMT
+      - Mon, 06 Aug 2018 16:56:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3ad53651-ed67-4d02-aa23-ce5063872b93
+      - req-6d6f20df-ea61-4f19-901c-491fcc83d7b1
       Content-Length:
       - '4196'
       Connection:
@@ -342,10 +342,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:35.535978", "expires":
-        "2018-08-03T20:34:35Z", "id": "d06febf4df9d4c7da0068cfeb6faca7a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.458543", "expires":
+        "2018-08-06T17:56:15Z", "id": "ca75336b6a60407bbb6e84831eb5f0fa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4azWfBSaSGKepGGwJy8wXw", "CK7UxJzuRhKYgvsa4ppMeg"]},
+        "name": "admin"}, "audit_ids": ["Xu3qDGEFTbC3isSvn3XKOA", "Pbs7uwuUT3KuOVHoECrU8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -390,7 +390,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -408,13 +408,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:35 GMT
+      - Mon, 06 Aug 2018 16:56:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-be67427f-d561-4447-8c1a-90d8cd9c43f4
+      - req-40518fac-75ce-4893-a772-ed514bb08f2d
       Content-Length:
       - '4170'
       Connection:
@@ -423,10 +423,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:35.864127", "expires":
-        "2018-08-03T20:34:35Z", "id": "3ab26690b02f401e90651b1a2c640ecf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.716568", "expires":
+        "2018-08-06T17:56:15Z", "id": "c54b89e03477463abe9a6a86d7c2931f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["FxSR4BeqTteJp11DLLQy6Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zOqNN1N2TxuSm8MIQIwtKA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -471,7 +471,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -486,7 +486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 300
@@ -497,7 +497,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:34:35 GMT
+      - Mon, 06 Aug 2018 16:56:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -510,7 +510,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:35 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:36 GMT
+      - Mon, 06 Aug 2018 16:56:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69fe2aaa-3368-49dd-b9ed-e189088ac3d3
+      - req-63d07123-687b-48e7-8755-00a0223a0de4
       Content-Length:
       - '4170'
       Connection:
@@ -543,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:36.267983", "expires":
-        "2018-08-03T20:34:36Z", "id": "3b49cbc7a9ec4a31be018959fd9ae48d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.066697", "expires":
+        "2018-08-06T17:56:16Z", "id": "5b88b8db6550473b983d820ddfa10fe2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Y_HpR0_jQOePcI0W2WP4vQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2MHkPVA_S4GY0KE9nD0Qrw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -591,7 +591,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -609,13 +609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:36 GMT
+      - Mon, 06 Aug 2018 16:56:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d13f4142-0b71-4c45-95af-a2d3136b0d0d
+      - req-02c66512-4048-47f6-a7da-ad0562342ae7
       Content-Length:
       - '4170'
       Connection:
@@ -624,10 +624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:36.588493", "expires":
-        "2018-08-03T20:34:36Z", "id": "8f6e95a0a5ba489498e42c304caa2e45", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.352435", "expires":
+        "2018-08-06T17:56:16Z", "id": "4db9e3de52b64fe6b9f75231e3c18989", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pBENSJc7SYaQLw9g98Z8mg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TBLLtuLVQzWab_d3ZYeQNg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -672,7 +672,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:36 GMT
+      - Mon, 06 Aug 2018 16:56:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76528945-c34a-43e7-995b-a5dcba854921
+      - req-29702310-45d2-4779-a859-8ccb9b64200c
       Content-Length:
       - '4170'
       Connection:
@@ -705,10 +705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:36.929435", "expires":
-        "2018-08-03T20:34:36Z", "id": "65e635bb6e564833b1be62a828f7c274", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.758306", "expires":
+        "2018-08-06T17:56:16Z", "id": "6efb20d8e15a42a9afa2416469cf6a2f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["p6YBqHkjQpiv56xXaWT1wA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rap5m-aVRMOpsu4v9PZvDA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -753,7 +753,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:36 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -771,13 +771,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:37 GMT
+      - Mon, 06 Aug 2018 16:56:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-499f6714-f0bd-4d9a-aaff-13b84f75dc06
+      - req-b5d87fa3-108f-4991-b931-8c8766b28301
       Content-Length:
       - '4170'
       Connection:
@@ -786,10 +786,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:37.286900", "expires":
-        "2018-08-03T20:34:37Z", "id": "98025da14d644f5ba4f8f342730a12b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.107166", "expires":
+        "2018-08-06T17:56:17Z", "id": "205ecc32b3af4bcc81803ca4c4f52a76", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Ujueq8hPQbiXzrkh_LfPOw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wEPLiSEtS7GixARNESZugA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -834,7 +834,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -852,13 +852,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:37 GMT
+      - Mon, 06 Aug 2018 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ff99d42-2891-48ca-9f6c-2f18e3d720ff
+      - req-c8f079bb-9087-4d62-8359-ee9e44a69280
       Content-Length:
       - '370'
       Connection:
@@ -867,13 +867,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:37.508689", "expires":
-        "2018-08-03T20:34:37Z", "id": "1f6fa8c2791e4e0b90493a1365995c83", "audit_ids":
-        ["LZGv6Z0GS6uL4PaEkRdBmQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.302499", "expires":
+        "2018-08-06T17:56:17Z", "id": "50ccf52529f44392aa9d0aa0dbe6618f", "audit_ids":
+        ["k47DKPNDRTCPrxSQuFVmiA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -888,20 +888,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1f6fa8c2791e4e0b90493a1365995c83
+      - 50ccf52529f44392aa9d0aa0dbe6618f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:37 GMT
+      - Mon, 06 Aug 2018 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-62ffe045-d027-49bc-b34d-446534128214
+      - req-7c196760-f557-4b0a-b9a9-67d53eab9432
       Content-Length:
       - '500'
       Connection:
@@ -918,13 +918,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:37 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1f6fa8c2791e4e0b90493a1365995c83"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"50ccf52529f44392aa9d0aa0dbe6618f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -936,13 +936,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:37 GMT
+      - Mon, 06 Aug 2018 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06f13a94-95a5-4297-9813-ea4d04a3221c
+      - req-e788d5da-ddc4-4537-b129-e53da2f2e023
       Content-Length:
       - '4143'
       Connection:
@@ -951,11 +951,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:37.998514", "expires":
-        "2018-08-03T20:34:37Z", "id": "0b4186b2fd614d1db206392f4d42d774", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.715285", "expires":
+        "2018-08-06T17:56:17Z", "id": "7c713406d636412593ed99b535664778", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SYVRTkb5SLavmzJi_x0UaA",
-        "LZGv6Z0GS6uL4PaEkRdBmQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["NDm2ZrUdQFyb5dytgl9j-A",
+        "k47DKPNDRTCPrxSQuFVmiA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -999,7 +999,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1014,20 +1014,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1f6fa8c2791e4e0b90493a1365995c83
+      - 50ccf52529f44392aa9d0aa0dbe6618f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:38 GMT
+      - Mon, 06 Aug 2018 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fd963449-8b6f-4965-9949-48383b81f8d7
+      - req-20ec89df-8a3d-4533-b59a-4f6a93501351
       Content-Length:
       - '500'
       Connection:
@@ -1044,7 +1044,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1062,13 +1062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:38 GMT
+      - Mon, 06 Aug 2018 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e61eab7e-eae7-4d26-84c3-9e226a498e6f
+      - req-58f3b92d-4999-4db5-905f-b188b2b34e61
       Content-Length:
       - '4117'
       Connection:
@@ -1077,10 +1077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:38.519315", "expires":
-        "2018-08-03T20:34:38Z", "id": "48536afe2e234c3a9261bcb3bdd16cca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.155722", "expires":
+        "2018-08-06T17:56:18Z", "id": "881a1cf149d840a1ae7b08cac9ebb411", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dT4-xHyNT1uLBj-yfk6C3Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fiEBHIZwTDmPFVWNFq6nmw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1124,7 +1124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1139,7 +1139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48536afe2e234c3a9261bcb3bdd16cca
+      - 881a1cf149d840a1ae7b08cac9ebb411
   response:
     status:
       code: 200
@@ -1150,7 +1150,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:34:38 GMT
+      - Mon, 06 Aug 2018 16:56:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1159,7 +1159,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1177,13 +1177,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:38 GMT
+      - Mon, 06 Aug 2018 16:56:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91c33819-f158-464e-ab47-a3be3fb64a0d
+      - req-de7a2d5c-c755-4c44-8913-266d2885fb2b
       Content-Length:
       - '4131'
       Connection:
@@ -1192,10 +1192,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:38.949858", "expires":
-        "2018-08-03T20:34:38Z", "id": "5a4b613594084254809c85204593173a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.505734", "expires":
+        "2018-08-06T17:56:18Z", "id": "1145d419d34e4a81821bbc0e14581dba", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["YFz1_4bySnOkUxhC7PS08Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["T8a2afxESvuP-iJ0d19oRw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1239,7 +1239,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:38 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1254,7 +1254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a4b613594084254809c85204593173a
+      - 1145d419d34e4a81821bbc0e14581dba
   response:
     status:
       code: 200
@@ -1265,7 +1265,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:34:39 GMT
+      - Mon, 06 Aug 2018 16:56:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1274,7 +1274,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1292,13 +1292,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:39 GMT
+      - Mon, 06 Aug 2018 16:56:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-202f5a84-098a-4edf-accc-7df6b319f026
+      - req-3a3bab12-f007-4877-9430-37a6acb287b5
       Content-Length:
       - '4118'
       Connection:
@@ -1307,10 +1307,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:39.437445", "expires":
-        "2018-08-03T20:34:39Z", "id": "5641c191275a49fdb77887b7e83ff3f1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.881163", "expires":
+        "2018-08-06T17:56:18Z", "id": "3702476a21494fc48a21e6378c0a9856", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xBY-LtUnRvmjvkMzyeMo1g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["79aztpQCSj-fXPD5PAQlAg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1354,7 +1354,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1369,7 +1369,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5641c191275a49fdb77887b7e83ff3f1
+      - 3702476a21494fc48a21e6378c0a9856
   response:
     status:
       code: 200
@@ -1380,7 +1380,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:34:39 GMT
+      - Mon, 06 Aug 2018 16:56:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1389,7 +1389,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:39 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1404,7 +1404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1417,9 +1417,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-e6985b43-e74e-4eda-8fa3-c05b54f7e0c4
+      - req-2f901f4e-1541-46a4-be93-949eaa633f2d
       Date:
-      - Fri, 03 Aug 2018 19:34:40 GMT
+      - Mon, 06 Aug 2018 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1433,7 +1433,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1448,7 +1448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1461,9 +1461,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-48787ab8-b47d-4188-b6e7-0b8720d80574
+      - req-a814a803-a443-476d-8536-c5d625db9fbf
       Date:
-      - Fri, 03 Aug 2018 19:34:40 GMT
+      - Mon, 06 Aug 2018 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1477,7 +1477,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1492,7 +1492,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1505,9 +1505,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-9b697e5b-9277-4515-b30b-0c048dc909e3
+      - req-b987e4fa-0dde-4c1f-aead-d418a3c340ea
       Date:
-      - Fri, 03 Aug 2018 19:34:40 GMT
+      - Mon, 06 Aug 2018 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1522,7 +1522,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1537,7 +1537,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1550,9 +1550,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-733552b6-4eb5-4484-923c-cd0b116334e7
+      - req-221feb4d-ebfa-408c-872e-dc45299c6803
       Date:
-      - Fri, 03 Aug 2018 19:34:40 GMT
+      - Mon, 06 Aug 2018 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1562,7 +1562,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1577,7 +1577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1590,15 +1590,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-f9fa7aa6-bfe9-4969-8053-6522e11a4ce4
+      - req-b57e365e-b78c-407d-a374-93768c91f63c
       Date:
-      - Fri, 03 Aug 2018 19:34:41 GMT
+      - Mon, 06 Aug 2018 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -1613,7 +1613,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1626,15 +1626,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-b256eba8-87fd-4035-a0ba-658d81669afa
+      - req-f7867229-8588-473f-96e7-20d2f60c8d79
       Date:
-      - Fri, 03 Aug 2018 19:34:41 GMT
+      - Mon, 06 Aug 2018 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1649,28 +1649,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b49cbc7a9ec4a31be018959fd9ae48d
+      - 5b88b8db6550473b983d820ddfa10fe2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-711a3208-345d-4468-988a-e1974c861af7
+      - req-392d519d-f883-421a-9b57-57b9d5c93e5f
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-711a3208-345d-4468-988a-e1974c861af7
+      - req-392d519d-f883-421a-9b57-57b9d5c93e5f
       Date:
-      - Fri, 03 Aug 2018 19:34:41 GMT
+      - Mon, 06 Aug 2018 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1685,7 +1685,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1698,14 +1698,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-387d294b-a5b9-4af4-8901-7df09fb91e55
+      - req-900559fb-4bdb-4124-af42-093441bf08ce
       Date:
-      - Fri, 03 Aug 2018 19:34:41 GMT
+      - Mon, 06 Aug 2018 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1720,7 +1720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48536afe2e234c3a9261bcb3bdd16cca
+      - 881a1cf149d840a1ae7b08cac9ebb411
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1733,9 +1733,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f2ba97fb-db9a-44c0-87ec-6d1a3fb9c392
+      - req-a6f1d15b-cc6b-460e-ba4e-ce66c66b476e
       Date:
-      - Fri, 03 Aug 2018 19:34:42 GMT
+      - Mon, 06 Aug 2018 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1744,7 +1744,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1759,7 +1759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a4b613594084254809c85204593173a
+      - 1145d419d34e4a81821bbc0e14581dba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1772,9 +1772,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-954601ae-2a7c-49ce-b7f0-c084c3fd84a3
+      - req-f179412e-9587-480e-b1ce-fb1ee991ef1b
       Date:
-      - Fri, 03 Aug 2018 19:34:42 GMT
+      - Mon, 06 Aug 2018 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1783,7 +1783,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1798,7 +1798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1811,9 +1811,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-01cdc297-b59b-4c36-a520-22f08c3f8565
+      - req-7a8df9f0-e743-4632-a445-59b48ded306e
       Date:
-      - Fri, 03 Aug 2018 19:34:42 GMT
+      - Mon, 06 Aug 2018 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1822,7 +1822,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1837,7 +1837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5641c191275a49fdb77887b7e83ff3f1
+      - 3702476a21494fc48a21e6378c0a9856
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1850,9 +1850,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-e4ddad02-88fb-4cfd-b913-2b63d7f5efc7
+      - req-964061b9-e000-4f07-8d91-deb4fe8f46c3
       Date:
-      - Fri, 03 Aug 2018 19:34:43 GMT
+      - Mon, 06 Aug 2018 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1861,7 +1861,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1879,13 +1879,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:43 GMT
+      - Mon, 06 Aug 2018 16:56:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b3acd52e-1bd5-4041-b05a-33c3db0f63fa
+      - req-fe56bc4b-b119-494a-8726-44a8e1ff1d6e
       Content-Length:
       - '4117'
       Connection:
@@ -1894,10 +1894,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:43.333678", "expires":
-        "2018-08-03T20:34:43Z", "id": "0f226f89218146b093751620a4abe6e8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:22.654971", "expires":
+        "2018-08-06T17:56:22Z", "id": "6e5d42e1e0244ca8898fc13a04d8d0ae", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zjRqQkYiSjGuwvHMC04juQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9FjhQYBZRAyhSob1Ld9EMw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1941,7 +1941,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1956,22 +1956,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f226f89218146b093751620a4abe6e8
+      - 6e5d42e1e0244ca8898fc13a04d8d0ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c3f4e43-78e5-46d7-bdcd-ea74a74a6479
+      - req-818ff1c5-71d1-48cd-9ff9-43eb594d01c0
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7c3f4e43-78e5-46d7-bdcd-ea74a74a6479
+      - req-818ff1c5-71d1-48cd-9ff9-43eb594d01c0
       Date:
-      - Fri, 03 Aug 2018 19:34:44 GMT
+      - Mon, 06 Aug 2018 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1981,7 +1981,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1999,13 +1999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:44 GMT
+      - Mon, 06 Aug 2018 16:56:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-61477927-2dbf-4aeb-9501-9fb8af720006
+      - req-cc5b3b42-03d1-4a5f-af1e-98dd37b36cf7
       Content-Length:
       - '4131'
       Connection:
@@ -2014,10 +2014,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:44.475938", "expires":
-        "2018-08-03T20:34:44Z", "id": "5efcb7428cf8486284cf6c71a90e247d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:23.972216", "expires":
+        "2018-08-06T17:56:23Z", "id": "2ef6d42a81de4eda86c3f0788cccac3e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gnjmwCRuSymE6yY3PCmFYQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LA3iHMW4QZKQJtDRPaWF8A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2061,7 +2061,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2076,22 +2076,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5efcb7428cf8486284cf6c71a90e247d
+      - 2ef6d42a81de4eda86c3f0788cccac3e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4427a303-a49a-49e6-8958-1b7c6482131a
+      - req-a0bcd97d-17f3-4226-bb38-3b9dbc5c82a1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4427a303-a49a-49e6-8958-1b7c6482131a
+      - req-a0bcd97d-17f3-4226-bb38-3b9dbc5c82a1
       Date:
-      - Fri, 03 Aug 2018 19:34:45 GMT
+      - Mon, 06 Aug 2018 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2101,7 +2101,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2116,22 +2116,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b49cbc7a9ec4a31be018959fd9ae48d
+      - 5b88b8db6550473b983d820ddfa10fe2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1a5bfce-ee0f-4b1e-9b4e-5c62150cd38f
+      - req-b379f742-8b78-42cc-93c2-1627919a9575
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e1a5bfce-ee0f-4b1e-9b4e-5c62150cd38f
+      - req-b379f742-8b78-42cc-93c2-1627919a9575
       Date:
-      - Fri, 03 Aug 2018 19:34:46 GMT
+      - Mon, 06 Aug 2018 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2141,7 +2141,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2159,13 +2159,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:46 GMT
+      - Mon, 06 Aug 2018 16:56:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d6f4e86-e41a-4683-b499-90dca6b3187e
+      - req-29d80e03-ef0b-4446-9fa6-07e36ddd7f00
       Content-Length:
       - '4118'
       Connection:
@@ -2174,10 +2174,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:46.454471", "expires":
-        "2018-08-03T20:34:46Z", "id": "acaa378554c14f3e96b159c3c2a8c0fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:25.385736", "expires":
+        "2018-08-06T17:56:25Z", "id": "ef629047ae834d218a3877ef380e67d0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4MwodrOfQ9iTI43fp72QNA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0RiE_jzETpmtH23-gxlOLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2221,7 +2221,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2236,22 +2236,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - acaa378554c14f3e96b159c3c2a8c0fc
+      - ef629047ae834d218a3877ef380e67d0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-767d831b-5568-4803-aba4-e0a5a4a309f5
+      - req-ffce3195-1037-4ea1-8e53-f21b3cbded90
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-767d831b-5568-4803-aba4-e0a5a4a309f5
+      - req-ffce3195-1037-4ea1-8e53-f21b3cbded90
       Date:
-      - Fri, 03 Aug 2018 19:34:47 GMT
+      - Mon, 06 Aug 2018 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2261,7 +2261,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2279,13 +2279,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:47 GMT
+      - Mon, 06 Aug 2018 16:56:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d203b886-ceec-467b-994d-c171fad52728
+      - req-a2b7236b-e704-48b9-b578-36c8d6b10b4b
       Content-Length:
       - '4117'
       Connection:
@@ -2294,10 +2294,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:47.516771", "expires":
-        "2018-08-03T20:34:47Z", "id": "bcad217db22b41ec8ee43b5a328e7138", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:26.034194", "expires":
+        "2018-08-06T17:56:26Z", "id": "1e2cb570c56f4116b4da740a2aa589e2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JxgW7rmuQauQ0UL2GL7hOA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tRDLwEjrTyOOvdJqVf932g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2341,7 +2341,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcad217db22b41ec8ee43b5a328e7138
+      - 1e2cb570c56f4116b4da740a2aa589e2
   response:
     status:
       code: 200
@@ -2367,16 +2367,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-575f09d1-51aa-44dc-8b45-f22d5f2ccf13
+      - req-790be193-93b0-4b7f-bab3-2909c1f277dc
       Date:
-      - Fri, 03 Aug 2018 19:34:47 GMT
+      - Mon, 06 Aug 2018 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2394,13 +2394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:47 GMT
+      - Mon, 06 Aug 2018 16:56:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e920e223-b1c1-4437-9a4b-f9d8619d950a
+      - req-af104d62-aff9-4274-bebc-aa792784466a
       Content-Length:
       - '4131'
       Connection:
@@ -2409,10 +2409,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:48.161629", "expires":
-        "2018-08-03T20:34:48Z", "id": "d4e1dd9a876844d68419d9609546d315", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:26.466517", "expires":
+        "2018-08-06T17:56:26Z", "id": "e8cbefb71e204c3a8ac73a2961d69584", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fYGqfNDAR2O9b2HDdRJOpg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["p6uo2xYMRrK3hEYGhOz2xw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2456,7 +2456,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2471,7 +2471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4e1dd9a876844d68419d9609546d315
+      - e8cbefb71e204c3a8ac73a2961d69584
   response:
     status:
       code: 200
@@ -2482,16 +2482,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9a80a83f-7b84-40ed-bbbc-97a073c7f5d3
+      - req-f16d2c13-807d-4e78-8a0a-8c947038c052
       Date:
-      - Fri, 03 Aug 2018 19:34:48 GMT
+      - Mon, 06 Aug 2018 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2506,7 +2506,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a9d991bb9c142f2b6f771a88de95134
+      - 3862a3a06e9047739c1cf95f9679d56b
   response:
     status:
       code: 200
@@ -2517,16 +2517,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-aceb9936-28e4-456e-b24b-14fa08c4182b
+      - req-a73f7bef-194d-45d3-83e8-9f50902297c3
       Date:
-      - Fri, 03 Aug 2018 19:34:48 GMT
+      - Mon, 06 Aug 2018 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2544,13 +2544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:48 GMT
+      - Mon, 06 Aug 2018 16:56:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-651587ec-3a7f-4d92-928b-855e310f643c
+      - req-917fc6cb-6a36-4dcd-bd15-1ed260a3a3e4
       Content-Length:
       - '4118'
       Connection:
@@ -2559,10 +2559,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:49.105844", "expires":
-        "2018-08-03T20:34:49Z", "id": "dc089fbe231242f98e6352c19cc72623", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:27.192292", "expires":
+        "2018-08-06T17:56:27Z", "id": "ba09d12a155c46e59314ab4c239c8db2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jdR_oEwVTPy9vbhxyVPxdw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1TGmcJdHREC7zF3II-XjRQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2606,7 +2606,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc089fbe231242f98e6352c19cc72623
+      - ba09d12a155c46e59314ab4c239c8db2
   response:
     status:
       code: 200
@@ -2632,16 +2632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-505ad918-47c9-4883-ad95-5a4aa9e73800
+      - req-4f1b4c48-91c0-4336-804a-51f9a4bfe2e8
       Date:
-      - Fri, 03 Aug 2018 19:34:49 GMT
+      - Mon, 06 Aug 2018 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2656,7 +2656,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2669,9 +2669,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2df4b525-3169-4ec6-b6ae-c801665b0cfd
+      - req-6607e277-f5ee-4317-a814-46ca9307943d
       Date:
-      - Fri, 03 Aug 2018 19:34:49 GMT
+      - Mon, 06 Aug 2018 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2681,7 +2681,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2696,7 +2696,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2709,9 +2709,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-60f3d3fa-061f-45c7-9ffe-0a2cf13e25f4
+      - req-ae7c0e14-785e-4d6a-8485-a9518464654f
       Date:
-      - Fri, 03 Aug 2018 19:34:49 GMT
+      - Mon, 06 Aug 2018 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2721,7 +2721,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2739,13 +2739,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:49 GMT
+      - Mon, 06 Aug 2018 16:56:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ff401398-aed2-4a54-a2ba-a49bde811985
+      - req-b482fa67-720b-4f2a-b10e-4e3baee2337a
       Content-Length:
       - '4117'
       Connection:
@@ -2754,10 +2754,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:49.917915", "expires":
-        "2018-08-03T20:34:49Z", "id": "7bcb932f64fb48d8a5bc467c8ddc3e23", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:27.830932", "expires":
+        "2018-08-06T17:56:27Z", "id": "ad174646641448fc94c6034560539b00", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CiQt1WGAQnO3J2fHCviomA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["84bJQLx_Rm28Q3MG_ioqGw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2801,7 +2801,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2816,7 +2816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -2827,9 +2827,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-a382b555-3490-439a-a347-98c134dba268
+      - req-7bcbfbf6-454c-4090-bdc1-23aeeede03f3
       Date:
-      - Fri, 03 Aug 2018 19:34:50 GMT
+      - Mon, 06 Aug 2018 16:56:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2863,7 +2863,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2878,7 +2878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -2889,14 +2889,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b327d753-ce30-49a9-8a42-3ed03180caf8
+      - req-cd5ff660-e306-4e37-b3a1-faaf4a0c53e6
       Date:
-      - Fri, 03 Aug 2018 19:34:50 GMT
+      - Mon, 06 Aug 2018 16:56:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2914,13 +2914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:50 GMT
+      - Mon, 06 Aug 2018 16:56:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a83994ef-9e49-4725-9b5e-27ea455f8f71
+      - req-c8b07d18-8462-4d20-b627-35e9ae3c8b0a
       Content-Length:
       - '4131'
       Connection:
@@ -2929,10 +2929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:50.782978", "expires":
-        "2018-08-03T20:34:50Z", "id": "e25266045f924eb082cc852fbcf82561", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:29.130650", "expires":
+        "2018-08-06T17:56:29Z", "id": "abafe865999248acaa6b4b3cebd2f188", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zunamsakRmmo1ScCWTB8DA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DLnv7gnqQrmTnfnNsx4FNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2976,7 +2976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2991,7 +2991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25266045f924eb082cc852fbcf82561
+      - abafe865999248acaa6b4b3cebd2f188
   response:
     status:
       code: 200
@@ -3002,14 +3002,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ad129ec4-d869-4f00-8545-133e97e4b075
+      - req-76aa79f0-7607-4bc1-b41d-929ecbeab02b
       Date:
-      - Fri, 03 Aug 2018 19:34:51 GMT
+      - Mon, 06 Aug 2018 16:56:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3024,7 +3024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98025da14d644f5ba4f8f342730a12b7
+      - 205ecc32b3af4bcc81803ca4c4f52a76
   response:
     status:
       code: 200
@@ -3035,14 +3035,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-27554990-4d2a-499c-917d-81e248821650
+      - req-9917cefb-9d4e-4fc5-886b-d7d69d72e8b3
       Date:
-      - Fri, 03 Aug 2018 19:34:51 GMT
+      - Mon, 06 Aug 2018 16:56:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3060,13 +3060,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:34:51 GMT
+      - Mon, 06 Aug 2018 16:56:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a6e269d-8400-470f-9df6-536c8a0fd900
+      - req-c22ff259-287c-4d20-83a5-3077b8c70ed0
       Content-Length:
       - '4118'
       Connection:
@@ -3075,10 +3075,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:34:51.723462", "expires":
-        "2018-08-03T20:34:51Z", "id": "368670f0df75475fb76da71b133cc28e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:30.036982", "expires":
+        "2018-08-06T17:56:29Z", "id": "d27125eef53c46719de5f474efb814fe", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QVnRzSHgSfCzPgK9XckKFw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ze1iinhNS96Dr_pYxv7akA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3122,7 +3122,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3137,7 +3137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 368670f0df75475fb76da71b133cc28e
+      - d27125eef53c46719de5f474efb814fe
   response:
     status:
       code: 200
@@ -3148,14 +3148,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cd8af177-995e-44a7-9f6e-128d4b2d286e
+      - req-465c371d-3b38-4931-9686-06c73d254387
       Date:
-      - Fri, 03 Aug 2018 19:34:51 GMT
+      - Mon, 06 Aug 2018 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3170,7 +3170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3181,9 +3181,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-252f9158-713a-4da0-b5b6-3a4d189acf8a
+      - req-fb17740b-61e3-47d8-9af3-7c4a35557463
       Date:
-      - Fri, 03 Aug 2018 19:34:52 GMT
+      - Mon, 06 Aug 2018 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3210,7 +3210,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3225,7 +3225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3236,9 +3236,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-697d468e-ed11-4403-8a5e-47825a2911d9
+      - req-b35c284e-1160-462c-9821-9115246608fc
       Date:
-      - Fri, 03 Aug 2018 19:34:53 GMT
+      - Mon, 06 Aug 2018 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3265,7 +3265,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3280,7 +3280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3291,9 +3291,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2ca3d6a6-b33e-450e-83fc-7e6a1220ae15
+      - req-b5baf4e8-97cf-4abb-b4ce-abee44df037e
       Date:
-      - Fri, 03 Aug 2018 19:34:53 GMT
+      - Mon, 06 Aug 2018 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3320,7 +3320,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3335,7 +3335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3346,9 +3346,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d2521b6c-04f7-45db-abf6-63e23024cb4c
+      - req-23094a90-0c57-4d32-ac3f-eb5339c5a1da
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3360,7 +3360,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3375,7 +3375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3386,9 +3386,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7413ed3c-1c8e-4fd2-8816-1e880e50a0cb
+      - req-7ef7fe41-9ff4-4f89-a680-b9446c328bf5
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3444,7 +3444,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3459,7 +3459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3470,9 +3470,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-29cdb212-bee0-49eb-97ec-2b81a8b63baf
+      - req-45baedf9-5deb-4e00-84d4-7e2ff2e6debb
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3484,7 +3484,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3510,9 +3510,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-da0c90b4-ba08-473d-b4bf-249a1f32cf33
+      - req-9dd01a0e-128d-491a-8475-a519331c533d
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3568,7 +3568,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3583,7 +3583,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3594,9 +3594,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4a9fa90d-8617-4d1a-b52a-4b1f9987b556
+      - req-df7ca1c6-0645-4f71-97b5-8ae539426c95
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3608,7 +3608,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3623,7 +3623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcb932f64fb48d8a5bc467c8ddc3e23
+      - ad174646641448fc94c6034560539b00
   response:
     status:
       code: 200
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-befbc64f-bb04-46a9-a5d8-2a7f360c7e2e
+      - req-315d9959-778b-4786-8bad-34977784840e
       Date:
-      - Fri, 03 Aug 2018 19:34:54 GMT
+      - Mon, 06 Aug 2018 16:56:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3692,7 +3692,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3707,7 +3707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3718,14 +3718,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ba7e3d27-855c-4021-a147-bac9efc319ab
+      - req-6ad6abc4-475b-4d11-a666-a082ecc46293
       Date:
-      - Fri, 03 Aug 2018 19:34:55 GMT
+      - Mon, 06 Aug 2018 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3751,9 +3751,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4e77d8f1-5b0d-4c81-9bcb-036bde0832b0
+      - req-ede95c51-6e6d-4f6b-8739-b0477af5a0a8
       Date:
-      - Fri, 03 Aug 2018 19:34:55 GMT
+      - Mon, 06 Aug 2018 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3795,7 +3795,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3810,7 +3810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3821,14 +3821,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a1e473cd-bde2-4ca5-966c-1d93ddc4cbd1
+      - req-4ccd5496-069f-48fc-832c-f359ad5e3a3c
       Date:
-      - Fri, 03 Aug 2018 19:34:55 GMT
+      - Mon, 06 Aug 2018 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3843,7 +3843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3854,14 +3854,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cdb648cc-d012-4651-a83e-b4ca1bfdec28
+      - req-3490cfde-2364-4339-8a5e-abdeb4f0cc7b
       Date:
-      - Fri, 03 Aug 2018 19:34:55 GMT
+      - Mon, 06 Aug 2018 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3887,14 +3887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a2b246eb-be04-4934-99d7-12ed17d36433
+      - req-5a602754-8a2e-43c2-a4b5-396a87e120bb
       Date:
-      - Fri, 03 Aug 2018 19:34:55 GMT
+      - Mon, 06 Aug 2018 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3909,7 +3909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab26690b02f401e90651b1a2c640ecf
+      - c54b89e03477463abe9a6a86d7c2931f
   response:
     status:
       code: 200
@@ -3920,14 +3920,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-fa2d6ff6-5631-4cba-839c-b026e90dc8ff
+      - req-c2e89cab-6629-4b92-9406-38908337f0cb
       Date:
-      - Fri, 03 Aug 2018 19:34:56 GMT
+      - Mon, 06 Aug 2018 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3942,7 +3942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3955,9 +3955,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-61dd4599-61c6-4287-bf9f-7a3bca230e2b
+      - req-ac5dc1c5-4661-4aee-84ab-56ced7147fc9
       Date:
-      - Fri, 03 Aug 2018 19:34:56 GMT
+      - Mon, 06 Aug 2018 16:56:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -4003,7 +4003,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -4018,7 +4018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4031,9 +4031,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-6b43452b-c811-40cc-bbcf-9234e7796c42
+      - req-33a96184-5e0c-4dd6-8a73-9d5e091d68ef
       Date:
-      - Fri, 03 Aug 2018 19:34:57 GMT
+      - Mon, 06 Aug 2018 16:56:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -4079,7 +4079,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -4094,7 +4094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4107,9 +4107,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-1827e10a-da19-4f69-a273-79f8b189e064
+      - req-57145f92-00e1-42f4-8630-27dec521dcae
       Date:
-      - Fri, 03 Aug 2018 19:34:57 GMT
+      - Mon, 06 Aug 2018 16:56:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -4157,7 +4157,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4172,7 +4172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4185,9 +4185,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-1e148360-a730-49c3-9858-babf0d435273
+      - req-65900957-9ec9-4fac-90d1-11402da259e5
       Date:
-      - Fri, 03 Aug 2018 19:34:57 GMT
+      - Mon, 06 Aug 2018 16:56:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4229,7 +4229,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4244,7 +4244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4257,9 +4257,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-d0fa228c-36eb-431e-9c9d-f12928a0bd1d
+      - req-28529117-8fba-4407-975e-4232c56215a6
       Date:
-      - Fri, 03 Aug 2018 19:34:58 GMT
+      - Mon, 06 Aug 2018 16:56:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4282,7 +4282,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4297,7 +4297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4310,14 +4310,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-1aa69114-52f0-4c34-8c65-7c12aade99e1
+      - req-dc42ce06-1123-46c9-8d99-c83ecab3166e
       Date:
-      - Fri, 03 Aug 2018 19:34:58 GMT
+      - Mon, 06 Aug 2018 16:56:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4332,7 +4332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4345,14 +4345,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8bdb3a2a-d0bc-4d3f-8751-b3ff5c763105
+      - req-4574d923-d3a7-4c41-8954-eb142a9b4744
       Date:
-      - Fri, 03 Aug 2018 19:34:58 GMT
+      - Mon, 06 Aug 2018 16:56:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4367,7 +4367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4380,14 +4380,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5290add9-b9ea-4777-802a-47e69d1425a4
+      - req-6e31004a-9583-47e0-86e3-1126028bd16a
       Date:
-      - Fri, 03 Aug 2018 19:34:58 GMT
+      - Mon, 06 Aug 2018 16:56:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4402,7 +4402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4415,14 +4415,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e9ade793-34fd-4598-b9f7-1ae31ac2817e
+      - req-f78a0c91-699e-4e78-b2ce-f865543d2af5
       Date:
-      - Fri, 03 Aug 2018 19:34:58 GMT
+      - Mon, 06 Aug 2018 16:56:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4437,7 +4437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4450,14 +4450,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ff9f7ece-11f6-4b6b-a30f-36a2b8c923c4
+      - req-f721f735-2070-4cef-83fb-c1d8e58a07ae
       Date:
-      - Fri, 03 Aug 2018 19:34:59 GMT
+      - Mon, 06 Aug 2018 16:56:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4472,7 +4472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4485,14 +4485,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d27a0545-e094-4675-9e25-78f972a80e70
+      - req-890536dd-4b5f-432f-ac79-0c600411bf67
       Date:
-      - Fri, 03 Aug 2018 19:34:59 GMT
+      - Mon, 06 Aug 2018 16:56:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4507,7 +4507,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4520,14 +4520,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-35059ca1-e9f0-4aa4-bdc9-80c6eb4d7bd5
+      - req-41f32673-f5c9-4cb0-8be2-4c9e1ad98f8a
       Date:
-      - Fri, 03 Aug 2018 19:34:59 GMT
+      - Mon, 06 Aug 2018 16:56:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4542,7 +4542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4555,14 +4555,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-3c1d8922-5ac8-4f20-aaed-31b84598ccd6
+      - req-7d61d164-1bf6-4a37-8844-1cad119cf8ca
       Date:
-      - Fri, 03 Aug 2018 19:34:59 GMT
+      - Mon, 06 Aug 2018 16:56:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4577,7 +4577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4590,14 +4590,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-31b26225-1385-4355-b0fd-9dd5edfc9655
+      - req-c2f3f3a8-3fec-4e70-901c-888c3c0f5715
       Date:
-      - Fri, 03 Aug 2018 19:34:59 GMT
+      - Mon, 06 Aug 2018 16:56:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:34:59 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4612,7 +4612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4625,26 +4625,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e537564b-e212-4c67-af4c-af12efefb67e
+      - req-342ee94b-e390-4228-9bbb-de53c0ce8c99
       Date:
-      - Fri, 03 Aug 2018 19:35:00 GMT
+      - Mon, 06 Aug 2018 16:56:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:34:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:56:40.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:34:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:34:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:56:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:34:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:34:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:56:40.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4659,7 +4659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5cfb268534b430dab6b4553bc214a77
+      - 0a1c251a0a53413d860cc9c5dad0829c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4672,26 +4672,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-138cb0e3-2e73-4658-bcc0-bbfd8230343b
+      - req-722ecb19-1e30-4291-9c9f-9cf3830d0865
       Date:
-      - Fri, 03 Aug 2018 19:35:00 GMT
+      - Mon, 06 Aug 2018 16:56:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:34:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:56:40.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:34:52.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:34:53.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:56:42.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:34:53.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:34:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:56:40.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:00 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4709,13 +4709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:01 GMT
+      - Mon, 06 Aug 2018 16:56:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d66f8dba-7528-4e54-9204-0eab6e83b16f
+      - req-75a021a1-7980-40e7-baa8-94ad5113fe40
       Content-Length:
       - '4170'
       Connection:
@@ -4724,10 +4724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:01.548646", "expires":
-        "2018-08-03T20:35:01Z", "id": "da5042fcb2844cc8a94dd6b75f7f16eb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:46.478985", "expires":
+        "2018-08-06T17:56:46Z", "id": "be12d611959a4c47adce9174d3e901cd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hLgew6dPSmWd4ixQbZKhaw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["OYxJrs86TfqFGZDdYSuwOA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4772,7 +4772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:01 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4790,13 +4790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:01 GMT
+      - Mon, 06 Aug 2018 16:56:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48788643-6d4c-4760-9505-ae2d5ee0496d
+      - req-340fd13a-04e9-44bd-876f-85951f821894
       Content-Length:
       - '4170'
       Connection:
@@ -4805,10 +4805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:01.969721", "expires":
-        "2018-08-03T20:35:01Z", "id": "8b300743b4624d6fbfae755278221cab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:46.961147", "expires":
+        "2018-08-06T17:56:46Z", "id": "995d15dff95a4fee96f30b7fd1edbdd7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["IX0S817fTBqwCDV0V3rE8g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DGTJnr4-TpioKqPNJIFakw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4853,7 +4853,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4868,7 +4868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -4879,9 +4879,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-f7d535f6-31ba-4a50-bfe8-7bb0f7c8fa0f
+      - req-bb642dbf-5426-4efc-b553-70bd44e77f81
       Date:
-      - Fri, 03 Aug 2018 19:35:02 GMT
+      - Mon, 06 Aug 2018 16:56:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4923,7 +4923,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4938,7 +4938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -4949,9 +4949,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-2705151e-cc92-453b-8521-30ae1ac79866
+      - req-d58fb241-41eb-48db-9733-9b375538c434
       Date:
-      - Fri, 03 Aug 2018 19:35:02 GMT
+      - Mon, 06 Aug 2018 16:56:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4994,7 +4994,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -5009,7 +5009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5020,9 +5020,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-e225b817-6dd1-4717-97a8-6324dc448a31
+      - req-3680ed49-649a-4f07-8129-04703fb39f3e
       Date:
-      - Fri, 03 Aug 2018 19:35:02 GMT
+      - Mon, 06 Aug 2018 16:56:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -5057,7 +5057,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5072,7 +5072,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5083,9 +5083,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-4d47948d-fc25-4fe3-895a-800d66a36331
+      - req-ba3363c3-f1d7-483e-8f88-c08d7cc78a3c
       Date:
-      - Fri, 03 Aug 2018 19:35:02 GMT
+      - Mon, 06 Aug 2018 16:56:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -5172,7 +5172,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5187,7 +5187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5198,42 +5198,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-099c9357-bee2-4d8e-8df6-7c61d1ea0f9a
+      - req-e6760fea-05bf-4056-83e4-6c291bf445b5
       Date:
-      - Fri, 03 Aug 2018 19:35:02 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -5263,14 +5238,39 @@ http_interactions:
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:02 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5285,7 +5285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5296,42 +5296,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-143f0d68-1de0-43a0-9ed5-76a72ab65ab7
+      - req-48c78a6b-bea8-4779-961f-a06f631ff30d
       Date:
-      - Fri, 03 Aug 2018 19:35:03 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -5378,6 +5348,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -5389,6 +5365,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5402,7 +5402,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -5417,7 +5417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5428,42 +5428,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d854ffa1-c069-4822-bb57-3e2bbb3407c4
+      - req-0da892a0-e78f-4bfd-99d1-1f96aa20985b
       Date:
-      - Fri, 03 Aug 2018 19:35:03 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -5510,6 +5480,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -5521,6 +5497,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5534,7 +5534,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5549,7 +5549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5560,9 +5560,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8b9716fa-cc6d-4476-a133-dcaf5dcd2eea
+      - req-75dc90e4-3096-4cf9-9f66-afb985d9f1a7
       Date:
-      - Fri, 03 Aug 2018 19:35:03 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5594,7 +5594,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5609,7 +5609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5620,9 +5620,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1da2a13d-edd0-426d-962a-04380be7ff74
+      - req-d92ffeb6-143c-49e5-acbb-95966f677377
       Date:
-      - Fri, 03 Aug 2018 19:35:03 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5654,7 +5654,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:03 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5669,7 +5669,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -5680,9 +5680,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9d5169e4-c6e1-473c-a203-75eba1df0975
+      - req-7e473469-e6da-4db5-8c0b-1af34982f671
       Date:
-      - Fri, 03 Aug 2018 19:35:04 GMT
+      - Mon, 06 Aug 2018 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6085,7 +6085,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6100,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -6111,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d2e26f97-44b6-462a-8944-ecda18ef36af
+      - req-e05d32b0-f8cb-4b79-be34-b8dfb7977b43
       Date:
-      - Fri, 03 Aug 2018 19:35:04 GMT
+      - Mon, 06 Aug 2018 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6516,7 +6516,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6531,7 +6531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -6542,9 +6542,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e2016829-5203-4974-8c5f-ae01cf19e859
+      - req-523f92a6-e681-4623-98c4-e962cd980acc
       Date:
-      - Fri, 03 Aug 2018 19:35:04 GMT
+      - Mon, 06 Aug 2018 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6586,7 +6586,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6601,7 +6601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b300743b4624d6fbfae755278221cab
+      - 995d15dff95a4fee96f30b7fd1edbdd7
   response:
     status:
       code: 200
@@ -6612,9 +6612,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0ff022c5-2296-4dca-be8e-84904db0ddf1
+      - req-ccf89078-37d3-4959-9e1b-2a0fa2e9013c
       Date:
-      - Fri, 03 Aug 2018 19:35:04 GMT
+      - Mon, 06 Aug 2018 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6656,7 +6656,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:04 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6674,13 +6674,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:05 GMT
+      - Mon, 06 Aug 2018 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f3f8b30f-c6c0-41a8-95c1-35011044c01e
+      - req-920acb9c-ff5d-49e6-94e1-feef456300a0
       Content-Length:
       - '4170'
       Connection:
@@ -6689,10 +6689,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:05.765971", "expires":
-        "2018-08-03T20:35:05Z", "id": "9ba96fd3e79d44bca582bd3c59f9c0c9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:50.579053", "expires":
+        "2018-08-06T17:56:50Z", "id": "cc0c60a8a61f4d628f3397e0492b86ed", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ojLIZZVfQ76Bz-P6kWIrBA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["L9r8X1y2Qay69jqGcJiTXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6737,7 +6737,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:05 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6755,13 +6755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:05 GMT
+      - Mon, 06 Aug 2018 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-80cb9d54-26d7-42d8-ad0c-e284db6fd3d6
+      - req-6ee2ad75-a8ed-4007-8cff-97ff8e3367dd
       Content-Length:
       - '4170'
       Connection:
@@ -6770,10 +6770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:06.066162", "expires":
-        "2018-08-03T20:35:06Z", "id": "30d5180ccebf4826931c5dab583e8440", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.061062", "expires":
+        "2018-08-06T17:56:50Z", "id": "ed186c04f9c846a599c65b9f6a6ba987", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9joCkCcsQ9KrkVIJsBAeuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PqdLtuLVTwySXgPG0qZFlQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6818,7 +6818,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6836,13 +6836,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:06 GMT
+      - Mon, 06 Aug 2018 16:56:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5d32951d-19eb-40a8-a0df-2144a1c994a0
+      - req-211e6daa-f06e-4dbd-938f-728bd15d480d
       Content-Length:
       - '370'
       Connection:
@@ -6851,13 +6851,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:06.259899", "expires":
-        "2018-08-03T20:35:06Z", "id": "c1ecd1974c4a407eae3c1474b9232dd4", "audit_ids":
-        ["7mNUOzZoT2aLv1anApTlCA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.231099", "expires":
+        "2018-08-06T17:56:51Z", "id": "4bc75d56cf684cc696f38224ed1d5f1c", "audit_ids":
+        ["wy-GK5oRSQqhu5aIIXaMOw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6872,20 +6872,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1ecd1974c4a407eae3c1474b9232dd4
+      - 4bc75d56cf684cc696f38224ed1d5f1c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:06 GMT
+      - Mon, 06 Aug 2018 16:56:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2bc0f6bc-e919-4124-bf13-aa8622f3c978
+      - req-89541bc3-a0dd-4036-826f-0948bee250cd
       Content-Length:
       - '500'
       Connection:
@@ -6902,13 +6902,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c1ecd1974c4a407eae3c1474b9232dd4"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"4bc75d56cf684cc696f38224ed1d5f1c"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6920,13 +6920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:06 GMT
+      - Mon, 06 Aug 2018 16:56:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-03f6bdef-804b-48f4-9114-9cf1aedba9ab
+      - req-8e4d3954-0fcb-489d-b9bf-58aace5f488c
       Content-Length:
       - '4143'
       Connection:
@@ -6935,11 +6935,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:06.766036", "expires":
-        "2018-08-03T20:35:06Z", "id": "bd0f78b86f7d4d218be8da67db0e31c2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.569092", "expires":
+        "2018-08-06T17:56:51Z", "id": "c421a5033be4461f8c029fad53364fe6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["m5btNT7jQNyQCBMK97hOPg",
-        "7mNUOzZoT2aLv1anApTlCA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8sveZeh-RDOrlBUOAuQj_A",
+        "wy-GK5oRSQqhu5aIIXaMOw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6983,7 +6983,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6998,20 +6998,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1ecd1974c4a407eae3c1474b9232dd4
+      - 4bc75d56cf684cc696f38224ed1d5f1c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:06 GMT
+      - Mon, 06 Aug 2018 16:56:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7219a15d-53df-493f-97e2-d43b59565933
+      - req-c5ecf08f-3947-42ac-b9fe-fb4beb3dcd91
       Content-Length:
       - '500'
       Connection:
@@ -7028,7 +7028,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:06 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7046,13 +7046,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:07 GMT
+      - Mon, 06 Aug 2018 16:56:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3edb7f3e-8eca-4f86-a5fa-7afec12dce1b
+      - req-56b503c7-df7b-49d8-a481-aaeff6d7017e
       Content-Length:
       - '4117'
       Connection:
@@ -7061,10 +7061,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:07.340884", "expires":
-        "2018-08-03T20:35:07Z", "id": "d0562f3b944b4dbfa6b0acb4b6ec9b7c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.933612", "expires":
+        "2018-08-06T17:56:51Z", "id": "6bc5be06280848e3969a5e1ea819c807", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xmrlmbmGTPWqbI1rqRTang"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RjRzm8rAQFSxrDohoxmLUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7108,7 +7108,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7126,13 +7126,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:07 GMT
+      - Mon, 06 Aug 2018 16:56:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-09c6b124-5e2c-4d5f-8c49-f233c07500e1
+      - req-172189b5-491c-43a0-bcb0-b3ded1af5e52
       Content-Length:
       - '4131'
       Connection:
@@ -7141,10 +7141,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:07.650169", "expires":
-        "2018-08-03T20:35:07Z", "id": "6d949716d3d148d085dc0edb8981cbfd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.225492", "expires":
+        "2018-08-06T17:56:52Z", "id": "6d86c0a7c738417ea657be24c5bcf7d6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["bWKNJ_4vQyqurvh2KXpdaQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ev3a9TOoTLK3t5CvU19Gdw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7188,7 +7188,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7206,13 +7206,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:07 GMT
+      - Mon, 06 Aug 2018 16:56:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-234b30c3-243f-4aa8-bdeb-950a8baddc2f
+      - req-3d4638db-9007-49a2-803b-2403e20ed8b4
       Content-Length:
       - '4118'
       Connection:
@@ -7221,10 +7221,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:07.934425", "expires":
-        "2018-08-03T20:35:07Z", "id": "ef1219cbbabf4ebd80af5894955bd0e8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.530687", "expires":
+        "2018-08-06T17:56:52Z", "id": "b0a1b7822c10457fa81cf5cd9c360bfd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AR_HQamoTBOIKzVlMYKTGA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9_o5PeyvRDuCxAnQAO2ONw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7268,7 +7268,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:07 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7286,13 +7286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:08 GMT
+      - Mon, 06 Aug 2018 16:56:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aa87b7c8-894c-4172-a279-54fc4c1f774c
+      - req-ec1f6712-37bb-427f-ac6b-94e6f55edebb
       Content-Length:
       - '4117'
       Connection:
@@ -7301,10 +7301,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:08.228475", "expires":
-        "2018-08-03T20:35:08Z", "id": "ccd62e87b80343bc8ee856fdd50fbd88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.963097", "expires":
+        "2018-08-06T17:56:52Z", "id": "06acf8463c4c4ef79ad6f44d02ccdd63", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Rr8_FQcXQIetuxfHv8Jkcg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9mRETT2eTk-_D79lwBTC1g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7348,7 +7348,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -7363,22 +7363,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2fe971fe-4e09-4489-8cd1-0ec4fff4ecf6
+      - req-ffafa90a-69a3-4020-986b-fafdce1abcd3
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-2fe971fe-4e09-4489-8cd1-0ec4fff4ecf6
+      - req-ffafa90a-69a3-4020-986b-fafdce1abcd3
       Date:
-      - Fri, 03 Aug 2018 19:35:08 GMT
+      - Mon, 06 Aug 2018 16:56:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -7411,7 +7411,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:08 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -7426,22 +7426,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b2d76f4-c6f0-4b1c-b9b2-c2beaa11d80a
+      - req-c9f4098a-80f8-40a5-ae49-2209b1a110c7
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-8b2d76f4-c6f0-4b1c-b9b2-c2beaa11d80a
+      - req-c9f4098a-80f8-40a5-ae49-2209b1a110c7
       Date:
-      - Fri, 03 Aug 2018 19:35:09 GMT
+      - Mon, 06 Aug 2018 16:56:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -7482,7 +7482,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7497,22 +7497,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2bad7eaa-0d3c-4a37-9aba-e8ac2280d4be
+      - req-96affb07-c31b-4fb5-9859-eb7224e186eb
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-2bad7eaa-0d3c-4a37-9aba-e8ac2280d4be
+      - req-96affb07-c31b-4fb5-9859-eb7224e186eb
       Date:
-      - Fri, 03 Aug 2018 19:35:09 GMT
+      - Mon, 06 Aug 2018 16:56:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7546,7 +7546,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7561,27 +7561,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a987ac8d-b5cb-423c-ae40-b0a70effe263
+      - req-2a4ed828-3828-4308-88ab-bf0f94a48eff
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a987ac8d-b5cb-423c-ae40-b0a70effe263
+      - req-2a4ed828-3828-4308-88ab-bf0f94a48eff
       Date:
-      - Fri, 03 Aug 2018 19:35:09 GMT
+      - Mon, 06 Aug 2018 16:56:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:09 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7599,13 +7599,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:09 GMT
+      - Mon, 06 Aug 2018 16:56:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86d45edb-d1dc-414a-aa13-14ff38f155e2
+      - req-0224ddac-a7be-4c97-bace-56d6bddb617f
       Content-Length:
       - '4131'
       Connection:
@@ -7614,10 +7614,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:10.168320", "expires":
-        "2018-08-03T20:35:10Z", "id": "0af75bc9066444a9b2818f4185a476d3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:55.557308", "expires":
+        "2018-08-06T17:56:55Z", "id": "7eb0a84107494998878267bc4e6dc4a9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vdbe5BbMSuasfZXv3ZzJbg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["M_sSZZhmRt2H7A1hipYtEA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7661,7 +7661,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7676,27 +7676,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0af75bc9066444a9b2818f4185a476d3
+      - 7eb0a84107494998878267bc4e6dc4a9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86656c15-069f-4e29-994c-6c31b2b82d97
+      - req-8dacea87-1c86-4b7d-ab96-468d7138bf11
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-86656c15-069f-4e29-994c-6c31b2b82d97
+      - req-8dacea87-1c86-4b7d-ab96-468d7138bf11
       Date:
-      - Fri, 03 Aug 2018 19:35:10 GMT
+      - Mon, 06 Aug 2018 16:56:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:10 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7711,27 +7711,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30d5180ccebf4826931c5dab583e8440
+      - ed186c04f9c846a599c65b9f6a6ba987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61fb5174-c1e8-49b4-9982-13f8c08325b1
+      - req-6337c501-b057-4df6-a38a-12e24df71925
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-61fb5174-c1e8-49b4-9982-13f8c08325b1
+      - req-6337c501-b057-4df6-a38a-12e24df71925
       Date:
-      - Fri, 03 Aug 2018 19:35:11 GMT
+      - Mon, 06 Aug 2018 16:56:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7749,13 +7749,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:11 GMT
+      - Mon, 06 Aug 2018 16:56:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-19b186b4-ce01-43d0-8e7a-982c5c9e43d4
+      - req-99110dec-c428-4b48-b70a-24e28d0242a9
       Content-Length:
       - '4118'
       Connection:
@@ -7764,10 +7764,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:11.474346", "expires":
-        "2018-08-03T20:35:11Z", "id": "0dc2d7b7c2b9479fa34f2be1e94e9603", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:56.827925", "expires":
+        "2018-08-06T17:56:56Z", "id": "c21f45052e2f4a368d89147de075b0db", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lG9YrshdSr-IR5IPWzrgyg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qe-PdPKlQ9W9SJ-QZuyAWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7811,7 +7811,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7826,27 +7826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dc2d7b7c2b9479fa34f2be1e94e9603
+      - c21f45052e2f4a368d89147de075b0db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-621079c6-4d99-4e19-85a5-ce9556961059
+      - req-59ff5418-d28a-4b9a-84b1-0dd5bc648540
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-621079c6-4d99-4e19-85a5-ce9556961059
+      - req-59ff5418-d28a-4b9a-84b1-0dd5bc648540
       Date:
-      - Fri, 03 Aug 2018 19:35:11 GMT
+      - Mon, 06 Aug 2018 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:11 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7861,22 +7861,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa10870d-e809-4aae-b716-b8d393b752a9
+      - req-65aea607-d930-4d63-9c05-60a563cb81a0
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-aa10870d-e809-4aae-b716-b8d393b752a9
+      - req-65aea607-d930-4d63-9c05-60a563cb81a0
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7891,7 +7891,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7906,22 +7906,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0c643fb5-f8f2-45f3-8f60-59469f348f75
+      - req-06018a1c-711d-40b3-a136-54f5ec5700c1
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-0c643fb5-f8f2-45f3-8f60-59469f348f75
+      - req-06018a1c-711d-40b3-a136-54f5ec5700c1
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7936,7 +7936,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7951,27 +7951,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0af75bc9066444a9b2818f4185a476d3
+      - 7eb0a84107494998878267bc4e6dc4a9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c1b78525-ef97-4f32-8e70-8aac401fb22e
+      - req-6ecb3545-8a04-4e81-8fe7-81e26799e241
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c1b78525-ef97-4f32-8e70-8aac401fb22e
+      - req-6ecb3545-8a04-4e81-8fe7-81e26799e241
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7986,27 +7986,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0af75bc9066444a9b2818f4185a476d3
+      - 7eb0a84107494998878267bc4e6dc4a9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa87b318-d869-46e7-951e-c7c706562eb6
+      - req-a20b2645-3fc3-4a18-9e90-708b42ef8f65
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fa87b318-d869-46e7-951e-c7c706562eb6
+      - req-a20b2645-3fc3-4a18-9e90-708b42ef8f65
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8021,27 +8021,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30d5180ccebf4826931c5dab583e8440
+      - ed186c04f9c846a599c65b9f6a6ba987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eea6582e-dff3-48f6-93c9-0bf6d9f73229
+      - req-b082ae1e-e0c9-48c6-9bce-38a2c83dd0c9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-eea6582e-dff3-48f6-93c9-0bf6d9f73229
+      - req-b082ae1e-e0c9-48c6-9bce-38a2c83dd0c9
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8056,27 +8056,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30d5180ccebf4826931c5dab583e8440
+      - ed186c04f9c846a599c65b9f6a6ba987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a73fc9c-7840-4be3-a85a-f99bcf57dbd5
+      - req-6714871e-43b3-4c91-867f-5580f445e738
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9a73fc9c-7840-4be3-a85a-f99bcf57dbd5
+      - req-6714871e-43b3-4c91-867f-5580f445e738
       Date:
-      - Fri, 03 Aug 2018 19:35:12 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:12 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8091,27 +8091,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dc2d7b7c2b9479fa34f2be1e94e9603
+      - c21f45052e2f4a368d89147de075b0db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70cfc794-84df-4ba0-a4bb-dcb1ee17afa7
+      - req-e2d6d2bf-ec34-4f6e-bfc3-725d954e1501
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-70cfc794-84df-4ba0-a4bb-dcb1ee17afa7
+      - req-e2d6d2bf-ec34-4f6e-bfc3-725d954e1501
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8126,27 +8126,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dc2d7b7c2b9479fa34f2be1e94e9603
+      - c21f45052e2f4a368d89147de075b0db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb80bafb-9c83-4fe0-bef6-ed1a2bbe0cf2
+      - req-e1c17739-8638-444f-8179-99bbbcb19595
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fb80bafb-9c83-4fe0-bef6-ed1a2bbe0cf2
+      - req-e1c17739-8638-444f-8179-99bbbcb19595
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8161,27 +8161,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ceb8daf2-b055-43cb-95ee-ca8e281eb5fb
+      - req-caab2ecf-1321-41f1-8193-cc03d2059485
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ceb8daf2-b055-43cb-95ee-ca8e281eb5fb
+      - req-caab2ecf-1321-41f1-8193-cc03d2059485
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8196,27 +8196,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd62e87b80343bc8ee856fdd50fbd88
+      - 06acf8463c4c4ef79ad6f44d02ccdd63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-577f8efd-7541-402b-a36e-e22c7d5a1731
+      - req-2638cc2c-b2f8-4a31-abd3-0eaa16b3e46f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-577f8efd-7541-402b-a36e-e22c7d5a1731
+      - req-2638cc2c-b2f8-4a31-abd3-0eaa16b3e46f
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8231,27 +8231,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0af75bc9066444a9b2818f4185a476d3
+      - 7eb0a84107494998878267bc4e6dc4a9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b65d29e-4908-473c-b195-ade1a54946fe
+      - req-4d1ad414-9538-4d5f-8746-34d0ca987c5b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5b65d29e-4908-473c-b195-ade1a54946fe
+      - req-4d1ad414-9538-4d5f-8746-34d0ca987c5b
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -8266,27 +8266,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0af75bc9066444a9b2818f4185a476d3
+      - 7eb0a84107494998878267bc4e6dc4a9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8194ee35-1ff0-4d12-8ce3-f07ff0f4a7f4
+      - req-876ae076-1f36-4b8b-b6dc-8ef15511b68a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8194ee35-1ff0-4d12-8ce3-f07ff0f4a7f4
+      - req-876ae076-1f36-4b8b-b6dc-8ef15511b68a
       Date:
-      - Fri, 03 Aug 2018 19:35:13 GMT
+      - Mon, 06 Aug 2018 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:13 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -8301,27 +8301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30d5180ccebf4826931c5dab583e8440
+      - ed186c04f9c846a599c65b9f6a6ba987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b918b74-0aa2-4de6-8ea1-7eba849c3cac
+      - req-9d8a642d-c2f0-481c-9999-14fd8e174558
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8b918b74-0aa2-4de6-8ea1-7eba849c3cac
+      - req-9d8a642d-c2f0-481c-9999-14fd8e174558
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -8336,27 +8336,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30d5180ccebf4826931c5dab583e8440
+      - ed186c04f9c846a599c65b9f6a6ba987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-403f1f88-c1b1-4f98-88fb-4cb174331fad
+      - req-2eed5cc8-5f61-4661-a26a-4def387c432e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-403f1f88-c1b1-4f98-88fb-4cb174331fad
+      - req-2eed5cc8-5f61-4661-a26a-4def387c432e
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -8371,27 +8371,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dc2d7b7c2b9479fa34f2be1e94e9603
+      - c21f45052e2f4a368d89147de075b0db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-064a6012-55b2-4a2b-a9ca-fe1a7788e475
+      - req-64c63ffb-0d45-425b-a478-fe8d18661c16
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-064a6012-55b2-4a2b-a9ca-fe1a7788e475
+      - req-64c63ffb-0d45-425b-a478-fe8d18661c16
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -8406,27 +8406,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dc2d7b7c2b9479fa34f2be1e94e9603
+      - c21f45052e2f4a368d89147de075b0db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5592c2cb-f12e-46fb-b70d-4b865d647ce3
+      - req-aa7f5366-0965-4e71-8b19-351b457255e3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5592c2cb-f12e-46fb-b70d-4b865d647ce3
+      - req-aa7f5366-0965-4e71-8b19-351b457255e3
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:57:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8444,13 +8444,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8352eedc-314c-40c6-9f79-d1e578ff2d3d
+      - req-1e2705fd-23b7-433e-b625-b4f6f60c4301
       Content-Length:
       - '4170'
       Connection:
@@ -8459,10 +8459,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:14.834948", "expires":
-        "2018-08-03T20:35:14Z", "id": "71f7eab519c74062b6129031a30625f0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.384701", "expires":
+        "2018-08-06T17:57:00Z", "id": "71be248c5ed042d8aff306959db2842c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["v_HQX2pOQvmWFCdhW5XMqQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["eJYJsxrjQfu8vpDfbJDj_w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8507,7 +8507,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:14 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8525,13 +8525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:14 GMT
+      - Mon, 06 Aug 2018 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-db56d3d2-83bb-4a4f-aafb-275b7377c8f8
+      - req-bd198b68-799f-4262-b33c-7b2695f94616
       Content-Length:
       - '4170'
       Connection:
@@ -8540,10 +8540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:15.137905", "expires":
-        "2018-08-03T20:35:15Z", "id": "bdc15295cfde42239298d6d5a2c79904", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.696703", "expires":
+        "2018-08-06T17:57:00Z", "id": "2eac73dde1584d6da60d15616eb4c873", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["FbBvcOmDRCOy8sfemrfxWw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["yPj0UWyCSOaWX2aRAIzI7A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8588,7 +8588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:15 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8606,13 +8606,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:20 GMT
+      - Mon, 06 Aug 2018 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-40619456-706c-4e39-a96f-6fccf1909635
+      - req-3611b8f0-41c0-4ae6-8b6d-c19922deaaa4
       Content-Length:
       - '370'
       Connection:
@@ -8621,13 +8621,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:20.475892", "expires":
-        "2018-08-03T20:35:20Z", "id": "c13c83e0a39d4599a12eed9f2fbcf9d4", "audit_ids":
-        ["LvehRoUUQlmfTOieoi8R3g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.972189", "expires":
+        "2018-08-06T17:57:00Z", "id": "8d535895943a4208b0d9222202d126e1", "audit_ids":
+        ["zo5AJ_yTTh6-8wSKVlleqQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8642,20 +8642,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c13c83e0a39d4599a12eed9f2fbcf9d4
+      - 8d535895943a4208b0d9222202d126e1
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:20 GMT
+      - Mon, 06 Aug 2018 16:57:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b53f8521-3b48-440c-8a01-5fc3608948a2
+      - req-9433fb8e-04a1-49be-a808-5f44aed8d100
       Content-Length:
       - '500'
       Connection:
@@ -8672,13 +8672,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c13c83e0a39d4599a12eed9f2fbcf9d4"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"8d535895943a4208b0d9222202d126e1"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8690,13 +8690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:20 GMT
+      - Mon, 06 Aug 2018 16:57:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-44bf2538-4399-44fb-beb3-c79035508a69
+      - req-180d03b1-deef-4575-a191-86e81cbe3d7f
       Content-Length:
       - '4143'
       Connection:
@@ -8705,11 +8705,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:20.922783", "expires":
-        "2018-08-03T20:35:20Z", "id": "079513349c2a404fbf6fc0602caeb6a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:01.421210", "expires":
+        "2018-08-06T17:57:00Z", "id": "3dd1fd34de034a4481f002a5b7bf69ad", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jAcKpcczQGisC2X8_2qT0g",
-        "LvehRoUUQlmfTOieoi8R3g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vUszXZOET_mZiX87F2ejIg",
+        "zo5AJ_yTTh6-8wSKVlleqQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8753,7 +8753,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:20 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8768,20 +8768,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c13c83e0a39d4599a12eed9f2fbcf9d4
+      - 8d535895943a4208b0d9222202d126e1
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:21 GMT
+      - Mon, 06 Aug 2018 16:57:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3548584f-4150-4fb4-8cbe-fb666992788d
+      - req-eb98f8f2-7ad7-427e-be87-d5c3980a4a21
       Content-Length:
       - '500'
       Connection:
@@ -8798,7 +8798,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8816,13 +8816,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:21 GMT
+      - Mon, 06 Aug 2018 16:57:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a933e03b-8e27-4118-8a7f-d48c95e6460a
+      - req-ddefd0ab-4138-4eaf-b3b9-6c7bcd3f0154
       Content-Length:
       - '4117'
       Connection:
@@ -8831,10 +8831,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:21.468456", "expires":
-        "2018-08-03T20:35:21Z", "id": "41709f5dc4f04b52ae5ae5ba3079d56c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:01.984773", "expires":
+        "2018-08-06T17:57:01Z", "id": "c9325dd5841d42018cfb6c21b7e5b308", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["H2ojQZy0T6GoLuBAN9ldrg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["waNr8HdUS3qXzIugMyUgPg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8878,7 +8878,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8896,13 +8896,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:21 GMT
+      - Mon, 06 Aug 2018 16:57:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fed9c429-d907-487c-a1f5-664ad67cca44
+      - req-ebc0d368-a53d-4dcc-a85f-3a254b8a4c7d
       Content-Length:
       - '4131'
       Connection:
@@ -8911,10 +8911,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:21.862339", "expires":
-        "2018-08-03T20:35:21Z", "id": "e0ae8fb9bd494806be7e83ed7be0553f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.385843", "expires":
+        "2018-08-06T17:57:02Z", "id": "c251c9e8eb75465aaccef0253c261317", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Y3_S4FLBRNu3pWR2aZN_-g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jB8cVlBwTOKUTR9ildYvDw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8958,7 +8958,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:21 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8976,13 +8976,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:22 GMT
+      - Mon, 06 Aug 2018 16:57:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-075d1666-7f89-4d4f-8551-11c8dd474c66
+      - req-f14dcf98-9ac5-43f3-899d-f9a1f6628c7f
       Content-Length:
       - '4118'
       Connection:
@@ -8991,10 +8991,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:22.241406", "expires":
-        "2018-08-03T20:35:22Z", "id": "531ee9bf6ed748758f874f64f9e7aad9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.608348", "expires":
+        "2018-08-06T17:57:02Z", "id": "2195d7890565448cb38d03cf9e2a217e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["L3I7vwTgTD62yiyDBF8kOA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ObGIAU_dQpyMFFPj-cW9FA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9038,7 +9038,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9056,13 +9056,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:22 GMT
+      - Mon, 06 Aug 2018 16:57:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d42acc15-3d1c-4dab-86dc-9316bfd603fb
+      - req-15f51f56-5d47-4c46-bdcb-e7cf4c32c5a8
       Content-Length:
       - '4117'
       Connection:
@@ -9071,10 +9071,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:22.594344", "expires":
-        "2018-08-03T20:35:22Z", "id": "7b11abe51b054f14bfc2b3d298878d39", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.931562", "expires":
+        "2018-08-06T17:57:02Z", "id": "a2c63efa619041c58ccc9fdec7e9fbda", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7XNnc7SMRwe2jpC2KffAIg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ac8kq-1eTLKQ0Fi76WJRWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9118,7 +9118,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9133,7 +9133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b11abe51b054f14bfc2b3d298878d39
+      - a2c63efa619041c58ccc9fdec7e9fbda
   response:
     status:
       code: 200
@@ -9162,15 +9162,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx9ffb6bd194024048afb57-005b64ae7a
+      - tx987ce71af18643cfb5d53-005b687ddf
       Date:
-      - Fri, 03 Aug 2018 19:35:22 GMT
+      - Mon, 06 Aug 2018 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:22 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -9185,7 +9185,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b11abe51b054f14bfc2b3d298878d39
+      - a2c63efa619041c58ccc9fdec7e9fbda
   response:
     status:
       code: 200
@@ -9214,14 +9214,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx3241bc1553e1474889291-005b64ae7a
+      - tx28bca008f47d4ecfbb763-005b687ddf
       Date:
-      - Fri, 03 Aug 2018 19:35:23 GMT
+      - Mon, 06 Aug 2018 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9239,13 +9239,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:23 GMT
+      - Mon, 06 Aug 2018 16:57:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1a2e4c00-4f91-405a-bd61-a6a2956eae1d
+      - req-e8fc7351-4314-4243-87b6-45dcc2654ee4
       Content-Length:
       - '4131'
       Connection:
@@ -9254,10 +9254,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:23.356368", "expires":
-        "2018-08-03T20:35:23Z", "id": "f77c2dc3276f434e9e44d047cf06b0fb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:03.529753", "expires":
+        "2018-08-06T17:57:03Z", "id": "a06298606e024ef7a40201e115661e57", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hAhXl2hjQueK_fEFWUUo7A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3U3HHg9KTG6z_3SsOdiMZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9301,7 +9301,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -9316,7 +9316,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f77c2dc3276f434e9e44d047cf06b0fb
+      - a06298606e024ef7a40201e115661e57
   response:
     status:
       code: 200
@@ -9329,22 +9329,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324923.77216'
+      - '1533574623.88674'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324923.77216'
+      - '1533574623.88674'
       X-Trans-Id:
-      - tx43e81f355fa24e4da084b-005b64ae7b
+      - txad8767f21427409b8b83d-005b687ddf
       Date:
-      - Fri, 03 Aug 2018 19:35:23 GMT
+      - Mon, 06 Aug 2018 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:23 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -9359,7 +9359,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdc15295cfde42239298d6d5a2c79904
+      - 2eac73dde1584d6da60d15616eb4c873
   response:
     status:
       code: 200
@@ -9372,22 +9372,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324924.09087'
+      - '1533574624.21729'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324924.09087'
+      - '1533574624.21729'
       X-Trans-Id:
-      - txd1ae3c26133d4934ad1b1-005b64ae7b
+      - txc42924ddd67c4540aa9d3-005b687ddf
       Date:
-      - Fri, 03 Aug 2018 19:35:24 GMT
+      - Mon, 06 Aug 2018 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9405,13 +9405,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:24 GMT
+      - Mon, 06 Aug 2018 16:57:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-574a0095-df34-49ee-96d0-5d4c3f56c063
+      - req-47fd3399-ce5a-4ea3-a2ee-ba34d543cf5e
       Content-Length:
       - '4118'
       Connection:
@@ -9420,10 +9420,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:24.351303", "expires":
-        "2018-08-03T20:35:24Z", "id": "437ed1af84a24cd38d210bb323b4bb1d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:04.484115", "expires":
+        "2018-08-06T17:57:04Z", "id": "f428efed191d4db8a15191895d91f9a1", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3Fch-Sw4R5iMUON0vhIVvw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["v3eDcWO7SzyINcD6wRdwBA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9467,7 +9467,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -9482,7 +9482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 437ed1af84a24cd38d210bb323b4bb1d
+      - f428efed191d4db8a15191895d91f9a1
   response:
     status:
       code: 200
@@ -9495,22 +9495,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533324924.73074'
+      - '1533574624.91193'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533324924.73074'
+      - '1533574624.91193'
       X-Trans-Id:
-      - txd432ddfe8b6849bea5e73-005b64ae7c
+      - txe4eb1ff07f1849e5a6307-005b687de0
       Date:
-      - Fri, 03 Aug 2018 19:35:24 GMT
+      - Mon, 06 Aug 2018 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -9525,7 +9525,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b11abe51b054f14bfc2b3d298878d39
+      - a2c63efa619041c58ccc9fdec7e9fbda
   response:
     status:
       code: 200
@@ -9546,9 +9546,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8c9d29c83d2f4d60876de-005b64ae7c
+      - tx20e266eeeb984d20b6fa2-005b687de0
       Date:
-      - Fri, 03 Aug 2018 19:35:24 GMT
+      - Mon, 06 Aug 2018 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -9558,7 +9558,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -9573,7 +9573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b11abe51b054f14bfc2b3d298878d39
+      - a2c63efa619041c58ccc9fdec7e9fbda
   response:
     status:
       code: 200
@@ -9594,14 +9594,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8ead7f6bd3b743c081a37-005b64ae7c
+      - txef840bf0049f400a8410d-005b687de1
       Date:
-      - Fri, 03 Aug 2018 19:35:24 GMT
+      - Mon, 06 Aug 2018 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:24 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -9616,7 +9616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b11abe51b054f14bfc2b3d298878d39
+      - a2c63efa619041c58ccc9fdec7e9fbda
   response:
     status:
       code: 200
@@ -9637,12 +9637,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txde10b2e2872a49fdb790b-005b64ae7c
+      - tx725247f6a4dc47e7a0aa7-005b687de1
       Date:
-      - Fri, 03 Aug 2018 19:35:25 GMT
+      - Mon, 06 Aug 2018 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:25 GMT
+  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:47 GMT
+      - Mon, 06 Aug 2018 16:59:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cdc60d50-df56-457a-84fc-c40c913d3c5a
+      - req-49fcc167-2303-408a-a933-91696d253013
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:48.167420", "expires":
-        "2018-08-03T20:35:48Z", "id": "615909c359d042b0b60946446108189f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:50.551203", "expires":
+        "2018-08-06T17:59:50Z", "id": "56fa1691c6fb4af3b50a1cf2ad67cc53", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kgT3K5x7R3udsWO-tChHtg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dV7ANEN8RQuWbXF3E9fXwA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:48 GMT
+      - Mon, 06 Aug 2018 16:59:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-38c618be-80b5-40a1-8d43-bc07068ff33b
+      - req-9baa322b-19da-437a-802a-1f1447642888
       Date:
-      - Fri, 03 Aug 2018 19:35:48 GMT
+      - Mon, 06 Aug 2018 16:59:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:48 GMT
+      - Mon, 06 Aug 2018 16:59:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bbbec4f5-dc22-4527-8d87-d11a7679b7f9
+      - req-fad1d3ad-b1cd-4302-9ba0-257c1084efb6
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:48.943630", "expires":
-        "2018-08-03T20:35:48Z", "id": "1c7e1237709549489012c5fcb1b011e5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:51.329010", "expires":
+        "2018-08-06T17:59:51Z", "id": "8efeefad72744c61821793b8a51068c6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MIY7sJxhRNmh0PrP34PrPg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["smWV1xTsQaWqNhZaynhjDA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:48 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bcf7bcb2-cb8c-4dd5-8fad-643345320b19
+      - req-ee281bef-6be2-4908-9af3-971d852853a6
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-bcf7bcb2-cb8c-4dd5-8fad-643345320b19
+      - req-ee281bef-6be2-4908-9af3-971d852853a6
       Date:
-      - Fri, 03 Aug 2018 19:35:49 GMT
+      - Mon, 06 Aug 2018 16:59:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:49 GMT
+      - Mon, 06 Aug 2018 16:59:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-127c4457-751c-4aaf-ad34-7366f26be961
+      - req-3791392d-e3ca-41b8-b5cd-1a9cb720a686
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:49.582740", "expires":
-        "2018-08-03T20:35:49Z", "id": "841ab09ddaf24cae8438281a11fb853b", "audit_ids":
-        ["CphUpwwyQv-FHEG2C9CUWA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:51.801215", "expires":
+        "2018-08-06T17:59:51Z", "id": "d2fcf01b1d3b4dd989ba55dbf9727efa", "audit_ids":
+        ["hi09Gm2JRE2mwgKeFIkoOw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 841ab09ddaf24cae8438281a11fb853b
+      - d2fcf01b1d3b4dd989ba55dbf9727efa
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:49 GMT
+      - Mon, 06 Aug 2018 16:59:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94ad7b92-e2db-494a-9287-05b6fe3c8299
+      - req-c208d629-a4d3-4988-8bcb-a0468939289d
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:49 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"841ab09ddaf24cae8438281a11fb853b"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"d2fcf01b1d3b4dd989ba55dbf9727efa"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:49 GMT
+      - Mon, 06 Aug 2018 16:59:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ceefa483-2404-4f0e-9e99-a4a0e310387e
+      - req-6b8c0f01-92fd-43fb-ba06-245ec81001c8
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:50.043617", "expires":
-        "2018-08-03T20:35:49Z", "id": "9463b571f470469b860f28a3ef77a28e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:52.250984", "expires":
+        "2018-08-06T17:59:51Z", "id": "293e12e85aa04a889f9fbc1c1e3bac9c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JpOp6u7BT0SKJ1ggs4M8Cg",
-        "CphUpwwyQv-FHEG2C9CUWA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["22A4tKeZRB23aAEE6-mjtQ",
+        "hi09Gm2JRE2mwgKeFIkoOw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 841ab09ddaf24cae8438281a11fb853b
+      - d2fcf01b1d3b4dd989ba55dbf9727efa
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:50 GMT
+      - Mon, 06 Aug 2018 16:59:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f8ee4e7f-a786-402f-af28-ae0bdf873965
+      - req-00d4eca9-cf48-49de-a1f5-15a541607c3b
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:50 GMT
+      - Mon, 06 Aug 2018 16:59:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46b6d624-8511-425f-bfae-7e7b2bde91a2
+      - req-ea3fec5f-9106-494a-8b6c-976143b68c40
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:50.498141", "expires":
-        "2018-08-03T20:35:50Z", "id": "06c57b27f0564e6094c99e6dbb626fcf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:52.731190", "expires":
+        "2018-08-06T17:59:52Z", "id": "cd85a4926736420da6cd4881729d1172", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1QPzhm6mRkWvQox6-P3pDg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jcsX4EZMTpqLN880docxJw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:50 GMT
+      - Mon, 06 Aug 2018 16:59:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:50 GMT
+      - Mon, 06 Aug 2018 16:59:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55f05817-b6e4-4d35-b9c3-4a60880f1ebb
+      - req-c5319805-76b9-4001-8dd3-4051241408bd
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:50.870693", "expires":
-        "2018-08-03T20:35:50Z", "id": "15729ae235cf499cb72e94e3fc02dcff", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:53.018597", "expires":
+        "2018-08-06T17:59:52Z", "id": "3155dbf6fed14fb1b8dce46bc6e1ae60", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["HSevSedJQSOY3_7zc_Ctaw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XsJN9zbuToCTxOqs26EzBw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:50 GMT
+      - Mon, 06 Aug 2018 16:59:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:50 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:51 GMT
+      - Mon, 06 Aug 2018 16:59:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f1766eec-44a7-45f7-8a3b-00784c2ee518
+      - req-ce64a074-4d4f-48ea-ae9b-a57b534b5264
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:51.164015", "expires":
-        "2018-08-03T20:35:51Z", "id": "c595254e90094677a46e2b66130cf49e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:53.312443", "expires":
+        "2018-08-06T17:59:53Z", "id": "0c66371c954d40358957e61a748e81d0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F0FJHs62Re2eIAir9SPbnQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dfG5ArRpRpS8cQwKrifJgw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:51 GMT
+      - Mon, 06 Aug 2018 16:59:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7a1f25f2-ab3f-4937-9f73-ca1bb23eca77
+      - req-0a646a17-f984-4f0a-bca4-a957cb2e8ea0
       Date:
-      - Fri, 03 Aug 2018 19:35:51 GMT
+      - Mon, 06 Aug 2018 16:59:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-cac87235-496a-47f7-b44e-131573abc630
+      - req-01e9aa11-570e-4c55-9df1-19b22ebed087
       Date:
-      - Fri, 03 Aug 2018 19:35:51 GMT
+      - Mon, 06 Aug 2018 16:59:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-32ef5e64-d682-443c-b6c8-65b092e445cf
+      - req-341be9c3-fa8f-40d8-b110-b427e5588185
       Date:
-      - Fri, 03 Aug 2018 19:35:51 GMT
+      - Mon, 06 Aug 2018 16:59:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:51 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-957612b7-bc97-48a9-929a-c06b5e6ec783
+      - req-c79bcdb2-5885-4842-99d4-edf15f652e82
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e38623f4-3be5-4abc-8e69-2ab01b2242dc
+      - req-3a74c502-bee4-4f8e-a85c-6330b2adeefb
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-8ff0ebdc-09fb-488b-85dc-c852b31d4d11
+      - req-2448fe4f-b4d6-4a51-a80b-4d3547fc2e05
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-963e8112-3dc1-49db-8767-b3c386fe3b16
+      - req-b7336026-f020-4eba-82d3-73be17171224
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0ff645d2-40af-4b15-80e2-b2e10c845d07
+      - req-d9433acd-864e-4610-8131-7071cf64ff8b
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-03T19:35:51.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-03T19:35:42.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-03T19:35:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-03T19:35:43.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-03T19:35:51.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-5b2e1e76-817b-42f7-b66c-09a1d716d202
+      - req-01a96637-ecc1-4a44-b7d7-a5355f96a1aa
       Date:
-      - Fri, 03 Aug 2018 19:35:52 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:52 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-b67d35c0-b5ff-4dbb-873c-fbc30094071f
+      - req-cd6ece87-5180-4f67-8c25-8e09be33eeee
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-3f1f7817-4464-4175-89b3-c5c5bd30cd09
+      - req-a800d261-8066-4f18-ac1f-72ca0731cf50
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-083cceef-67b7-4e15-8064-859a3befe995
+      - req-c96fb4a5-35b0-458d-927f-a4b30a0e4745
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1400,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-2619705f-f6a3-4418-b6cc-65191c154078
+      - req-a5b56449-69c6-4f3f-a44b-54eba318809a
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9d089ebb-8e49-44ce-92aa-98799a61a863
+      - req-11e11312-513d-4bcb-9c35-10d42fc5df66
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1441,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:53.779393", "expires":
-        "2018-08-03T20:35:53Z", "id": "7455c3e46bf94c089e419d4322d8b8a4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:56.257625", "expires":
+        "2018-08-06T17:59:56Z", "id": "0de681b6677b450899a0d95b079d4631", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["El1o9M4zQJ-OZic-FNQYsg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rR0pXbnfS8W_N0oR6MPYoA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,7 +1489,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7455c3e46bf94c089e419d4322d8b8a4
+      - 0de681b6677b450899a0d95b079d4631
   response:
     status:
       code: 300
@@ -1515,7 +1515,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -1528,7 +1528,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:53 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:53 GMT
+      - Mon, 06 Aug 2018 16:59:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f076ce1a-32c2-4a6f-8c85-80fa4d3a085f
+      - req-9bcb2025-1877-4798-a6e0-ce0e7aa83fa6
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:54.135305", "expires":
-        "2018-08-03T20:35:54Z", "id": "31a3847284384e55b8bf6d3ef8a5b930", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:56.623669", "expires":
+        "2018-08-06T17:59:56Z", "id": "d0423ae7a2ce4c428620b0f9ce1989a1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OyvR4BcmRpSEW2GnyiigRA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["o3bd5pc7T7K7D3QScp09wA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a3847284384e55b8bf6d3ef8a5b930
+      - d0423ae7a2ce4c428620b0f9ce1989a1
   response:
     status:
       code: 200
@@ -1634,9 +1634,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5443ab30-9ad1-46e4-8f1e-b97005773f6a
+      - req-c7088f7c-fb92-4294-b71c-59e647bd9909
       Date:
-      - Fri, 03 Aug 2018 19:35:54 GMT
+      - Mon, 06 Aug 2018 16:59:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1678,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a3847284384e55b8bf6d3ef8a5b930
+      - d0423ae7a2ce4c428620b0f9ce1989a1
   response:
     status:
       code: 200
@@ -1704,14 +1704,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-08d7ab3f-5b63-474d-aee0-718a7daefb8b
+      - req-154642eb-f887-4828-adbc-8aa20296bab1
       Date:
-      - Fri, 03 Aug 2018 19:35:54 GMT
+      - Mon, 06 Aug 2018 16:59:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:54 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1729,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:54 GMT
+      - Mon, 06 Aug 2018 16:59:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e68b8766-0cd1-4825-a1b0-3feca9583ea4
+      - req-58fe6f20-30a4-4542-9d3f-5ce3a69ac77b
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1744,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:55.084482", "expires":
-        "2018-08-03T20:35:55Z", "id": "b6637c54314440f6b4644149e49c22f3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:57.326561", "expires":
+        "2018-08-06T17:59:57Z", "id": "4f84cc04338b4c749bfe6c34d206b36c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["igbUGU6oQ5qJ-XDPyZVhVw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["P6kVfj_oQQSnUbgu2UYV2A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1791,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6637c54314440f6b4644149e49c22f3
+      - 4f84cc04338b4c749bfe6c34d206b36c
   response:
     status:
       code: 200
@@ -1817,9 +1817,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-97ba9f50-5627-4858-bd96-38c9f6550b31
+      - req-5f854669-abcc-4655-868c-2b0b69db0169
       Date:
-      - Fri, 03 Aug 2018 19:35:55 GMT
+      - Mon, 06 Aug 2018 16:59:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1861,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6637c54314440f6b4644149e49c22f3
+      - 4f84cc04338b4c749bfe6c34d206b36c
   response:
     status:
       code: 200
@@ -1887,14 +1887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4677fb97-a697-4d7e-897c-5b24e38abdce
+      - req-a20c3394-07a0-415a-a649-23f9c5519190
       Date:
-      - Fri, 03 Aug 2018 19:35:55 GMT
+      - Mon, 06 Aug 2018 16:59:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:55 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7455c3e46bf94c089e419d4322d8b8a4
+      - 0de681b6677b450899a0d95b079d4631
   response:
     status:
       code: 200
@@ -1920,9 +1920,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0d732d91-43ba-4d78-9e5d-3c22dfc5b4f2
+      - req-01dbc4de-39bd-47a2-9369-5170c3f5803c
       Date:
-      - Fri, 03 Aug 2018 19:35:56 GMT
+      - Mon, 06 Aug 2018 16:59:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1964,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7455c3e46bf94c089e419d4322d8b8a4
+      - 0de681b6677b450899a0d95b079d4631
   response:
     status:
       code: 200
@@ -1990,14 +1990,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-48b566aa-dac1-47b4-81c6-9a022ddd1b3a
+      - req-1f4f7839-ef34-4426-9e0d-2b077873f36f
       Date:
-      - Fri, 03 Aug 2018 19:35:56 GMT
+      - Mon, 06 Aug 2018 16:59:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +2015,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:56 GMT
+      - Mon, 06 Aug 2018 16:59:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a7f9207a-41da-4f61-960b-6014005ed33e
+      - req-08f735e1-5afe-43f9-8e16-e2bdc768d5a6
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +2030,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:56.696858", "expires":
-        "2018-08-03T20:35:56Z", "id": "2e9005bda01f4a18bef4a0fe7bdbae61", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:58.532641", "expires":
+        "2018-08-06T17:59:58Z", "id": "d6b1b9e707d94e36a94526cca19b3f6e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["CNG5PNRBS-S3yyJTKjmteA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EqjG-wwpTzWhW0I3O241Og"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +2077,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:56 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +2092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e9005bda01f4a18bef4a0fe7bdbae61
+      - d6b1b9e707d94e36a94526cca19b3f6e
   response:
     status:
       code: 200
@@ -2103,9 +2103,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a465f77f-ae28-4317-a7b6-5f65b790593e
+      - req-3d5953f5-7008-4db3-9992-f7a3a803d496
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +2147,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +2162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e9005bda01f4a18bef4a0fe7bdbae61
+      - d6b1b9e707d94e36a94526cca19b3f6e
   response:
     status:
       code: 200
@@ -2173,14 +2173,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3db1dd12-6f92-46ef-b846-a231dfa3c92e
+      - req-5b44998d-a72b-4707-a5cf-7311e9839773
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2208,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-fd8bc492-cfda-46d6-8e6f-edcffe8b3324
+      - req-13d25faa-3110-4ee6-8871-ae34b1866b78
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2220,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2248,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-f3e8e712-a56a-4edc-9a14-2dfc147e3093
+      - req-54ec7b60-d51c-4aaa-b041-6d8d08d6ee3d
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2260,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-711b6a4a-d717-46ad-bff2-f50b9b893ddf
+      - req-d3751315-2bd8-4a78-ae95-3801dda8fc47
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2300,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2328,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e80b0b67-d318-4ec0-a8c6-94617a577e89
+      - req-f3c943ae-71dd-40ad-a52e-ad7b68f69e0c
       Date:
-      - Fri, 03 Aug 2018 19:35:57 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2340,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:57 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2368,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-161523ab-b20d-4a5d-9bb3-74e080750932
+      - req-0b7b2954-8cd1-4c2f-918d-8c7df5136537
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2380,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:58 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ea9e7400-fc52-4946-a032-e949115f37f9
+      - req-7251dea6-8c0e-4924-b98b-c38c60705978
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 16:59:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2420,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2448,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-898f8eac-8259-44b3-b6db-4807a9d39ff0
+      - req-c4d61da0-d200-46c2-91ab-c74c4bada72a
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 17:00:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2460,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2488,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a034082f-68e9-45aa-874f-7b064821ac11
+      - req-582bacee-0254-4d98-9e91-8cbd090639d1
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 17:00:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2500,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2518,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 17:00:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-352e96fc-475a-4e18-bbf8-862e3711ff09
+      - req-5c460561-650e-4f52-8c82-8217f42dfe37
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2533,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:58.831318", "expires":
-        "2018-08-03T20:35:58Z", "id": "0ed43363971946fb9f2b668d53d0a071", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:00.491581", "expires":
+        "2018-08-06T18:00:00Z", "id": "63989ef7a2614b4c8601528c204dba77", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["FqcbbIDZS6unWpseuzp4Hw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YWUmcnCNSCuY50ZVm81sUw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2599,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:58 GMT
+      - Mon, 06 Aug 2018 17:00:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cec63d3c-40bd-4780-9178-22025ee4c382
+      - req-73331118-8585-4bdf-888d-21028b00f1ab
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2614,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:59.127335", "expires":
-        "2018-08-03T20:35:59Z", "id": "9e2cc301f01b4bdabe9a3c560a34265d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:00.852485", "expires":
+        "2018-08-06T18:00:00Z", "id": "219a6398964b4962bb220aab326166e3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jR_hOzeNTU25vpLbMkjVwA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IV9hLix8TMGrkovxExJ7hw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2661,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -2687,9 +2687,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-cc6a3d14-a9d5-43d0-a275-ac32c33dbdb2
+      - req-88a4bf95-c091-4215-93d6-8b841d188781
       Date:
-      - Fri, 03 Aug 2018 19:35:59 GMT
+      - Mon, 06 Aug 2018 17:00:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2723,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -2749,14 +2749,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7f4d69c9-619f-43f2-b4f7-dba42f4d6168
+      - req-905789f1-e476-44cc-b689-82427c50a8c0
       Date:
-      - Fri, 03 Aug 2018 19:35:59 GMT
+      - Mon, 06 Aug 2018 17:00:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2774,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:59 GMT
+      - Mon, 06 Aug 2018 17:00:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c7668ad4-d8b7-466e-976d-3e3c3ecf43eb
+      - req-568c84f3-9f49-4095-89b1-66f644a14466
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2789,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:00.046873", "expires":
-        "2018-08-03T20:35:59Z", "id": "f901b72f55a94cd39ce9e8e195e518a7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:01.794788", "expires":
+        "2018-08-06T18:00:01Z", "id": "814db331afec4f84be7ddb30a03e3f09", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JHr_jjMqQVSNA59P3l08mA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["W4yz6w0yThaBXQ-xOcc0qg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2836,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f901b72f55a94cd39ce9e8e195e518a7
+      - 814db331afec4f84be7ddb30a03e3f09
   response:
     status:
       code: 200
@@ -2862,14 +2862,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0bde30a2-c60c-464e-ad80-5318b9e6c3d9
+      - req-f1506344-2b98-41b5-84ee-71f6dcc44041
       Date:
-      - Fri, 03 Aug 2018 19:36:00 GMT
+      - Mon, 06 Aug 2018 17:00:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed43363971946fb9f2b668d53d0a071
+      - 63989ef7a2614b4c8601528c204dba77
   response:
     status:
       code: 200
@@ -2895,14 +2895,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-91e1969b-0359-4818-916e-ee68959b43b2
+      - req-2c4a56c3-c1f5-4a56-8860-85f745ca7263
       Date:
-      - Fri, 03 Aug 2018 19:36:00 GMT
+      - Mon, 06 Aug 2018 17:00:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:00 GMT
+      - Mon, 06 Aug 2018 17:00:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b92d32c2-bba3-4706-a7f4-c7c2baf43e92
+      - req-46eb2032-212b-43c2-8d3a-5d2bfae118fd
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:01.031305", "expires":
-        "2018-08-03T20:36:00Z", "id": "e589354c828749f4b64e821595d6b0da", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:02.739868", "expires":
+        "2018-08-06T18:00:02Z", "id": "d2e5507f087d45a1bcbb5881f49aa4fd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kbYdLHAOQ4-YdVb4Q9Phxw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wfg4notmRYaYY8dfEDB3Hw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2982,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:01 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e589354c828749f4b64e821595d6b0da
+      - d2e5507f087d45a1bcbb5881f49aa4fd
   response:
     status:
       code: 200
@@ -3008,14 +3008,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-fa91a824-d8f1-4359-94b8-1b413f9ea18b
+      - req-40923f00-d639-4c1c-8fa2-1039f426fafc
       Date:
-      - Fri, 03 Aug 2018 19:36:01 GMT
+      - Mon, 06 Aug 2018 17:00:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:01 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-59259716-c354-4b2e-9176-a505a982763e
+      - req-1e4a849b-1412-4536-aab4-fc14fed998f4
       Date:
-      - Fri, 03 Aug 2018 19:36:02 GMT
+      - Mon, 06 Aug 2018 17:00:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +3070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +3085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3096,9 +3096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9d8de025-5547-4b11-81f3-f1f1e8564522
+      - req-f67a3177-91b4-427d-be70-588086e32021
       Date:
-      - Fri, 03 Aug 2018 19:36:03 GMT
+      - Mon, 06 Aug 2018 17:00:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +3125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +3140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3151,9 +3151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e60f85b5-659c-4842-b2c4-22204fd2b37f
+      - req-7b941492-7cb0-46a4-b378-27d899102bb2
       Date:
-      - Fri, 03 Aug 2018 19:36:03 GMT
+      - Mon, 06 Aug 2018 17:00:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3206,9 +3206,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-a6393689-d1ed-4861-b0f1-2d2dbd1cd148
+      - req-110b8d82-e8e8-49f7-ac46-668f48b872e3
       Date:
-      - Fri, 03 Aug 2018 19:36:03 GMT
+      - Mon, 06 Aug 2018 17:00:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3264,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3290,9 +3290,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b0481e96-75d0-4a89-a20e-607e467a2e9f
+      - req-f11878be-7c71-41b9-ae6f-347cf343730d
       Date:
-      - Fri, 03 Aug 2018 19:36:04 GMT
+      - Mon, 06 Aug 2018 17:00:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3304,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:04 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,9 +3332,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-d1ecbb76-88ab-497c-b06f-1e32f0172903
+      - req-7ee8e9f0-096f-47ad-a2be-28b64eac644d
       Date:
-      - Fri, 03 Aug 2018 19:36:05 GMT
+      - Mon, 06 Aug 2018 17:00:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3380,7 +3380,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3408,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-bb469a2e-73f6-4db4-bb4a-b154120cb091
+      - req-e07dceaa-61bd-42b1-b70c-60634f242368
       Date:
-      - Fri, 03 Aug 2018 19:36:06 GMT
+      - Mon, 06 Aug 2018 17:00:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3456,7 +3456,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:06 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,9 +3484,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-52795693-1bf6-44df-bbdb-2c59a03a71d6
+      - req-157aab20-bfdf-4da0-b39b-b380244d2aad
       Date:
-      - Fri, 03 Aug 2018 19:36:07 GMT
+      - Mon, 06 Aug 2018 17:00:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3534,7 +3534,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:07 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3562,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-dd224f5e-6c05-43f4-a757-c6ba0729090d
+      - req-160be441-5b0b-49c2-a836-858f7381a98c
       Date:
-      - Fri, 03 Aug 2018 19:36:07 GMT
+      - Mon, 06 Aug 2018 17:00:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3606,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:07 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-13648d1e-fcce-4e0c-bbb5-02f95e0de2ea
+      - req-77ef48a0-7def-46f5-95cd-963eee30d907
       Date:
-      - Fri, 03 Aug 2018 19:36:08 GMT
+      - Mon, 06 Aug 2018 17:00:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3659,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3687,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-2275ab34-5112-4c40-9f38-c1f03757e1f4
+      - req-6e97405f-ce7b-4394-aa06-f012e2f34e15
       Date:
-      - Fri, 03 Aug 2018 19:36:08 GMT
+      - Mon, 06 Aug 2018 17:00:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3722,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-5bbcd9c7-9735-46cb-8145-ee891f6669e1
+      - req-2a13b63b-330e-4bc2-9f7e-859b9091565f
       Date:
-      - Fri, 03 Aug 2018 19:36:08 GMT
+      - Mon, 06 Aug 2018 17:00:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3757,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e7ead57f-9f34-465b-b869-9cf2c9e0903d
+      - req-9f4982de-f731-46cc-83a1-409ddf77e853
       Date:
-      - Fri, 03 Aug 2018 19:36:08 GMT
+      - Mon, 06 Aug 2018 17:00:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3790,9 +3790,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-56f44d39-0790-40f5-a1e2-9ccfa30571a9
+      - req-d4879db0-838e-4887-8289-4109189234ee
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3848,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3874,9 +3874,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-df249543-930a-4a58-82ed-ca8472546f69
+      - req-ffbc0217-c9f0-4308-ab5e-fed0bf2d1840
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3888,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-46583386-0b1d-48fc-8ae0-68b9f486946c
+      - req-dc0245a8-8501-4ed2-b5b0-fb5c76ee0776
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3972,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3987,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e2cc301f01b4bdabe9a3c560a34265d
+      - 219a6398964b4962bb220aab326166e3
   response:
     status:
       code: 200
@@ -3998,9 +3998,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-67ebaa88-ce80-43e2-b096-4db5c96019dd
+      - req-85752491-6d83-4c2d-9cab-65a6da29e979
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +4012,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +4027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +4040,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-ab75c3d7-f0a5-48d0-8c98-bd55ba01ee60
+      - req-46a3a883-d408-41ef-8015-4ac4e1dc0211
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +4051,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +4066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15729ae235cf499cb72e94e3fc02dcff
+      - 3155dbf6fed14fb1b8dce46bc6e1ae60
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +4079,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-38068f16-12ab-401c-af3c-fddbacd6fe65
+      - req-b1de8cde-e71e-4988-ab5d-6644100da5c7
       Date:
-      - Fri, 03 Aug 2018 19:36:09 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +4090,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +4105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +4118,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-343dc622-7e03-4872-bba5-10148a4b03dd
+      - req-46ed76fe-d396-4ba3-a9b3-26d2fbfc52ab
       Date:
-      - Fri, 03 Aug 2018 19:36:10 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +4129,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c595254e90094677a46e2b66130cf49e
+      - 0c66371c954d40358957e61a748e81d0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +4157,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6ce3b999-a800-48dc-8b07-265614fbf6f1
+      - req-dc477a84-a55b-4270-9052-d9a8cfaa2d09
       Date:
-      - Fri, 03 Aug 2018 19:36:10 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4168,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4186,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:10 GMT
+      - Mon, 06 Aug 2018 17:00:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86b79720-cf88-4db4-98ac-6d95de9a1cc9
+      - req-08f19ccf-d6ff-4eb9-880a-b2980049de54
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4201,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:10.455136", "expires":
-        "2018-08-03T20:36:10Z", "id": "98684f4789ce4339ab9d7345932c280f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:11.846922", "expires":
+        "2018-08-06T18:00:11Z", "id": "decfc8b9eb7146819ee0df0822d82d3d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CIs-ynsASliOpvgITH0_Zw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3D4qnOcmSL2ICRDxti2XlA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4248,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f9bbbe4f-ad3e-49b0-b3a6-cdc8ec577a3d
+      - req-832291ab-6d0e-4e3a-ac77-243969bd1cd2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f9bbbe4f-ad3e-49b0-b3a6-cdc8ec577a3d
+      - req-832291ab-6d0e-4e3a-ac77-243969bd1cd2
       Date:
-      - Fri, 03 Aug 2018 19:36:11 GMT
+      - Mon, 06 Aug 2018 17:00:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4288,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4306,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:11 GMT
+      - Mon, 06 Aug 2018 17:00:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4885bbfe-91fd-4ed5-9bb3-ebf0bd9d1179
+      - req-fd5d37c0-70b0-4f47-be38-ded3befed868
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4321,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:11.616561", "expires":
-        "2018-08-03T20:36:11Z", "id": "fdfa5ff734a74fa6a4e87ce600385f0b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:12.627330", "expires":
+        "2018-08-06T18:00:12Z", "id": "4600c460134943d289621988e0ea8124", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Y9dLZ8qsTH2iOZZrZvoncg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["AOOfbRFyRXy_A-KqUsA_KA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4368,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4383,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdfa5ff734a74fa6a4e87ce600385f0b
+      - 4600c460134943d289621988e0ea8124
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-481bca17-dd73-4a9e-9f2c-d38639ff1339
+      - req-3fbc6a43-a288-4876-908b-63a7019c239c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-481bca17-dd73-4a9e-9f2c-d38639ff1339
+      - req-3fbc6a43-a288-4876-908b-63a7019c239c
       Date:
-      - Fri, 03 Aug 2018 19:36:12 GMT
+      - Mon, 06 Aug 2018 17:00:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4408,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4423,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e9f03be-3436-4ed4-83f0-bb4da5dfeda7
+      - req-8e4149a9-4998-4af4-aa67-608b8141aa05
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1e9f03be-3436-4ed4-83f0-bb4da5dfeda7
+      - req-8e4149a9-4998-4af4-aa67-608b8141aa05
       Date:
-      - Fri, 03 Aug 2018 19:36:13 GMT
+      - Mon, 06 Aug 2018 17:00:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4448,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:13 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:13 GMT
+      - Mon, 06 Aug 2018 17:00:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d20e4acd-a65a-462a-b3f7-d1ee5d7b00fa
+      - req-f716356c-5b32-455c-99f2-627bb1e572fd
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:13.615441", "expires":
-        "2018-08-03T20:36:13Z", "id": "95cb53b70da540429d661ef304bae3ee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:14.907527", "expires":
+        "2018-08-06T18:00:14Z", "id": "e10a5d8d663f46b6a7bd8d11d35eba60", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["IE9d7H1CQZmSYsrH_g8hgw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Hf4mQkPoRfOqbe1oVpoSTw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:13 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4543,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95cb53b70da540429d661ef304bae3ee
+      - e10a5d8d663f46b6a7bd8d11d35eba60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e7a3bc2-7e95-41be-b495-8167de76d97b
+      - req-5107a805-f488-4348-a1a7-f2fc363f8e3b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4e7a3bc2-7e95-41be-b495-8167de76d97b
+      - req-5107a805-f488-4348-a1a7-f2fc363f8e3b
       Date:
-      - Fri, 03 Aug 2018 19:36:14 GMT
+      - Mon, 06 Aug 2018 17:00:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4568,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:14 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:14 GMT
+      - Mon, 06 Aug 2018 17:00:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e8741ce6-083d-4c9a-bc32-97018e708443
+      - req-18534c89-2130-427d-9fec-2683e6872cf5
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:14.642704", "expires":
-        "2018-08-03T20:36:14Z", "id": "b75fc6b6b24c417dad47cfccc7ef5d74", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:15.666900", "expires":
+        "2018-08-06T18:00:15Z", "id": "e8b4e3d0c7114c7380c010a01a0a1efc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uAZgXjs4Sqerw_evr3Z9Sw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QLVkOA_RQLuxKCXNA-OM8Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,7 +4649,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:14 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -4664,7 +4664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fc6b6b24c417dad47cfccc7ef5d74
+      - e8b4e3d0c7114c7380c010a01a0a1efc
   response:
     status:
       code: 200
@@ -4675,13 +4675,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:36:14 GMT
+      - Mon, 06 Aug 2018 17:00:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:14 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4699,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:14 GMT
+      - Mon, 06 Aug 2018 17:00:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-71c2ad94-5ca5-475b-941f-f99056250158
+      - req-463b07f4-8671-4799-b04b-8a37a940c6c3
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4714,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:15.014206", "expires":
-        "2018-08-03T20:36:14Z", "id": "1943d59c06e445b6a93710bf2a90e05b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:16.032814", "expires":
+        "2018-08-06T18:00:15Z", "id": "b3fa122ed0614b90b5544d0b89f48bfe", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["nUo8E7xxTIqhCvKHbDoqPA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mL7T7zc6RAWN816eXHOPZw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4761,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:15 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1943d59c06e445b6a93710bf2a90e05b
+      - b3fa122ed0614b90b5544d0b89f48bfe
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-604aa92d-7134-4a24-845b-5ccddd0f72f4
+      - req-4b43ccc3-b7f1-4ddc-94a1-3c957983a8e8
       Date:
-      - Fri, 03 Aug 2018 19:36:15 GMT
+      - Mon, 06 Aug 2018 17:00:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:15 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4814,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:15 GMT
+      - Mon, 06 Aug 2018 17:00:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7af07226-c13a-466f-acaf-216d6a163ed4
+      - req-50259896-6c8f-4f5e-8d18-8ddb30f4a457
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4829,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:15.850835", "expires":
-        "2018-08-03T20:36:15Z", "id": "9464378fd4e44467b9b255dbd9e8dc50", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:16.511619", "expires":
+        "2018-08-06T18:00:16Z", "id": "1db67d4e2a5140c4ae9d578e40ff869e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["g4EA5ldRRyeo5WIqoibdtA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2LXnZRlfRLK69kyRx-6YFA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4876,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:15 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9464378fd4e44467b9b255dbd9e8dc50
+      - 1db67d4e2a5140c4ae9d578e40ff869e
   response:
     status:
       code: 200
@@ -4902,16 +4902,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8b0ca0ac-98c2-47a2-a5a8-90161ccab8ad
+      - req-29ba3805-38d4-403a-9261-e3e100133e1a
       Date:
-      - Fri, 03 Aug 2018 19:36:16 GMT
+      - Mon, 06 Aug 2018 17:00:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fc6b6b24c417dad47cfccc7ef5d74
+      - e8b4e3d0c7114c7380c010a01a0a1efc
   response:
     status:
       code: 200
@@ -4937,16 +4937,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-604e5a69-24ab-4bea-b763-d00e9f42a22e
+      - req-c6a24d28-cbee-4999-a8be-7e813b85d363
       Date:
-      - Fri, 03 Aug 2018 19:36:16 GMT
+      - Mon, 06 Aug 2018 17:00:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:16 GMT
+      - Mon, 06 Aug 2018 17:00:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-27ba2cc2-ad24-450c-ad5b-6d86d38f03b8
+      - req-766c54eb-9de5-443c-996e-4f4cab90e097
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:16.807507", "expires":
-        "2018-08-03T20:36:16Z", "id": "2f108d00b7e14d3c803e1e39d4fe5a68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:17.141096", "expires":
+        "2018-08-06T18:00:17Z", "id": "e9109594d130493facbc8bf5abc8cf9a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["v33PD8MyTFGI85f_iC6YVw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BR_loN2wSJqBaT9P8L-Abw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +5026,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +5041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f108d00b7e14d3c803e1e39d4fe5a68
+      - e9109594d130493facbc8bf5abc8cf9a
   response:
     status:
       code: 200
@@ -5052,16 +5052,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6bc9d556-0c87-4945-b034-a98dcf52477e
+      - req-b78468b3-05e2-4535-bcd8-0dcd4e75f4ef
       Date:
-      - Fri, 03 Aug 2018 19:36:17 GMT
+      - Mon, 06 Aug 2018 17:00:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:17 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +5076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +5089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-8a6a01a0-4b86-4df3-89df-a027ac5928f3
+      - req-3d1fac2f-23a7-41cb-be62-815c1e3dd832
       Date:
-      - Fri, 03 Aug 2018 19:36:17 GMT
+      - Mon, 06 Aug 2018 17:00:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +5114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:17 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +5129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +5142,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-fce6377e-1e49-45bf-9f2c-77671e1bfdf8
+      - req-3559df95-f2e8-4ebf-a6be-c228b0bae4bd
       Date:
-      - Fri, 03 Aug 2018 19:36:17 GMT
+      - Mon, 06 Aug 2018 17:00:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +5167,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:17 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +5182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +5195,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d7faa212-87da-439f-bb7b-de2dd22ccc7a
+      - req-cac5869e-2d6e-4655-9750-d33c7aa5bc4d
       Date:
-      - Fri, 03 Aug 2018 19:36:18 GMT
+      - Mon, 06 Aug 2018 17:00:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5220,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5248,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-8d8df122-d568-4c6a-b3eb-441011240404
+      - req-1797cca9-7134-4564-960c-76c6211b6f9d
       Date:
-      - Fri, 03 Aug 2018 19:36:18 GMT
+      - Mon, 06 Aug 2018 17:00:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5273,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5301,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-f3b6ead1-926c-4fde-826d-3d43af76fbf4
+      - req-d29cd86b-e9d5-4eb2-a254-68c28b416130
       Date:
-      - Fri, 03 Aug 2018 19:36:18 GMT
+      - Mon, 06 Aug 2018 17:00:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5326,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5354,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-b9d61cc2-88a9-44d0-9e6c-60c3f9badd27
+      - req-b9964120-a6a5-416d-88e6-a0984c46ffe1
       Date:
-      - Fri, 03 Aug 2018 19:36:19 GMT
+      - Mon, 06 Aug 2018 17:00:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5390,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-30f7d847-a34a-4fd2-adbf-e8f2cbbc0e02
+      - req-d14508dd-b8ff-4c40-9d0f-958dad6be408
       Date:
-      - Fri, 03 Aug 2018 19:36:19 GMT
+      - Mon, 06 Aug 2018 17:00:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5415,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5443,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-e1db6ab5-a8b5-4784-b862-79df0ad850e5
+      - req-2c7df7ca-bda0-4ded-8098-c1cd5dace56f
       Date:
-      - Fri, 03 Aug 2018 19:36:19 GMT
+      - Mon, 06 Aug 2018 17:00:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5479,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-52e5b813-575f-4081-ae19-e9e6290bbf05
+      - req-1040897e-8d70-4dc0-a021-c2db58275072
       Date:
-      - Fri, 03 Aug 2018 19:36:20 GMT
+      - Mon, 06 Aug 2018 17:00:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5504,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5532,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1dedc4a9-bfaa-4048-9b2d-ac0167520612
+      - req-384a1edf-59b1-4ca8-97ff-77b5b983c218
       Date:
-      - Fri, 03 Aug 2018 19:36:20 GMT
+      - Mon, 06 Aug 2018 17:00:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5557,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c57b27f0564e6094c99e6dbb626fcf
+      - cd85a4926736420da6cd4881729d1172
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5585,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d93ea674-e180-4949-9ef8-71b9daaa86d1
+      - req-df892f7e-d7e6-459c-ac93-bc22731d10c5
       Date:
-      - Fri, 03 Aug 2018 19:36:20 GMT
+      - Mon, 06 Aug 2018 17:00:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5610,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5628,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:21 GMT
+      - Mon, 06 Aug 2018 17:00:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-61cb4ec4-8057-4f57-94e1-763c9926ac93
+      - req-619d37eb-2b09-4f05-a97e-f5cd9c1d210e
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5643,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:21.322440", "expires":
-        "2018-08-03T20:36:21Z", "id": "532a3f7bb4464884b56749ae59a06648", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:20.815007", "expires":
+        "2018-08-06T18:00:20Z", "id": "99dea2b5355640f688504cab769f168b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6tv_NqZRQXuAFvyxMO1rnw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0SZ8GCw0TeOT7cCLtVjIuA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,13 +5691,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"532a3f7bb4464884b56749ae59a06648"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"99dea2b5355640f688504cab769f168b"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5709,13 +5709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:21 GMT
+      - Mon, 06 Aug 2018 17:00:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d3296cd2-6691-40ca-b1ce-2f35ae584b55
+      - req-c62e3dd8-3558-4a37-a827-9c8e3d7d24bc
       Content-Length:
       - '4196'
       Connection:
@@ -5724,10 +5724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:21.692169", "expires":
-        "2018-08-03T20:36:21Z", "id": "f09199dd228047aba3d05da068b5f475", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.011633", "expires":
+        "2018-08-06T18:00:20Z", "id": "adaf4faeb7f6498592ef6e96fd6840f5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ueK3lcDhS8C3e0PFge8rbg", "6tv_NqZRQXuAFvyxMO1rnw"]},
+        "name": "admin"}, "audit_ids": ["0ChIQ0jjRmyYM9rd9nNYww", "0SZ8GCw0TeOT7cCLtVjIuA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5772,7 +5772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:21 GMT
+      - Mon, 06 Aug 2018 17:00:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f675e8c-3165-40ea-8191-161ad36d543c
+      - req-7d8020f5-a2f6-44e1-bdf7-53860bdfef05
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:22.029608", "expires":
-        "2018-08-03T20:36:21Z", "id": "2819d9edda5d423384e2cfa7b7fa7183", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.218728", "expires":
+        "2018-08-06T18:00:21Z", "id": "f579051adf134a85abe4cd639bffb4b0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_gq-E3R-Soum7PthhBihyg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mfa_Ckf7TfyRluzatXrglA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,13 +5853,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"2819d9edda5d423384e2cfa7b7fa7183"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"f579051adf134a85abe4cd639bffb4b0"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5871,13 +5871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:22 GMT
+      - Mon, 06 Aug 2018 17:00:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aac5d2e3-74ef-4513-b8f7-3186355a7db1
+      - req-ec2ececc-e01d-4130-be6f-f13ca56665ec
       Content-Length:
       - '4196'
       Connection:
@@ -5886,10 +5886,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:22.362556", "expires":
-        "2018-08-03T20:36:21Z", "id": "e3dce460df564412b26eee0b3b25ddd9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.432734", "expires":
+        "2018-08-06T18:00:21Z", "id": "0f0ffae2a7cc404faf60cbf47cfbb76c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["5OO-KGDMQ0yoGwBTdQEmtw", "_gq-E3R-Soum7PthhBihyg"]},
+        "name": "admin"}, "audit_ids": ["9UOnWyksSPCYH2y9CTFmkg", "mfa_Ckf7TfyRluzatXrglA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5934,7 +5934,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 615909c359d042b0b60946446108189f
+      - 56fa1691c6fb4af3b50a1cf2ad67cc53
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5962,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-a0b49327-9395-4c63-9bb8-63dc7d283244
+      - req-fa448189-ced8-4096-b4ea-e07a884fb0fb
       Date:
-      - Fri, 03 Aug 2018 19:36:22 GMT
+      - Mon, 06 Aug 2018 17:00:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5984,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce061ee6-8a28-4465-aa44-7071fdd9d401
+      - req-d4017457-1010-4d3e-9e24-9d26048f5bbf
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-ce061ee6-8a28-4465-aa44-7071fdd9d401
+      - req-d4017457-1010-4d3e-9e24-9d26048f5bbf
       Date:
-      - Fri, 03 Aug 2018 19:36:22 GMT
+      - Mon, 06 Aug 2018 17:00:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +6032,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +6047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9af52658-f1f7-453b-8d03-755181bf3031
+      - req-93e47bab-17cc-4b1a-a2d0-ba8f9e10de58
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-9af52658-f1f7-453b-8d03-755181bf3031
+      - req-93e47bab-17cc-4b1a-a2d0-ba8f9e10de58
       Date:
-      - Fri, 03 Aug 2018 19:36:23 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +6079,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +6094,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdfa5ff734a74fa6a4e87ce600385f0b
+      - 4600c460134943d289621988e0ea8124
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8556988e-d0d0-4f4b-a55f-3fa15fddcdf4
+      - req-5ece68a9-4623-4ac4-bf7e-56106e367580
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8556988e-d0d0-4f4b-a55f-3fa15fddcdf4
+      - req-5ece68a9-4623-4ac4-bf7e-56106e367580
       Date:
-      - Fri, 03 Aug 2018 19:36:23 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +6129,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-beb309cc-eeb6-4a72-b731-61c41f2fd6a4
+      - req-c7e5df97-cea0-4029-b060-6abba13104a9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-beb309cc-eeb6-4a72-b731-61c41f2fd6a4
+      - req-c7e5df97-cea0-4029-b060-6abba13104a9
       Date:
-      - Fri, 03 Aug 2018 19:36:23 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +6164,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95cb53b70da540429d661ef304bae3ee
+      - e10a5d8d663f46b6a7bd8d11d35eba60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ef25f2b0-3333-4c9b-b46a-52d0ac9b4234
+      - req-ed7368fe-8d49-4260-ba32-8039fb7b456d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ef25f2b0-3333-4c9b-b46a-52d0ac9b4234
+      - req-ed7368fe-8d49-4260-ba32-8039fb7b456d
       Date:
-      - Fri, 03 Aug 2018 19:36:24 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +6199,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f90a00d-b264-499c-a6d4-071a5d4cd0fd
+      - req-b2b9457c-f340-4ea5-9788-aaf75249e7a3
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-9f90a00d-b264-499c-a6d4-071a5d4cd0fd
+      - req-b2b9457c-f340-4ea5-9788-aaf75249e7a3
       Date:
-      - Fri, 03 Aug 2018 19:36:24 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +6229,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +6244,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-90448f7c-e50a-4cd5-9f7f-f91b05f2e964
+      - req-d427ff95-82c8-4c89-89e1-733ceb0008b7
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-90448f7c-e50a-4cd5-9f7f-f91b05f2e964
+      - req-d427ff95-82c8-4c89-89e1-733ceb0008b7
       Date:
-      - Fri, 03 Aug 2018 19:36:24 GMT
+      - Mon, 06 Aug 2018 17:00:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +6274,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +6289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdfa5ff734a74fa6a4e87ce600385f0b
+      - 4600c460134943d289621988e0ea8124
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a8066a1-e698-4874-9dc4-98e76639698a
+      - req-51973732-9e2e-4b3b-9f38-627b2bde1e5f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4a8066a1-e698-4874-9dc4-98e76639698a
+      - req-51973732-9e2e-4b3b-9f38-627b2bde1e5f
       Date:
-      - Fri, 03 Aug 2018 19:36:24 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +6324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdfa5ff734a74fa6a4e87ce600385f0b
+      - 4600c460134943d289621988e0ea8124
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8550ef87-10c9-4033-bee5-65ad69860859
+      - req-2e6468a5-d0bf-4547-a1e6-216ea131de19
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8550ef87-10c9-4033-bee5-65ad69860859
+      - req-2e6468a5-d0bf-4547-a1e6-216ea131de19
       Date:
-      - Fri, 03 Aug 2018 19:36:24 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b77d8ae2-efac-4e0a-ac05-e0a2b266697e
+      - req-39d06fc6-1d2f-48e1-991f-6085e4f93bfc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b77d8ae2-efac-4e0a-ac05-e0a2b266697e
+      - req-39d06fc6-1d2f-48e1-991f-6085e4f93bfc
       Date:
-      - Fri, 03 Aug 2018 19:36:25 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d586ee07-3ed2-42e1-9be8-e3514a2673f5
+      - req-0535fee3-4d1e-4057-b446-c3bef04eb283
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d586ee07-3ed2-42e1-9be8-e3514a2673f5
+      - req-0535fee3-4d1e-4057-b446-c3bef04eb283
       Date:
-      - Fri, 03 Aug 2018 19:36:25 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95cb53b70da540429d661ef304bae3ee
+      - e10a5d8d663f46b6a7bd8d11d35eba60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0ad3010-b976-49d3-8820-371e17228663
+      - req-90cf5285-b818-4a3f-b7c0-6b7a29c9b2b3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d0ad3010-b976-49d3-8820-371e17228663
+      - req-90cf5285-b818-4a3f-b7c0-6b7a29c9b2b3
       Date:
-      - Fri, 03 Aug 2018 19:36:25 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95cb53b70da540429d661ef304bae3ee
+      - e10a5d8d663f46b6a7bd8d11d35eba60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f1adbea-c106-4429-b14b-92b647afe13e
+      - req-acbf4233-c08b-4ea7-a00d-7bc994ad1090
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5f1adbea-c106-4429-b14b-92b647afe13e
+      - req-acbf4233-c08b-4ea7-a00d-7bc994ad1090
       Date:
-      - Fri, 03 Aug 2018 19:36:25 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6499,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd3dd4d4-9d44-4abe-b376-d042db2d4165
+      - req-033cf682-023d-488b-a1a4-86a09ef2c83b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-fd3dd4d4-9d44-4abe-b376-d042db2d4165
+      - req-033cf682-023d-488b-a1a4-86a09ef2c83b
       Date:
-      - Fri, 03 Aug 2018 19:36:25 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6547,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6562,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-128d0d36-3e57-40ff-a0ac-965a94162dba
+      - req-4af4656d-4ce0-4082-8694-9790861bcdc3
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-128d0d36-3e57-40ff-a0ac-965a94162dba
+      - req-4af4656d-4ce0-4082-8694-9790861bcdc3
       Date:
-      - Fri, 03 Aug 2018 19:36:26 GMT
+      - Mon, 06 Aug 2018 17:00:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6618,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:26 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6633,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1da223b8-1836-4bad-a723-12fd6bd1ce9d
+      - req-eee1e376-9313-449f-b0b5-83b9c46b5ca9
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-1da223b8-1836-4bad-a723-12fd6bd1ce9d
+      - req-eee1e376-9313-449f-b0b5-83b9c46b5ca9
       Date:
-      - Fri, 03 Aug 2018 19:36:26 GMT
+      - Mon, 06 Aug 2018 17:00:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6682,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:26 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6697,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98684f4789ce4339ab9d7345932c280f
+      - decfc8b9eb7146819ee0df0822d82d3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87b27db0-ed07-41b9-8d00-6d227f74bbbc
+      - req-25fc8d99-0aed-4efe-ade5-1caa4a6369c9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-87b27db0-ed07-41b9-8d00-6d227f74bbbc
+      - req-25fc8d99-0aed-4efe-ade5-1caa4a6369c9
       Date:
-      - Fri, 03 Aug 2018 19:36:26 GMT
+      - Mon, 06 Aug 2018 17:00:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:26 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6732,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdfa5ff734a74fa6a4e87ce600385f0b
+      - 4600c460134943d289621988e0ea8124
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df76d752-0951-4bc9-afc8-3f099d8e35cb
+      - req-6d196288-097b-482d-a77c-24b05a4db4dc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-df76d752-0951-4bc9-afc8-3f099d8e35cb
+      - req-6d196288-097b-482d-a77c-24b05a4db4dc
       Date:
-      - Fri, 03 Aug 2018 19:36:27 GMT
+      - Mon, 06 Aug 2018 17:00:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:27 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6767,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c7e1237709549489012c5fcb1b011e5
+      - 8efeefad72744c61821793b8a51068c6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2abfcdab-08f2-48d4-b3ce-1909c8d8bf48
+      - req-6f58466f-d2e1-4e5d-ad56-c9f13572350c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2abfcdab-08f2-48d4-b3ce-1909c8d8bf48
+      - req-6f58466f-d2e1-4e5d-ad56-c9f13572350c
       Date:
-      - Fri, 03 Aug 2018 19:36:27 GMT
+      - Mon, 06 Aug 2018 17:00:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:27 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6802,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95cb53b70da540429d661ef304bae3ee
+      - e10a5d8d663f46b6a7bd8d11d35eba60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0ccbc93-a153-4e2b-8ab4-3a1c8591c46e
+      - req-5458482f-9dec-4a95-bebb-f07c01d37503
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c0ccbc93-a153-4e2b-8ab4-3a1c8591c46e
+      - req-5458482f-9dec-4a95-bebb-f07c01d37503
       Date:
-      - Fri, 03 Aug 2018 19:36:27 GMT
+      - Mon, 06 Aug 2018 17:00:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:27 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6840,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:28 GMT
+      - Mon, 06 Aug 2018 17:00:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-65f9921c-e0b6-4af4-88ba-ce2c80f5a6c8
+      - req-17d2e2fe-2d41-41f8-bc8a-c71ea7c6f4ba
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6855,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:28.568447", "expires":
-        "2018-08-03T20:36:28Z", "id": "fc11f3674df146ce931aacd10a9f0fa7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:26.218965", "expires":
+        "2018-08-06T18:00:26Z", "id": "6657527c56ea4bb5ac4234c33d329961", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1ifMba15RGqR2VT5Ika0aw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["opnvYdn_TP67xBORuESOjw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6903,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:28 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:28 GMT
+      - Mon, 06 Aug 2018 17:00:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee6f865e-727d-4870-9380-b37bf3a736a5
+      - req-c12e2e64-2491-4b85-9b84-88fbe0cf7683
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6936,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:28.852683", "expires":
-        "2018-08-03T20:36:28Z", "id": "0c5069f8f79e48bdbc1eb877b2a884a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:26.546876", "expires":
+        "2018-08-06T18:00:26Z", "id": "148376632eb54dcca8a03dd4ef0e7a6f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vaOkx540ThaUolc-R7pmMA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DvYy2NKTQUKf8umjfxyVgg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6984,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:28 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -7010,17 +7010,57 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-c35e254b-c5b7-4b3f-8511-3575f1c5cda3
+      - req-c2dc136f-32fa-4630-a686-08d2e61204f7
       Date:
-      - Fri, 03 Aug 2018 19:36:29 GMT
+      - Mon, 06 Aug 2018 17:00:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
@@ -7030,59 +7070,19 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        53}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +7100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:29 GMT
+      - Mon, 06 Aug 2018 17:00:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f90af4e7-deb4-4323-bc50-f96820eafacd
+      - req-f36dd0f1-df90-47af-8906-09bcc28da255
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +7115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:29.609809", "expires":
-        "2018-08-03T20:36:29Z", "id": "ca2dc5a3d9b544a2a3d1a451ab8a61ea", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.436485", "expires":
+        "2018-08-06T18:00:27Z", "id": "1d986e079c3e4cb7bc2eceb0b7fa3022", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Mh1s38IfRDy5AI1N0bk7Cg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xkF-VW8NS9epxTjHFOQTbw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,7 +7163,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7181,13 +7181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:29 GMT
+      - Mon, 06 Aug 2018 17:00:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d7685a86-7b2b-499c-974e-d1447b86c38d
+      - req-c471d708-e11f-40c5-9430-6ffeb585b91d
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +7196,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:29.794505", "expires":
-        "2018-08-03T20:36:29Z", "id": "3b1257d2a2e143fc963cd8e926079ce9", "audit_ids":
-        ["zzHL0jxOQI2Z4yx5vPu9ug"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.586909", "expires":
+        "2018-08-06T18:00:27Z", "id": "f28bd9a6f26d4218a224620734b3802f", "audit_ids":
+        ["jfw2_JNqQDGodtay4q11iQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +7217,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b1257d2a2e143fc963cd8e926079ce9
+      - f28bd9a6f26d4218a224620734b3802f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:29 GMT
+      - Mon, 06 Aug 2018 17:00:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a3681277-0d11-4fb8-86c3-e40e7b0e7439
+      - req-4d32098d-ff8d-4d81-96c7-dd487297f82c
       Content-Length:
       - '500'
       Connection:
@@ -7247,13 +7247,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"3b1257d2a2e143fc963cd8e926079ce9"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"f28bd9a6f26d4218a224620734b3802f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7265,13 +7265,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:30 GMT
+      - Mon, 06 Aug 2018 17:00:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6d59d5ab-170d-470d-824b-9e6f51368bba
+      - req-6dfb0b9b-90ae-4023-adf6-572b309aa4b1
       Content-Length:
       - '4143'
       Connection:
@@ -7280,11 +7280,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:30.246569", "expires":
-        "2018-08-03T20:36:29Z", "id": "5b3774b062e148d8957186cd3964de09", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.937877", "expires":
+        "2018-08-06T18:00:27Z", "id": "eb142ec3e2484edab88b1a78bf2068d3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xNr9lxpdRpC_V_XbLRkN_g",
-        "zzHL0jxOQI2Z4yx5vPu9ug"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jNSU56yfQ7KhnmWtSggUgg",
+        "jfw2_JNqQDGodtay4q11iQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7328,7 +7328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7343,20 +7343,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b1257d2a2e143fc963cd8e926079ce9
+      - f28bd9a6f26d4218a224620734b3802f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:30 GMT
+      - Mon, 06 Aug 2018 17:00:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9bfe66fc-4d81-4501-8de5-623e94cd3015
+      - req-5c742e0e-2271-460b-92c8-6ebaad21f020
       Content-Length:
       - '500'
       Connection:
@@ -7373,7 +7373,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +7391,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:30 GMT
+      - Mon, 06 Aug 2018 17:00:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b061dfc-120c-4a73-a3b1-9c126c22284c
+      - req-2286173c-9125-4843-889a-32306a6bf90c
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +7406,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:30.720605", "expires":
-        "2018-08-03T20:36:30Z", "id": "b065a45043dd420f86c622b831b49aba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.398925", "expires":
+        "2018-08-06T18:00:28Z", "id": "cef81a1510804f9d9ae608207226e7fc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5J_5RA0yTrKayDmLm5fAWg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OYA97JFuS0Cc8TMPbC77Vg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +7453,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +7471,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:30 GMT
+      - Mon, 06 Aug 2018 17:00:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d7cc1bd-ac18-4642-afdf-5c862a072f1e
+      - req-ea743871-4a4d-4b03-b1cc-758c65f135f4
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7486,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:31.017632", "expires":
-        "2018-08-03T20:36:30Z", "id": "07d88c44a096441f9797a261d4455bea", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.602984", "expires":
+        "2018-08-06T18:00:28Z", "id": "e43f47204b9e495ead9152ca38722974", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["RudhgRZcRq2LetAA2pEFKg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kTP0wJcYQxWmW7zwJ842bA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7533,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7551,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:31 GMT
+      - Mon, 06 Aug 2018 17:00:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb32a4b7-d057-47b1-9d5b-38f9b300048b
+      - req-59bfbb5a-172c-43be-82fe-53b6e7c75b21
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7566,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:31.394738", "expires":
-        "2018-08-03T20:36:31Z", "id": "eaf56135b6774645b165f4d022f1b6f4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.833214", "expires":
+        "2018-08-06T18:00:28Z", "id": "1945eff6721542b1b0ef3a3fc4e999af", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["p52uMAuLS0Su8EoiBLRhqg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e3K2w54DSLCq-top_JbV7Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7613,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7631,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:31 GMT
+      - Mon, 06 Aug 2018 17:00:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ae1c870b-d6d8-4a40-b9c6-4e530609cf79
+      - req-4f621a60-25ef-456a-aa49-c4a89e8d31c3
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7646,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:31.783131", "expires":
-        "2018-08-03T20:36:31Z", "id": "7b8de2e7ae0a4e2d913db033dc074068", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:29.028880", "expires":
+        "2018-08-06T18:00:29Z", "id": "8158b40268cf49b8ae549525c4829180", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9OLoWi2fR-moeIYAnky1cA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8SjZkZhcR8CYfex55vJXUg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7693,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -7719,9 +7719,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-f2622719-8daf-450b-abbc-e00a25442b6c
+      - req-86fb6c1a-0a63-4ed1-aec6-de69586b6a49
       Date:
-      - Fri, 03 Aug 2018 19:36:32 GMT
+      - Mon, 06 Aug 2018 17:00:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7755,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -7781,14 +7781,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-06a73239-24a9-4695-b1e6-73d51d63b7be
+      - req-ac5d2c0f-c22d-4b3d-8520-093dd0cc5f22
       Date:
-      - Fri, 03 Aug 2018 19:36:32 GMT
+      - Mon, 06 Aug 2018 17:00:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7806,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:32 GMT
+      - Mon, 06 Aug 2018 17:00:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3d289b91-710c-48db-a097-f47fe1a418ee
+      - req-d70eef14-d96c-4e9a-974d-8ccd9e97dee6
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7821,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:32.685558", "expires":
-        "2018-08-03T20:36:32Z", "id": "9568c4d99ee1448f9f8e7845a93c6bd4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:29.928437", "expires":
+        "2018-08-06T18:00:29Z", "id": "378d5635795b44efb68da5ef518103c7", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["m2KbaYGORmy5GMb9B4Im3Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JS18N_WISpKZR53Lvbx2xg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7868,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7883,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9568c4d99ee1448f9f8e7845a93c6bd4
+      - 378d5635795b44efb68da5ef518103c7
   response:
     status:
       code: 200
@@ -7894,14 +7894,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a3c18ff1-0d64-4381-83c1-7e28f9f855fb
+      - req-9f067edb-296f-4a81-b1d1-cc137dad62b8
       Date:
-      - Fri, 03 Aug 2018 19:36:33 GMT
+      - Mon, 06 Aug 2018 17:00:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca2dc5a3d9b544a2a3d1a451ab8a61ea
+      - 1d986e079c3e4cb7bc2eceb0b7fa3022
   response:
     status:
       code: 200
@@ -7927,14 +7927,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2af06762-b115-4710-bfb1-26d7c1a717c0
+      - req-2e3ac978-4016-4b4b-b301-66cbb683f3c0
       Date:
-      - Fri, 03 Aug 2018 19:36:33 GMT
+      - Mon, 06 Aug 2018 17:00:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7952,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:33 GMT
+      - Mon, 06 Aug 2018 17:00:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d3358cb1-879c-4495-a433-8df59c5f2bf0
+      - req-927ad627-100e-43e9-9e22-f5b844fa0253
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7967,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:33.717340", "expires":
-        "2018-08-03T20:36:33Z", "id": "a8dc0967708a45ec9fac8bfa223b13bb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:30.965804", "expires":
+        "2018-08-06T18:00:30Z", "id": "b1250283d614402784ee1ece1fd1f93a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JmOZ7a2rTKydaG1p0bIluA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["i57aSqSFR3Sq3mregEboxQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +8014,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +8029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a8dc0967708a45ec9fac8bfa223b13bb
+      - b1250283d614402784ee1ece1fd1f93a
   response:
     status:
       code: 200
@@ -8040,14 +8040,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9aa5def6-6276-4a31-a943-817cd3822901
+      - req-81212789-049e-4b57-b5e1-1aeb51cb783b
       Date:
-      - Fri, 03 Aug 2018 19:36:34 GMT
+      - Mon, 06 Aug 2018 17:00:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +8062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8073,9 +8073,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-944efa30-ea68-4b1a-8aa0-876d4696ffa5
+      - req-e58b8693-1984-479f-8e02-bc874087e73f
       Date:
-      - Fri, 03 Aug 2018 19:36:35 GMT
+      - Mon, 06 Aug 2018 17:00:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +8102,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:35 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +8117,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8128,9 +8128,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-45deca47-d005-4903-8094-fdc0190de190
+      - req-eb3b5bd7-f79a-4272-94e2-0ca5b8a9c561
       Date:
-      - Fri, 03 Aug 2018 19:36:36 GMT
+      - Mon, 06 Aug 2018 17:00:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +8157,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +8172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8183,9 +8183,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f0c24f25-2598-4eaf-a29e-e6e956b140ce
+      - req-2aff34ab-3196-498b-afec-8cee40eacf0a
       Date:
-      - Fri, 03 Aug 2018 19:36:37 GMT
+      - Mon, 06 Aug 2018 17:00:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +8212,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +8227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8238,9 +8238,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e58e9fc4-e13e-4a89-9113-76897749ed99
+      - req-bb5d2a49-bfb3-4e36-8e5f-f55337a55ac4
       Date:
-      - Fri, 03 Aug 2018 19:36:37 GMT
+      - Mon, 06 Aug 2018 17:00:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +8252,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +8267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8278,9 +8278,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-697b2842-1086-4981-967d-6980bc08de4a
+      - req-76788074-ea2e-4534-88b8-25aa114cb2b5
       Date:
-      - Fri, 03 Aug 2018 19:36:37 GMT
+      - Mon, 06 Aug 2018 17:00:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +8292,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +8307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b8de2e7ae0a4e2d913db033dc074068
+      - 8158b40268cf49b8ae549525c4829180
   response:
     status:
       code: 200
@@ -8318,9 +8318,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-08f7ab60-13e6-4de4-bf5a-230d3b38b9be
+      - req-4e5ccbcf-b0db-4382-b1ef-98b8cd110909
       Date:
-      - Fri, 03 Aug 2018 19:36:37 GMT
+      - Mon, 06 Aug 2018 17:00:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +8332,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +8350,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:38 GMT
+      - Mon, 06 Aug 2018 17:00:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-22bf1cf4-99eb-4288-889d-b7263a087a36
+      - req-f57bc198-dd9d-4294-9475-8297b8a70783
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +8365,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:38.184873", "expires":
-        "2018-08-03T20:36:38Z", "id": "93c2ebe23fc641d69456fb5fa9095bcd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:34.670791", "expires":
+        "2018-08-06T18:00:34Z", "id": "59a766c81b1f46dd9a9a52210d2f7ebc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SxLYX58kTleMEEqvbjmbAw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WbtVOqwoRO6EENc-Z5UFfw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +8412,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +8427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -8438,9 +8438,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9569fbf3-db0b-446d-85f0-49946177e3ba
+      - req-9cc60ea1-92e9-4927-8214-490371215891
       Date:
-      - Fri, 03 Aug 2018 19:36:38 GMT
+      - Mon, 06 Aug 2018 17:00:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -8544,7 +8544,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8559,7 +8559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -8570,35 +8570,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-de7c7d8c-3ee6-4cdb-9224-fac79f7a32f5
+      - req-61fa7d90-d4fc-4cf7-b02e-0199f4f3ef59
       Date:
-      - Fri, 03 Aug 2018 19:36:38 GMT
+      - Mon, 06 Aug 2018 17:00:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -8611,58 +8593,76 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8676,7 +8676,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8694,13 +8694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:38 GMT
+      - Mon, 06 Aug 2018 17:00:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-84b6760c-4eb2-4544-b388-ccafe96f6de0
+      - req-50869b77-d098-4b49-a7da-3037d285b326
       Content-Length:
       - '4131'
       Connection:
@@ -8709,10 +8709,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:39.027992", "expires":
-        "2018-08-03T20:36:38Z", "id": "de454975fbcc4cddac3386ba000a8dd0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:36.591943", "expires":
+        "2018-08-06T18:00:36Z", "id": "776200032d3144a3bb4b48d0feb96079", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DcMHnzKwTZKUVXRNiAZqzw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eu4hE-xEQ_OqVGXvA7lm3A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8756,7 +8756,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8771,7 +8771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -8782,273 +8782,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d3d481a0-bee0-45ec-b7b5-b6c44fb1a9a1
+      - req-0fd92a59-0d2f-4e30-91f4-623712b4fb44
       Date:
-      - Fri, 03 Aug 2018 19:36:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c3584883-ceae-492e-82d5-40c1d0fba5a5
-      Date:
-      - Fri, 03 Aug 2018 19:36:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d6de8ca6-755e-47ce-bf4f-8e1543a2fbe4
-      Date:
-      - Fri, 03 Aug 2018 19:36:39 GMT
+      - Mon, 06 Aug 2018 17:00:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -9152,7 +8888,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9167,7 +8903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -9178,12 +8914,155 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bd0867c4-0b4a-4d52-b174-d04691b75c59
+      - req-877c84fd-4ebd-49cd-a00a-d98882f43d95
       Date:
-      - Fri, 03 Aug 2018 19:36:40 GMT
+      - Mon, 06 Aug 2018 17:00:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 148376632eb54dcca8a03dd4ef0e7a6f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-10ba617b-555b-45b3-b73e-a3a9dea7f562
+      Date:
+      - Mon, 06 Aug 2018 17:00:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -9260,6 +9139,80 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 148376632eb54dcca8a03dd4ef0e7a6f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7dbaba48-27fa-42ce-8056-ab2d6685d8dd
+      Date:
+      - Mon, 06 Aug 2018 17:00:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -9271,6 +9224,53 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9284,7 +9284,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9302,13 +9302,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:40 GMT
+      - Mon, 06 Aug 2018 17:00:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c40811df-b4fe-4d93-989c-a6d7ba08f6be
+      - req-b55447be-415b-4c2a-8eeb-6bf075a16bab
       Content-Length:
       - '4118'
       Connection:
@@ -9317,10 +9317,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:40.697239", "expires":
-        "2018-08-03T20:36:40Z", "id": "7c7ea11844d24a7aa5b468b73f247c1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:38.232180", "expires":
+        "2018-08-06T18:00:38Z", "id": "30a8e490b3de4722a8597f7a2bbab88d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oB0OC--uRVS-KMMRvRJL_Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MjdgePjnS9WNXcYGu8Fq6g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9364,7 +9364,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9379,7 +9379,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -9390,17 +9390,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-836460e2-5629-405c-b99a-95fe0df0c8d8
+      - req-b1f028de-75ec-4bd4-91ac-1327bb4a5abe
       Date:
-      - Fri, 03 Aug 2018 19:36:41 GMT
+      - Mon, 06 Aug 2018 17:00:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9448,7 +9483,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:00:38 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 30a8e490b3de4722a8597f7a2bbab88d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-46421aa9-a566-4c4f-83e7-c2cc87953079
+      Date:
+      - Mon, 06 Aug 2018 17:00:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -9472,6 +9551,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -9483,138 +9568,53 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ebcac8d3-82a7-4fee-bfd0-1ca280a74836
-      Date:
-      - Fri, 03 Aug 2018 19:36:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9628,7 +9628,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:41 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9643,7 +9643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -9654,9 +9654,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-403fe339-fb37-49ae-aa77-49916279b4e0
+      - req-c2d6b575-5d2f-46c2-950f-c194bb8d2f0d
       Date:
-      - Fri, 03 Aug 2018 19:36:41 GMT
+      - Mon, 06 Aug 2018 17:00:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9698,7 +9698,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:41 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9713,7 +9713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -9724,9 +9724,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-589d115f-a414-4ab4-8fdb-f127b8007291
+      - req-84a59bf2-f433-4c73-b88f-23470e9ebf91
       Date:
-      - Fri, 03 Aug 2018 19:36:41 GMT
+      - Mon, 06 Aug 2018 17:00:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9768,7 +9768,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:41 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9783,7 +9783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -9794,9 +9794,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9258c7b4-29d2-49e7-bf74-4a8f9e4c459a
+      - req-0735ada4-6e49-4277-9dc7-72678f54f6c7
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9838,7 +9838,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9853,7 +9853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -9864,9 +9864,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c15895cc-34be-47a0-ad68-ca39da0feee8
+      - req-1c12ed95-ecf6-43cb-bdf8-5fb98a364add
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9908,7 +9908,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9923,7 +9923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -9934,9 +9934,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7b34246b-188c-4429-b917-6f9b08f67fd3
+      - req-dd3002db-6031-464d-9752-ad36f796e540
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9978,7 +9978,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9993,7 +9993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -10004,9 +10004,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e8a259fa-8845-4f30-9728-aa3c24109499
+      - req-32b994b6-1b30-45ae-ba8f-d02eb05efccb
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10048,7 +10048,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10063,7 +10063,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -10074,9 +10074,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4c07db10-4040-4faf-99d5-9b67ea7ff34f
+      - req-1614b603-ab2b-4299-a286-24a1739dee01
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10118,7 +10118,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10133,7 +10133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -10144,9 +10144,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6a0e9560-f000-448a-b58f-2a044a3cd6cc
+      - req-9b096c05-9cf2-403e-a685-67b4d7ce82e8
       Date:
-      - Fri, 03 Aug 2018 19:36:42 GMT
+      - Mon, 06 Aug 2018 17:00:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10188,7 +10188,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10203,7 +10203,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -10214,9 +10214,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-41a22318-e86d-4ddd-a85f-5ffca933c41a
+      - req-98c1c9c8-a743-4ffa-a740-766fe5e2c856
       Date:
-      - Fri, 03 Aug 2018 19:36:43 GMT
+      - Mon, 06 Aug 2018 17:00:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10619,7 +10619,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:43 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10634,7 +10634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -10645,9 +10645,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f8257991-f4db-401e-8c55-1c232828d3ab
+      - req-20a062cc-de2e-4c8b-a568-7a45ba421958
       Date:
-      - Fri, 03 Aug 2018 19:36:43 GMT
+      - Mon, 06 Aug 2018 17:00:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11050,7 +11050,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:43 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11065,7 +11065,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -11076,9 +11076,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b325b6ac-ba65-47af-92b4-3030afbf08a8
+      - req-bb29df73-1efd-4272-aea5-c7c92e4616a9
       Date:
-      - Fri, 03 Aug 2018 19:36:44 GMT
+      - Mon, 06 Aug 2018 17:00:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11481,7 +11481,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:44 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11496,7 +11496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -11507,9 +11507,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-62d78d85-5c8e-438d-a16f-8483d01e9bbf
+      - req-8b0a2b41-edd9-4002-90d9-6a0f599f3079
       Date:
-      - Fri, 03 Aug 2018 19:36:44 GMT
+      - Mon, 06 Aug 2018 17:00:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11912,7 +11912,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:44 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11927,7 +11927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -11938,9 +11938,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4aa244a9-1b1f-4a84-99d8-aaa52dd2b099
+      - req-280ed1ae-0482-4801-87ef-a5417d1de3ce
       Date:
-      - Fri, 03 Aug 2018 19:36:44 GMT
+      - Mon, 06 Aug 2018 17:00:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12343,7 +12343,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:44 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12358,7 +12358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -12369,9 +12369,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-179270ce-f47a-443b-8fbf-141636575ead
+      - req-6d7021fa-f594-408e-a761-0d415374c5ef
       Date:
-      - Fri, 03 Aug 2018 19:36:44 GMT
+      - Mon, 06 Aug 2018 17:00:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12774,7 +12774,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:44 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12789,7 +12789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -12800,9 +12800,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fcb00841-9eff-48f0-b183-0fd6f4c06f52
+      - req-bade9464-f6da-4fa5-9908-49e7ddc06eeb
       Date:
-      - Fri, 03 Aug 2018 19:36:45 GMT
+      - Mon, 06 Aug 2018 17:00:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13205,7 +13205,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:45 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13220,7 +13220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -13231,9 +13231,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9b072186-e290-4d6e-8f3f-5f9e32c29c4d
+      - req-b380f525-21fa-4948-be0c-8c132f4abe1c
       Date:
-      - Fri, 03 Aug 2018 19:36:45 GMT
+      - Mon, 06 Aug 2018 17:00:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13636,7 +13636,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:45 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13651,7 +13651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -13662,9 +13662,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fc5b909d-8731-4b5a-8c49-fd4b2c24553a
+      - req-620f789b-219a-4bf8-812a-70b22413213c
       Date:
-      - Fri, 03 Aug 2018 19:36:45 GMT
+      - Mon, 06 Aug 2018 17:00:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13696,7 +13696,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:45 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13711,7 +13711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -13722,9 +13722,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d9f5447b-1fd8-45ea-bf59-6887be417eda
+      - req-2e8bfd9a-2f93-4dd3-8b1a-431a63972ea4
       Date:
-      - Fri, 03 Aug 2018 19:36:45 GMT
+      - Mon, 06 Aug 2018 17:00:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13756,7 +13756,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:45 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13771,7 +13771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -13782,9 +13782,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-239ba1b3-a2b2-4f93-97bc-94623721e27a
+      - req-67785b3f-fa20-404d-8d51-b56d0a663724
       Date:
-      - Fri, 03 Aug 2018 19:36:46 GMT
+      - Mon, 06 Aug 2018 17:00:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13816,7 +13816,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:46 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13831,7 +13831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -13842,9 +13842,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-c36ac4c9-d235-4f86-b62a-42ff28cd52cd
+      - req-f1b82b09-c6b3-485e-8525-5e8a869e5d15
       Date:
-      - Fri, 03 Aug 2018 19:36:46 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13876,7 +13876,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:46 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13891,7 +13891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -13902,9 +13902,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-17c39f1e-c4d4-428d-8c1e-e825972437f6
+      - req-8edcefac-c5db-47c5-8b4d-4005426c36b2
       Date:
-      - Fri, 03 Aug 2018 19:36:46 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13936,7 +13936,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:46 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13951,7 +13951,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -13962,9 +13962,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6ed9cf6e-f4a6-4d8b-8578-d51fd3041625
+      - req-ad5ca9a1-0b80-4e0f-8a52-a953b501a8b7
       Date:
-      - Fri, 03 Aug 2018 19:36:46 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13996,7 +13996,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:46 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14011,7 +14011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -14022,9 +14022,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-60abebf6-2b34-4e71-a362-0063e6dc864c
+      - req-5fd524f0-92b9-4a18-87af-a0dd665980d0
       Date:
-      - Fri, 03 Aug 2018 19:36:46 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14056,7 +14056,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:46 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14071,7 +14071,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -14082,9 +14082,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9fe0b4d1-a8f7-4cf7-bf27-e4f15b23c2eb
+      - req-a6ae2af3-2f94-42b6-b52e-861b0824229b
       Date:
-      - Fri, 03 Aug 2018 19:36:47 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14116,7 +14116,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:47 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14131,7 +14131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -14142,9 +14142,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-df375c8c-300d-499e-98be-aec5c1642e75
+      - req-91bc8367-093b-48b2-852e-81ec9a98f19a
       Date:
-      - Fri, 03 Aug 2018 19:36:47 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14186,7 +14186,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:47 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14201,7 +14201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -14212,9 +14212,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b0db6a34-45f6-42e1-b5fb-49d764fe8f01
+      - req-e356500f-862d-4a9d-81ed-93144124bb12
       Date:
-      - Fri, 03 Aug 2018 19:36:47 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14257,7 +14257,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:47 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14272,7 +14272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -14283,9 +14283,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-0f4db723-4bb0-429e-8b2f-628995e09310
+      - req-eade6049-488e-4c2e-a02b-01e01ad7e942
       Date:
-      - Fri, 03 Aug 2018 19:36:47 GMT
+      - Mon, 06 Aug 2018 17:00:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14320,7 +14320,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:47 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14335,7 +14335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93c2ebe23fc641d69456fb5fa9095bcd
+      - 59a766c81b1f46dd9a9a52210d2f7ebc
   response:
     status:
       code: 200
@@ -14346,9 +14346,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-c3b9ec13-3928-4a83-9dda-a7f26d561f27
+      - req-1c722657-6337-49cd-957b-cb9fc8a84999
       Date:
-      - Fri, 03 Aug 2018 19:36:47 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14435,7 +14435,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:47 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14450,7 +14450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -14461,9 +14461,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-785749fc-7c9a-45fc-bfd6-9924353fff95
+      - req-214364c7-1ad6-4164-94aa-0b5b8939b0be
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14505,7 +14505,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14520,7 +14520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -14531,9 +14531,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-909dcec0-cb10-48fb-8336-912d230c9fee
+      - req-4abeef11-f4df-4ae3-ab27-8e0ca79e080e
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14576,7 +14576,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14591,7 +14591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -14602,9 +14602,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b03e8b2b-aaf1-495a-b8d9-38a03ce6c5b5
+      - req-cca0eb7d-8882-4b19-9a93-0693a4a8ba59
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14639,7 +14639,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14654,7 +14654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de454975fbcc4cddac3386ba000a8dd0
+      - 776200032d3144a3bb4b48d0feb96079
   response:
     status:
       code: 200
@@ -14665,9 +14665,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-a3e844fe-ba64-4f63-a19b-82917ba4a3e5
+      - req-47f79c71-312c-488f-8972-bb94aba7a341
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14754,7 +14754,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14769,7 +14769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -14780,9 +14780,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-679fb9b1-1dad-4a42-8925-723525d0d4c0
+      - req-8f0c4ab8-5d05-4281-9592-070bc16b2408
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14824,7 +14824,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14839,7 +14839,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -14850,9 +14850,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-25c97c8e-983e-4d7a-8138-26cfe87a6bb8
+      - req-297871b7-acc1-4b32-8dc6-7d67757a1e06
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14895,7 +14895,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14910,7 +14910,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -14921,9 +14921,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-d386a3c2-6475-4a55-9edc-c73e572a00bd
+      - req-c3202eb1-c891-4812-8428-f7c691cd9208
       Date:
-      - Fri, 03 Aug 2018 19:36:48 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14958,7 +14958,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:48 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14973,7 +14973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5069f8f79e48bdbc1eb877b2a884a2
+      - 148376632eb54dcca8a03dd4ef0e7a6f
   response:
     status:
       code: 200
@@ -14984,9 +14984,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-4f5b44df-c301-4974-b435-5f626b629f2d
+      - req-e70641d3-f472-40f2-b13a-cddda36aebf0
       Date:
-      - Fri, 03 Aug 2018 19:36:49 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15073,7 +15073,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:49 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15088,7 +15088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -15099,9 +15099,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-5cb3babd-efea-437c-afd8-27341d557229
+      - req-05da1314-7cb4-43c7-98a4-83233b5988f3
       Date:
-      - Fri, 03 Aug 2018 19:36:49 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15143,7 +15143,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:49 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15158,7 +15158,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -15169,9 +15169,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-94495eec-449e-4181-a74b-5f437002cf90
+      - req-caae9784-d71c-49a3-903a-2e177fc76419
       Date:
-      - Fri, 03 Aug 2018 19:36:49 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15214,7 +15214,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:49 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15229,7 +15229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -15240,9 +15240,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-9dfff279-fb0b-4123-ba51-f587588b645b
+      - req-f17e65c1-2d5a-4e48-b8f1-4605db030a15
       Date:
-      - Fri, 03 Aug 2018 19:36:49 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15277,7 +15277,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:49 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15292,7 +15292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c7ea11844d24a7aa5b468b73f247c1c
+      - 30a8e490b3de4722a8597f7a2bbab88d
   response:
     status:
       code: 200
@@ -15303,9 +15303,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-6ef26a0b-2ac7-4f4c-92b8-c6d9c40d7a61
+      - req-a2866cd4-0b6b-47c4-8f2c-4d7666428146
       Date:
-      - Fri, 03 Aug 2018 19:36:50 GMT
+      - Mon, 06 Aug 2018 17:00:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15392,7 +15392,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:50 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15410,13 +15410,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:50 GMT
+      - Mon, 06 Aug 2018 17:00:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f76333d-011b-4b69-9cc9-2d859e635109
+      - req-f0cb49c9-68a8-46d7-9645-a7f0430d2ec2
       Content-Length:
       - '4170'
       Connection:
@@ -15425,10 +15425,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:50.823134", "expires":
-        "2018-08-03T20:36:50Z", "id": "1a0b4cb06e104d7fb82c8eba9a8cac6a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.556447", "expires":
+        "2018-08-06T18:00:48Z", "id": "1f51bb6885e949cfac2df0b63bdb8d16", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tLnEOKs6QtCdkB2V2Nd9Vw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["n0zdjjtlQWumMBsvEOjUvQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15473,7 +15473,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:50 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15491,13 +15491,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:50 GMT
+      - Mon, 06 Aug 2018 17:00:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ce52e45c-5581-4dec-8b48-8a59ae4b8a7b
+      - req-dec7f270-4cbd-4b7c-8ca3-65d66267884d
       Content-Length:
       - '4170'
       Connection:
@@ -15506,10 +15506,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:51.049689", "expires":
-        "2018-08-03T20:36:51Z", "id": "2344e8b8b2bb4d21ae869c4994ce49e4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.764517", "expires":
+        "2018-08-06T18:00:48Z", "id": "ecca10a7335e40c6acd2b26fe074b540", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ln3vVsaNQFa8blfSZcgHwQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rZtk-qEsTUuT6DMVHF6Zng"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15554,7 +15554,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:51 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15572,13 +15572,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:51 GMT
+      - Mon, 06 Aug 2018 17:00:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-11236e6f-7bf2-4bce-99b7-85113f0d14b2
+      - req-d381bdb0-c8b5-4f79-9ed7-dc75a5e41f90
       Content-Length:
       - '370'
       Connection:
@@ -15587,13 +15587,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:51.209237", "expires":
-        "2018-08-03T20:36:51Z", "id": "b2b2c02a8144468ca0037754c9555804", "audit_ids":
-        ["1VJu7gznTo6p1lmjQfUZIQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.950486", "expires":
+        "2018-08-06T18:00:48Z", "id": "6141e1af3a824db6a897ad43a852aa8e", "audit_ids":
+        ["JPGZhLA4RHarOIl3KqSGtQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:51 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15608,20 +15608,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2b2c02a8144468ca0037754c9555804
+      - 6141e1af3a824db6a897ad43a852aa8e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:51 GMT
+      - Mon, 06 Aug 2018 17:00:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3c9dda96-e82d-4da8-9fd0-ca4ad2e597ff
+      - req-977f4df1-6a6b-4671-877a-2d679fc93241
       Content-Length:
       - '500'
       Connection:
@@ -15638,13 +15638,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:51 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"b2b2c02a8144468ca0037754c9555804"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"6141e1af3a824db6a897ad43a852aa8e"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15656,13 +15656,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:51 GMT
+      - Mon, 06 Aug 2018 17:00:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-621a7780-c936-4f7b-aeb8-943c8ab6bd16
+      - req-d2d069d4-03bb-4f00-bdab-a495991f914e
       Content-Length:
       - '4143'
       Connection:
@@ -15671,11 +15671,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:51.660320", "expires":
-        "2018-08-03T20:36:51Z", "id": "9cebda7a38a14c94ae64439a9eaa99c2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.301359", "expires":
+        "2018-08-06T18:00:48Z", "id": "c39654dc5d7140ecb0696c1924992b73", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5yx6rHc2QTG54686QyiqjA",
-        "1VJu7gznTo6p1lmjQfUZIQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JEN2Jo-PSICpwJJjlnCtBA",
+        "JPGZhLA4RHarOIl3KqSGtQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15719,7 +15719,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:51 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15734,20 +15734,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2b2c02a8144468ca0037754c9555804
+      - 6141e1af3a824db6a897ad43a852aa8e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:51 GMT
+      - Mon, 06 Aug 2018 17:00:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cce13c58-2dc0-42ec-a748-b1adfda294f4
+      - req-ede5b056-a461-4466-b50d-fae7e907fe4d
       Content-Length:
       - '500'
       Connection:
@@ -15764,7 +15764,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:51 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15782,13 +15782,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:51 GMT
+      - Mon, 06 Aug 2018 17:00:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f06fcb5-16ca-4bd5-82a5-889e4f88e461
+      - req-d21320ac-df97-4801-a08e-b0d3b2147eb1
       Content-Length:
       - '4117'
       Connection:
@@ -15797,10 +15797,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:52.168812", "expires":
-        "2018-08-03T20:36:52Z", "id": "f41e68ac6a294dfeaa568eddae5dd555", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.682435", "expires":
+        "2018-08-06T18:00:49Z", "id": "93a884bd5e7945ac81adc8e930e51317", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["L4ZdD1WoSi611TzgYxQNFA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2msDfIuyRnqbxQy5DWSYtg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15844,7 +15844,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:52 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15862,13 +15862,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:52 GMT
+      - Mon, 06 Aug 2018 17:00:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-990fb4d4-fba0-42fa-a908-3cf2df6721a9
+      - req-2103b112-e958-4170-be60-cb1a73e39072
       Content-Length:
       - '4131'
       Connection:
@@ -15877,10 +15877,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:52.505056", "expires":
-        "2018-08-03T20:36:52Z", "id": "6a7c22c5c3914910bf6dd7b04680a45c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.894970", "expires":
+        "2018-08-06T18:00:49Z", "id": "6863161fa4ce48d1a8f2f545291329a3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Vf7Ngfj9Sb66r-xBvS5cDQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["F4zBQj7nQCO73sGy_isUtQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15924,7 +15924,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:52 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15942,13 +15942,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:52 GMT
+      - Mon, 06 Aug 2018 17:00:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7cea0313-b074-49c5-96f7-f6f2affefbad
+      - req-461e977b-95ac-4c10-ae31-a55e2496237f
       Content-Length:
       - '4118'
       Connection:
@@ -15957,10 +15957,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:52.834685", "expires":
-        "2018-08-03T20:36:52Z", "id": "3825575136604fafa7979e9cc1861e86", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:50.100326", "expires":
+        "2018-08-06T18:00:50Z", "id": "8621a4dba9704e498e5f79d4b007cc50", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WEkLGbNCRsyUBNX52Kjxgg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["h52XRftxQAyFPYCRb2cPqg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16004,7 +16004,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:52 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16022,13 +16022,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:52 GMT
+      - Mon, 06 Aug 2018 17:00:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-56a1788d-ebb1-459e-9fb1-8251e96bffe3
+      - req-abb5750c-c591-41a4-aba2-ab3f91a5c47b
       Content-Length:
       - '4117'
       Connection:
@@ -16037,10 +16037,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:53.184401", "expires":
-        "2018-08-03T20:36:53Z", "id": "e12a4c5a6bce4f8880c67be765e8f931", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:50.310965", "expires":
+        "2018-08-06T18:00:50Z", "id": "7a571e53cfef47c691c355add1c4cedc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gwzouDF2T3etAZyh00RzHQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yJcDFfSkRqSWhmJq1ykb5g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16084,7 +16084,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:53 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16099,22 +16099,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6597f33-0a3e-4aa2-abb0-deba50023eec
+      - req-1919fc1a-75a2-4e3f-ad54-762eb1a46d4d
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-c6597f33-0a3e-4aa2-abb0-deba50023eec
+      - req-1919fc1a-75a2-4e3f-ad54-762eb1a46d4d
       Date:
-      - Fri, 03 Aug 2018 19:36:53 GMT
+      - Mon, 06 Aug 2018 17:00:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16147,7 +16147,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:53 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16162,22 +16162,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29fefaf6-89c9-4250-b5b3-03143c096933
+      - req-605dc0b0-c998-48ba-834e-1d5d994f1c50
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-29fefaf6-89c9-4250-b5b3-03143c096933
+      - req-605dc0b0-c998-48ba-834e-1d5d994f1c50
       Date:
-      - Fri, 03 Aug 2018 19:36:54 GMT
+      - Mon, 06 Aug 2018 17:00:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16218,7 +16218,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:54 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16233,22 +16233,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d679bc8-d0c9-45a4-b52a-828f4c7a2cc0
+      - req-b8ee364a-2386-4ca9-9663-728080b430ca
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-1d679bc8-d0c9-45a4-b52a-828f4c7a2cc0
+      - req-b8ee364a-2386-4ca9-9663-728080b430ca
       Date:
-      - Fri, 03 Aug 2018 19:36:54 GMT
+      - Mon, 06 Aug 2018 17:00:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16282,7 +16282,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:54 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16297,27 +16297,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eac1a573-f710-478e-8572-33d22ae6067d
+      - req-b316847b-1da0-46ad-ba7e-f12c3395c3fd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-eac1a573-f710-478e-8572-33d22ae6067d
+      - req-b316847b-1da0-46ad-ba7e-f12c3395c3fd
       Date:
-      - Fri, 03 Aug 2018 19:36:55 GMT
+      - Mon, 06 Aug 2018 17:00:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:55 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16335,13 +16335,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:55 GMT
+      - Mon, 06 Aug 2018 17:00:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbd84341-5711-4c17-b3fd-023a3d05c204
+      - req-104381fa-9414-4f97-9ca9-64bc07d008f0
       Content-Length:
       - '4131'
       Connection:
@@ -16350,10 +16350,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:55.589424", "expires":
-        "2018-08-03T20:36:55Z", "id": "add3196a61894b6f98b6b099130340a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:52.674061", "expires":
+        "2018-08-06T18:00:52Z", "id": "5b92fcc730654fd9ad60bf96c5991831", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["6CuTidQmTIS4dUGT2q8XsQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ndvzQ0SpSYa0P1HnwEQ0aA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16397,7 +16397,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:55 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16412,27 +16412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f659bed3-f618-43f9-9f11-ee2aea27c5a7
+      - req-275f4427-5c91-436e-a1e0-213023653349
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f659bed3-f618-43f9-9f11-ee2aea27c5a7
+      - req-275f4427-5c91-436e-a1e0-213023653349
       Date:
-      - Fri, 03 Aug 2018 19:36:56 GMT
+      - Mon, 06 Aug 2018 17:00:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:56 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16447,27 +16447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-850aaac3-aaab-42c5-902e-de5a7702b079
+      - req-c14b1ced-140f-44ac-8d04-5ef7b076f222
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-850aaac3-aaab-42c5-902e-de5a7702b079
+      - req-c14b1ced-140f-44ac-8d04-5ef7b076f222
       Date:
-      - Fri, 03 Aug 2018 19:36:56 GMT
+      - Mon, 06 Aug 2018 17:00:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:56 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16485,13 +16485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:36:56 GMT
+      - Mon, 06 Aug 2018 17:00:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32300583-86e5-4b43-8e33-2c20b2e23e67
+      - req-653d3906-1407-49d3-b4c9-584ef3271ea0
       Content-Length:
       - '4118'
       Connection:
@@ -16500,10 +16500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:36:56.890026", "expires":
-        "2018-08-03T20:36:56Z", "id": "69c8c4093b3440afa8af4a7284d7e25d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:54.858840", "expires":
+        "2018-08-06T18:00:54Z", "id": "4b2148c4a29c42eebc12ac2874db78b4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["B99l310bTtK2XCCfMp2jKA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["din76STlRua05KzKUMkQkw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16547,7 +16547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:56 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16562,27 +16562,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bc2838d9-bd3a-4dfc-889f-6e7f43e5aa9a
+      - req-fa65ce4c-f21b-4292-ac27-beabb175872b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bc2838d9-bd3a-4dfc-889f-6e7f43e5aa9a
+      - req-fa65ce4c-f21b-4292-ac27-beabb175872b
       Date:
-      - Fri, 03 Aug 2018 19:36:57 GMT
+      - Mon, 06 Aug 2018 17:00:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:57 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16597,22 +16597,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e498011e-e625-4cfc-9e3d-3700e6a063dc
+      - req-2daf1e1a-4f10-43ef-9460-99e935410480
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-e498011e-e625-4cfc-9e3d-3700e6a063dc
+      - req-2daf1e1a-4f10-43ef-9460-99e935410480
       Date:
-      - Fri, 03 Aug 2018 19:36:57 GMT
+      - Mon, 06 Aug 2018 17:00:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16627,7 +16627,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:57 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16642,22 +16642,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1a418698-3ea0-4198-a19a-386253c2ccbe
+      - req-60bd5617-729f-45a2-b19f-01c73eac5402
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-1a418698-3ea0-4198-a19a-386253c2ccbe
+      - req-60bd5617-729f-45a2-b19f-01c73eac5402
       Date:
-      - Fri, 03 Aug 2018 19:36:57 GMT
+      - Mon, 06 Aug 2018 17:00:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16672,7 +16672,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:57 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16687,27 +16687,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ef7a27c5-0f8e-46e1-9a6c-4d32fd6f0aa2
+      - req-23977f98-acf4-4311-a108-a3303097b3c1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ef7a27c5-0f8e-46e1-9a6c-4d32fd6f0aa2
+      - req-23977f98-acf4-4311-a108-a3303097b3c1
       Date:
-      - Fri, 03 Aug 2018 19:36:57 GMT
+      - Mon, 06 Aug 2018 17:00:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16722,27 +16722,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6912b79b-c0b1-472c-a8d5-39370c528c37
+      - req-5b27d20e-cef1-45d6-8877-ad6e05ab146b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6912b79b-c0b1-472c-a8d5-39370c528c37
+      - req-5b27d20e-cef1-45d6-8877-ad6e05ab146b
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16757,27 +16757,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b9bea1f-8565-4586-a19f-22ee2279e57f
+      - req-1a2ed46a-ecac-4f1c-b2dc-fbe8a3e8c6f1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5b9bea1f-8565-4586-a19f-22ee2279e57f
+      - req-1a2ed46a-ecac-4f1c-b2dc-fbe8a3e8c6f1
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16792,27 +16792,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d563f035-6de7-41d3-b42e-2d3cfdfa6748
+      - req-04a0ea4a-b7c2-40b9-b447-a1b88d3bd314
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d563f035-6de7-41d3-b42e-2d3cfdfa6748
+      - req-04a0ea4a-b7c2-40b9-b447-a1b88d3bd314
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16827,27 +16827,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b9a7eab-38c6-406e-8a70-6f9985cb8bc7
+      - req-9dc437b7-7c51-4ef2-8bdd-3e4598a3b184
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4b9a7eab-38c6-406e-8a70-6f9985cb8bc7
+      - req-9dc437b7-7c51-4ef2-8bdd-3e4598a3b184
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16862,27 +16862,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fef371fd-f91d-4f13-8690-290e2ea5ca84
+      - req-7d9e92d1-61b0-44fc-871c-c33bc7fd8f82
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fef371fd-f91d-4f13-8690-290e2ea5ca84
+      - req-7d9e92d1-61b0-44fc-871c-c33bc7fd8f82
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16897,27 +16897,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-861e5d10-908b-4163-bec9-e1b65ba1997b
+      - req-258d00e6-8440-4c85-950e-d4350d08fe34
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-861e5d10-908b-4163-bec9-e1b65ba1997b
+      - req-258d00e6-8440-4c85-950e-d4350d08fe34
       Date:
-      - Fri, 03 Aug 2018 19:36:58 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:58 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16932,27 +16932,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b37d3499-2c8d-463a-aac1-8304053765b0
+      - req-b118fc6d-e50f-4e36-8e6b-a46e6e30c538
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b37d3499-2c8d-463a-aac1-8304053765b0
+      - req-b118fc6d-e50f-4e36-8e6b-a46e6e30c538
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16967,27 +16967,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-feb518d9-94ed-4f57-a05b-623dff515a6c
+      - req-95b67be9-7e9d-4969-ac15-ca513794bf07
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-feb518d9-94ed-4f57-a05b-623dff515a6c
+      - req-95b67be9-7e9d-4969-ac15-ca513794bf07
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17002,27 +17002,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f55f7941-3703-4117-b50f-3f08d0cbd5bd
+      - req-e655a3b5-f6cd-4f75-900a-d66084344d90
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f55f7941-3703-4117-b50f-3f08d0cbd5bd
+      - req-e655a3b5-f6cd-4f75-900a-d66084344d90
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17037,27 +17037,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5c1bbab-edae-4edd-81d4-d85b6d26aa3a
+      - req-7c3afc54-d6eb-49e4-8edd-8b9d675c5eca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b5c1bbab-edae-4edd-81d4-d85b6d26aa3a
+      - req-7c3afc54-d6eb-49e4-8edd-8b9d675c5eca
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17072,27 +17072,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d33de011-1bdc-4adf-b19a-d2de42153bc1
+      - req-12815f18-bcb0-4b0d-958b-a7fbf85715ed
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d33de011-1bdc-4adf-b19a-d2de42153bc1
+      - req-12815f18-bcb0-4b0d-958b-a7fbf85715ed
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17107,27 +17107,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e753f0fb-ea78-4fe4-bf86-221a58f7e120
+      - req-a070af36-a081-43ff-98ff-0b3d9a5d0a7d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e753f0fb-ea78-4fe4-bf86-221a58f7e120
+      - req-a070af36-a081-43ff-98ff-0b3d9a5d0a7d
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17142,27 +17142,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c95af8b-f39b-4f51-bdc1-a85895a17e5b
+      - req-85c5925f-17a5-4b5e-8f22-5a3ce065c2ca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c95af8b-f39b-4f51-bdc1-a85895a17e5b
+      - req-85c5925f-17a5-4b5e-8f22-5a3ce065c2ca
       Date:
-      - Fri, 03 Aug 2018 19:36:59 GMT
+      - Mon, 06 Aug 2018 17:00:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:36:59 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17177,22 +17177,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3cbbdb86-d719-44b4-a92a-64d1752d208a
+      - req-3b70e41c-3e96-44e3-8f03-c6d8002f9573
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3cbbdb86-d719-44b4-a92a-64d1752d208a
+      - req-3b70e41c-3e96-44e3-8f03-c6d8002f9573
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17204,7 +17204,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17219,22 +17219,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e12a4c5a6bce4f8880c67be765e8f931
+      - 7a571e53cfef47c691c355add1c4cedc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9178605b-92d4-49e6-91e3-7360a3efd0ea
+      - req-c31122cf-452d-4775-905e-d8a3682f9f78
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9178605b-92d4-49e6-91e3-7360a3efd0ea
+      - req-c31122cf-452d-4775-905e-d8a3682f9f78
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17246,7 +17246,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17261,22 +17261,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee24c0af-34d9-4907-8a31-16a405b9573c
+      - req-8186e4f5-aa19-4637-aa5f-64ea6ea5e994
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ee24c0af-34d9-4907-8a31-16a405b9573c
+      - req-8186e4f5-aa19-4637-aa5f-64ea6ea5e994
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17288,7 +17288,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17303,22 +17303,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - add3196a61894b6f98b6b099130340a3
+      - 5b92fcc730654fd9ad60bf96c5991831
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29f152e8-b915-4808-b535-5d25eb80ec68
+      - req-d20b9c34-4e6d-43a2-ba2e-ffbdda171233
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-29f152e8-b915-4808-b535-5d25eb80ec68
+      - req-d20b9c34-4e6d-43a2-ba2e-ffbdda171233
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17330,7 +17330,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17345,22 +17345,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ed2928a-86d8-4cd5-8a9e-b9cb0fa73e37
+      - req-605d667d-6f24-40cc-a38d-1e21806d75bf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4ed2928a-86d8-4cd5-8a9e-b9cb0fa73e37
+      - req-605d667d-6f24-40cc-a38d-1e21806d75bf
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17372,7 +17372,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17387,22 +17387,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2344e8b8b2bb4d21ae869c4994ce49e4
+      - ecca10a7335e40c6acd2b26fe074b540
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbbd5594-6153-484d-a59f-13138b31b2be
+      - req-6fe71af8-40fc-4971-9448-08fc12d927c5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dbbd5594-6153-484d-a59f-13138b31b2be
+      - req-6fe71af8-40fc-4971-9448-08fc12d927c5
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17414,7 +17414,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17429,22 +17429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b0cecfb-4df9-4dfc-bf28-1b7be5e9134d
+      - req-5cad3b8d-06f3-4632-a40d-0cee7fcf94f6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6b0cecfb-4df9-4dfc-bf28-1b7be5e9134d
+      - req-5cad3b8d-06f3-4632-a40d-0cee7fcf94f6
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17456,7 +17456,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17471,22 +17471,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69c8c4093b3440afa8af4a7284d7e25d
+      - 4b2148c4a29c42eebc12ac2874db78b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd7fcd0f-85d8-44cf-818f-30293c49468f
+      - req-9dd8bd54-3733-4523-bcce-d29fbd7263af
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dd7fcd0f-85d8-44cf-818f-30293c49468f
+      - req-9dd8bd54-3733-4523-bcce-d29fbd7263af
       Date:
-      - Fri, 03 Aug 2018 19:37:00 GMT
+      - Mon, 06 Aug 2018 17:00:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17498,7 +17498,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:00 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17516,13 +17516,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:01 GMT
+      - Mon, 06 Aug 2018 17:00:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b790b58f-bcd5-470f-87b3-568fcb8b5fbb
+      - req-56bc6e95-2a2c-4833-b1c2-665d3754cc64
       Content-Length:
       - '4170'
       Connection:
@@ -17531,10 +17531,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:01.535778", "expires":
-        "2018-08-03T20:37:01Z", "id": "da9f066474414396b607552560c479ca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:59.356895", "expires":
+        "2018-08-06T18:00:59Z", "id": "9ece4ed0acd1448ba620add95468e992", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Xs3XGnFsT_aNottIveC9cw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["eVAsx3ODRCqqWXDmH1yBBw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17579,7 +17579,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:01 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17597,13 +17597,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:01 GMT
+      - Mon, 06 Aug 2018 17:00:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-636ec2ba-c8a5-4232-8550-a2e1c16b9fdf
+      - req-bb58ec10-52fd-4b06-8d9d-c879c0a68816
       Content-Length:
       - '4170'
       Connection:
@@ -17612,10 +17612,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:01.932487", "expires":
-        "2018-08-03T20:37:01Z", "id": "935dfd530e9a40f4a0adaed3026be3c3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:59.678776", "expires":
+        "2018-08-06T18:00:59Z", "id": "45f160c86b294c10b6e3d7a643091f25", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["c4jvXCc_QM6HYT4EFVVOPw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Cn25BO0ER5iRzI32SPyTNg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17660,7 +17660,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:01 GMT
+  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17678,13 +17678,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a6d6896e-dd18-40fa-a06a-06575b145388
+      - req-7337f72f-11ac-4d03-a69e-fd914ea11ae7
       Content-Length:
       - '370'
       Connection:
@@ -17693,13 +17693,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:02.092713", "expires":
-        "2018-08-03T20:37:02Z", "id": "1dab7f1e0c4d4157b6457d89c75341fb", "audit_ids":
-        ["prl1C4cQQjSlde2jZ-tcVQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.156061", "expires":
+        "2018-08-06T18:01:00Z", "id": "90e91a7adaf64453a4aed49510b22b64", "audit_ids":
+        ["8u6ZFriDTUaAZstcYEvd5Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17714,20 +17714,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1dab7f1e0c4d4157b6457d89c75341fb
+      - 90e91a7adaf64453a4aed49510b22b64
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5e962f22-ac37-4251-ab68-bee1922d33e9
+      - req-b797f3a1-5c89-4e30-bedd-ed2ca95fa3bd
       Content-Length:
       - '500'
       Connection:
@@ -17744,13 +17744,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1dab7f1e0c4d4157b6457d89c75341fb"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"90e91a7adaf64453a4aed49510b22b64"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17762,13 +17762,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52a1022d-6a4b-4f7a-821c-faec881b5aca
+      - req-7529acb6-2a97-4eb7-95a9-64c44c55f141
       Content-Length:
       - '4143'
       Connection:
@@ -17777,11 +17777,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:02.450792", "expires":
-        "2018-08-03T20:37:02Z", "id": "85df231ab9d64f789c0baedc6f648d0c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.531375", "expires":
+        "2018-08-06T18:01:00Z", "id": "86c878eee8e748cdb34b6dfb0a14db75", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AwYOukDXTnKrwj58KgAmvQ",
-        "prl1C4cQQjSlde2jZ-tcVQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GAPqqnsDROuDEFJ1n7NUyA",
+        "8u6ZFriDTUaAZstcYEvd5Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17825,7 +17825,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17840,20 +17840,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1dab7f1e0c4d4157b6457d89c75341fb
+      - 90e91a7adaf64453a4aed49510b22b64
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6cfd9f63-904f-4a30-856c-b86e068f0956
+      - req-c26d5238-c720-4974-9321-a2c676315b98
       Content-Length:
       - '500'
       Connection:
@@ -17870,7 +17870,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17888,13 +17888,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d14fd791-b2b2-46f3-a471-8ac6b5c0551f
+      - req-68f958eb-c27e-46c8-ba14-aa894a592f98
       Content-Length:
       - '4117'
       Connection:
@@ -17903,10 +17903,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:02.830890", "expires":
-        "2018-08-03T20:37:02Z", "id": "e60a6174934946758993b0aae720a762", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.946368", "expires":
+        "2018-08-06T18:01:00Z", "id": "1996949e0ece485f919c08922ee53f3c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JK__9iXJRsKV86jI0OTU_A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8Yc7h-D-RJuvkJSdAmthIg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17950,7 +17950,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:02 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17968,13 +17968,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:02 GMT
+      - Mon, 06 Aug 2018 17:01:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ccaf12fb-25cd-46e9-9a4f-e05a2b05b22d
+      - req-6737788a-46e7-4985-81c4-3a533ae28c4a
       Content-Length:
       - '4131'
       Connection:
@@ -17983,10 +17983,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:03.027486", "expires":
-        "2018-08-03T20:37:03Z", "id": "58f75629e18d40e3b75977941a90d7dd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.167810", "expires":
+        "2018-08-06T18:01:01Z", "id": "50139e013ace43889659a8fcc24b2c4a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LAQNbUCtQYCNz4HE_zLCiw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pFNHDkheT4eJsI0H-PJLjw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18030,7 +18030,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18048,13 +18048,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:03 GMT
+      - Mon, 06 Aug 2018 17:01:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-569dd7f5-6d4f-42d4-9e3d-f5c8adac1062
+      - req-b07460ea-16ff-4459-817f-23bf07ac9a66
       Content-Length:
       - '4118'
       Connection:
@@ -18063,10 +18063,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:03.286122", "expires":
-        "2018-08-03T20:37:03Z", "id": "1f15f3f41e394f8280979d213f086f1f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.380979", "expires":
+        "2018-08-06T18:01:01Z", "id": "bddaef6a9b5043fc83089cc41d3d12c0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5iWCzxt5QcWwQh5o-WR0sA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["GwEWOIfUQp6Yd20_xqcSDg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18110,7 +18110,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18128,13 +18128,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:03 GMT
+      - Mon, 06 Aug 2018 17:01:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e95d4e1b-886e-4b7c-ba8c-18e805531f5c
+      - req-afb2d687-2c53-433b-bb2d-7a521559ad58
       Content-Length:
       - '4117'
       Connection:
@@ -18143,10 +18143,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:03.608013", "expires":
-        "2018-08-03T20:37:03Z", "id": "9fd8cb0d62774a54a1887c34a177601d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.806168", "expires":
+        "2018-08-06T18:01:01Z", "id": "7b119a4e71b24f34bde66e9ce95ca112", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0-8RutoaRNSr0y5pGc_3aw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3jqFRqOGSEmn6VFNQONcjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18190,7 +18190,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18205,7 +18205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fd8cb0d62774a54a1887c34a177601d
+      - 7b119a4e71b24f34bde66e9ce95ca112
   response:
     status:
       code: 200
@@ -18234,15 +18234,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx1de7b5dbd478428f861fb-005b64aedf
+      - txa4694a32f50c493ba4a8d-005b687ecd
       Date:
-      - Fri, 03 Aug 2018 19:37:03 GMT
+      - Mon, 06 Aug 2018 17:01:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:03 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18257,7 +18257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fd8cb0d62774a54a1887c34a177601d
+      - 7b119a4e71b24f34bde66e9ce95ca112
   response:
     status:
       code: 200
@@ -18286,14 +18286,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx2baa32ca411946c698bde-005b64aedf
+      - tx92c0f8f7b78c404ea2227-005b687ece
       Date:
-      - Fri, 03 Aug 2018 19:37:04 GMT
+      - Mon, 06 Aug 2018 17:01:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:04 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18311,13 +18311,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:04 GMT
+      - Mon, 06 Aug 2018 17:01:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74310467-74a8-4a05-b652-527a98c707f6
+      - req-f71b15af-c75f-4b88-bec9-9194cf605246
       Content-Length:
       - '4131'
       Connection:
@@ -18326,10 +18326,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:04.318741", "expires":
-        "2018-08-03T20:37:04Z", "id": "303cc784c85847238bbcbe1543ed95a7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:02.386851", "expires":
+        "2018-08-06T18:01:02Z", "id": "ccd2b550728248fbbdb696b0d3befb5b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SPLHkA1ZQdS2EluXXHFW1A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["38GPSHsdRdiSXkCQFgE3kg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18373,7 +18373,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:04 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18388,7 +18388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 303cc784c85847238bbcbe1543ed95a7
+      - ccd2b550728248fbbdb696b0d3befb5b
   response:
     status:
       code: 200
@@ -18401,22 +18401,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325024.62561'
+      - '1533574862.62021'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325024.62561'
+      - '1533574862.62021'
       X-Trans-Id:
-      - tx20470ca09342408c89ac1-005b64aee0
+      - tx5fe20d5a22704f19b4e21-005b687ece
       Date:
-      - Fri, 03 Aug 2018 19:37:04 GMT
+      - Mon, 06 Aug 2018 17:01:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:04 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18431,7 +18431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 935dfd530e9a40f4a0adaed3026be3c3
+      - 45f160c86b294c10b6e3d7a643091f25
   response:
     status:
       code: 200
@@ -18444,22 +18444,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325024.93224'
+      - '1533574862.97479'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325024.93224'
+      - '1533574862.97479'
       X-Trans-Id:
-      - tx84ad56ae367448b0ab8fc-005b64aee0
+      - tx0aa5e04446214107aa8af-005b687ece
       Date:
-      - Fri, 03 Aug 2018 19:37:04 GMT
+      - Mon, 06 Aug 2018 17:01:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:04 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18477,13 +18477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:05 GMT
+      - Mon, 06 Aug 2018 17:01:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c61f87eb-af45-4979-bd19-041b6ba44768
+      - req-29b6fdf8-ee31-4fa0-837d-d89f4f51a560
       Content-Length:
       - '4118'
       Connection:
@@ -18492,10 +18492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:05.191847", "expires":
-        "2018-08-03T20:37:05Z", "id": "d6ef9c2b3f8d46f49fd1a4579401af92", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:03.175178", "expires":
+        "2018-08-06T18:01:03Z", "id": "34818cb6faf649dbab3eb4c53f3054d6", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zNvkO-ueTH62vBo5pJDkow"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SWN9KzTlT7iKgaaV0Z0-HQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18539,7 +18539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18554,7 +18554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6ef9c2b3f8d46f49fd1a4579401af92
+      - 34818cb6faf649dbab3eb4c53f3054d6
   response:
     status:
       code: 200
@@ -18567,22 +18567,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533325025.61301'
+      - '1533574863.42643'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533325025.61301'
+      - '1533574863.42643'
       X-Trans-Id:
-      - txf38faccdbe7b4126a8941-005b64aee1
+      - txe8a4acaf8294495b8fe1a-005b687ecf
       Date:
-      - Fri, 03 Aug 2018 19:37:05 GMT
+      - Mon, 06 Aug 2018 17:01:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -18597,7 +18597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fd8cb0d62774a54a1887c34a177601d
+      - 7b119a4e71b24f34bde66e9ce95ca112
   response:
     status:
       code: 200
@@ -18618,9 +18618,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx00ce9a17326148a18e4b2-005b64aee1
+      - txf9a524465efc4dbaab667-005b687ecf
       Date:
-      - Fri, 03 Aug 2018 19:37:05 GMT
+      - Mon, 06 Aug 2018 17:01:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -18630,7 +18630,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -18645,7 +18645,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fd8cb0d62774a54a1887c34a177601d
+      - 7b119a4e71b24f34bde66e9ce95ca112
   response:
     status:
       code: 200
@@ -18666,14 +18666,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2680f5b22cff442197329-005b64aee1
+      - tx618a028b3ba84e1b8832a-005b687ecf
       Date:
-      - Fri, 03 Aug 2018 19:37:05 GMT
+      - Mon, 06 Aug 2018 17:01:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -18688,7 +18688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9fd8cb0d62774a54a1887c34a177601d
+      - 7b119a4e71b24f34bde66e9ce95ca112
   response:
     status:
       code: 200
@@ -18709,14 +18709,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd329e90cf25f4d989efc1-005b64aee1
+      - tx92954e711d924d3984c48-005b687ecf
       Date:
-      - Fri, 03 Aug 2018 19:37:05 GMT
+      - Mon, 06 Aug 2018 17:01:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:05 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -18731,7 +18731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fc6b6b24c417dad47cfccc7ef5d74
+      - e8b4e3d0c7114c7380c010a01a0a1efc
   response:
     status:
       code: 200
@@ -18742,9 +18742,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-4d2647f3-5c13-4606-96c7-28f9b24ffb56
+      - req-4662da9c-434c-4b45-b506-60f98063ca17
       Date:
-      - Fri, 03 Aug 2018 19:37:06 GMT
+      - Mon, 06 Aug 2018 17:01:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -18754,7 +18754,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:06 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -18769,7 +18769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1943d59c06e445b6a93710bf2a90e05b
+      - b3fa122ed0614b90b5544d0b89f48bfe
   response:
     status:
       code: 200
@@ -18780,35 +18780,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-22715d69-88dd-4c63-99e9-4458025008e6
+      - req-8229831c-5147-4b8d-a421-a9efeb8c1c30
       Date:
-      - Fri, 03 Aug 2018 19:37:06 GMT
+      - Mon, 06 Aug 2018 17:01:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -18821,108 +18803,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1943d59c06e445b6a93710bf2a90e05b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c75b0428-19e0-460a-8dcb-8365d35dd234
-      Date:
-      - Fri, 03 Aug 2018 19:37:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -18970,7 +18873,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b3fa122ed0614b90b5544d0b89f48bfe
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d9fe0ac1-58fa-4aa1-9648-3787776550b8
+      Date:
+      - Mon, 06 Aug 2018 17:01:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -18994,6 +18941,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -19005,56 +18958,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9464378fd4e44467b9b255dbd9e8dc50
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ec1c09fc-d3bc-4ba6-8833-7309f66d86ab
-      Date:
-      - Fri, 03 Aug 2018 19:37:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19102,41 +19005,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19150,10 +19018,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:07 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -19165,7 +19033,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9464378fd4e44467b9b255dbd9e8dc50
+      - 1db67d4e2a5140c4ae9d578e40ff869e
   response:
     status:
       code: 200
@@ -19176,9 +19044,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8716ef08-ddb1-42bd-ae95-499204f4e1ac
+      - req-85c1f3e3-67bf-46e5-9ed0-4af1acc017a3
       Date:
-      - Fri, 03 Aug 2018 19:37:07 GMT
+      - Mon, 06 Aug 2018 17:01:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -19282,10 +19150,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:07 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -19297,7 +19165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fc6b6b24c417dad47cfccc7ef5d74
+      - 1db67d4e2a5140c4ae9d578e40ff869e
   response:
     status:
       code: 200
@@ -19308,17 +19176,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bc736883-d0d0-4357-b0b2-40923e6802ae
+      - req-c2e99c09-f035-4138-9b41-dc7878c0096a
       Date:
-      - Fri, 03 Aug 2018 19:37:07 GMT
+      - Mon, 06 Aug 2018 17:01:06 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19366,7 +19269,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e8b4e3d0c7114c7380c010a01a0a1efc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f2e6c526-94ba-461a-b2ba-89f937c85a24
+      Date:
+      - Mon, 06 Aug 2018 17:01:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -19390,6 +19337,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -19401,56 +19354,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b75fc6b6b24c417dad47cfccc7ef5d74
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-75c50443-9fd9-479d-8315-6b049b7c0a2d
-      Date:
-      - Fri, 03 Aug 2018 19:37:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19498,41 +19401,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19546,139 +19414,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2f108d00b7e14d3c803e1e39d4fe5a68
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5992b74e-29be-4099-b497-a25336751323
-      Date:
-      - Fri, 03 Aug 2018 19:37:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -19693,7 +19429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f108d00b7e14d3c803e1e39d4fe5a68
+      - e8b4e3d0c7114c7380c010a01a0a1efc
   response:
     status:
       code: 200
@@ -19704,9 +19440,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-adc30682-858b-4f7d-be9b-913e5b6f4b0f
+      - req-7f202ed7-022d-45b7-96d4-47e0a31257d3
       Date:
-      - Fri, 03 Aug 2018 19:37:08 GMT
+      - Mon, 06 Aug 2018 17:01:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -19810,5 +19546,269 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:08 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e9109594d130493facbc8bf5abc8cf9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ebf8ff34-88bd-4d17-9285-16711f47d7cf
+      Date:
+      - Mon, 06 Aug 2018 17:01:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e9109594d130493facbc8bf5abc8cf9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-43a73b3e-9ead-47e2-ab3b-ae05c679490b
+      Date:
+      - Mon, 06 Aug 2018 17:01:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3eaa2660-56f3-4a04-bb3c-61b794886f2d
+      - req-e99cdf84-ad27-4c1f-8345-0dcce211ffd3
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:32.255210", "expires":
-        "2018-08-03T20:35:32Z", "id": "a6c14370f59c4fee9814489d21b7acfa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.460559", "expires":
+        "2018-08-06T18:01:50Z", "id": "5a95816840f74809af3d2ba263c72526", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["dYql63_VSqmnrreFSrV5rQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["JB18f2erRQ29gh2no0t68g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6c14370f59c4fee9814489d21b7acfa
+      - 5a95816840f74809af3d2ba263c72526
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a4da76e5-48c9-4209-ac11-531cc01c3f8e
+      - req-906359dc-fb28-4e1d-b5b2-f9dd70983dbe
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:32.616997", "expires":
-        "2018-08-03T20:35:32Z", "id": "c4f5fca4e7c243ab9625c2fef83caa3c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.739933", "expires":
+        "2018-08-06T18:01:50Z", "id": "c35c10b5575242ceb871e386b5d8014f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qwV2l2pISMGdit77tnYdTw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["6GRIfBDFQ3KXuVfOoackXQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4f5fca4e7c243ab9625c2fef83caa3c
+      - c35c10b5575242ceb871e386b5d8014f
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ab177345-6ac9-4899-91b7-c0d88e03e8c6
+      - req-8707172f-3773-4f3f-9986-93300a46e0ac
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +261,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:32.882850", "expires":
-        "2018-08-03T20:35:32Z", "id": "858c6a1b9e404792b56e485317b4a2e3", "audit_ids":
-        ["xFozF_DsQL2GUR4X6VSpSQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.979519", "expires":
+        "2018-08-06T18:01:50Z", "id": "37456e079baf40efa98bec32f0629f1d", "audit_ids":
+        ["yoGSA-3FQMOQzNoiL70LwQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +282,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 858c6a1b9e404792b56e485317b4a2e3
+      - 37456e079baf40efa98bec32f0629f1d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:32 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6d4879dc-5cf3-4ffc-9c64-c52123fe8b4b
+      - req-deca35cb-610b-4429-b0b5-0552ca4c6d89
       Content-Length:
       - '500'
       Connection:
@@ -312,13 +312,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"858c6a1b9e404792b56e485317b4a2e3"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"37456e079baf40efa98bec32f0629f1d"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -330,13 +330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:33 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d6fb71e9-9552-41f9-82ea-ea78a5f1b166
+      - req-a33c6c6b-9f78-45b6-a38f-399589da106e
       Content-Length:
       - '4143'
       Connection:
@@ -345,11 +345,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:33.461310", "expires":
-        "2018-08-03T20:35:32Z", "id": "d40ce41e78ea406fa3b711379813871f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.308010", "expires":
+        "2018-08-06T18:01:50Z", "id": "b9a23c90ac054253812f3d4dff7c898c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["6cTBs1JdS_OiKmUUhTeHRA",
-        "xFozF_DsQL2GUR4X6VSpSQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XxTvjm2RSm6_r6Z6flNtcw",
+        "yoGSA-3FQMOQzNoiL70LwQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -393,7 +393,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 858c6a1b9e404792b56e485317b4a2e3
+      - 37456e079baf40efa98bec32f0629f1d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:33 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76c3a8c6-b899-43fe-9619-661af89b6141
+      - req-0e49d11e-f3f2-4d66-8b9f-5474a4ae52bf
       Content-Length:
       - '500'
       Connection:
@@ -438,7 +438,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:33 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47aafbb5-a90b-41a9-b7e3-a4d632723f13
+      - req-48aa9b90-d62f-4e10-8e70-4e207147fe05
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +471,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:33.992543", "expires":
-        "2018-08-03T20:35:33Z", "id": "8835f01f3139494bbdbb3589a983eb49", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.686703", "expires":
+        "2018-08-06T18:01:51Z", "id": "fdd80dc78b764471896cf79595ce70ba", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8GaE5qNQTFGgnHhm7fHOlg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["grDLvqkQSUq68_XOtRc7Dw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +518,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8835f01f3139494bbdbb3589a983eb49
+      - fdd80dc78b764471896cf79595ce70ba
   response:
     status:
       code: 200
@@ -544,7 +544,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +553,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +571,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f874d895-d473-431f-af9f-7b025fc6d4f2
+      - req-7d51fb4e-2217-4b1c-9267-99c49094dd6d
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +586,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:34.344809", "expires":
-        "2018-08-03T20:35:34Z", "id": "0cd7534c838d4827baff3f417595c61c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.994659", "expires":
+        "2018-08-06T18:01:51Z", "id": "11ac600211d44f76aa8ac48581e9deac", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pGSCZ1jxSQaGE8ADosom7g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3xv88PHFSlqoipqVYqaJyg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +633,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0cd7534c838d4827baff3f417595c61c
+      - 11ac600211d44f76aa8ac48581e9deac
   response:
     status:
       code: 200
@@ -659,7 +659,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +668,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +686,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c36a64f3-6246-49da-9f8d-0188913cfe4f
+      - req-285ada13-1ecb-4c15-a024-86a6cfb57d9e
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +701,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:34.756081", "expires":
-        "2018-08-03T20:35:34Z", "id": "91ab66fb979a4d9daaaadc57000f8d24", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:52.291978", "expires":
+        "2018-08-06T18:01:52Z", "id": "33a96c37a8f34836aaea0039a364eb2a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["A9D4lcnUSXGoYO1geaNaBQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["268iTP_JS0i3GhljHbaZ9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +748,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91ab66fb979a4d9daaaadc57000f8d24
+      - 33a96c37a8f34836aaea0039a364eb2a
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +801,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:34 GMT
+      - Mon, 06 Aug 2018 17:01:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7168aa49-45b3-4218-8162-2d5ad248b1c2
+      - req-e6d3f3f3-13ab-4393-9559-6ef05cd99755
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +816,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:35.136602", "expires":
-        "2018-08-03T20:35:35Z", "id": "fa4aa0906a314596833be978bca97234", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:52.595855", "expires":
+        "2018-08-06T18:01:52Z", "id": "7733b1d636b247e0b1f7cef2274ccdf6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["i58BHV-wQdm94cr8lbz11A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Y1x5fDV-SLiVYdqdk5UiTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +863,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:35 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa4aa0906a314596833be978bca97234
+      - 7733b1d636b247e0b1f7cef2274ccdf6
   response:
     status:
       code: 200
@@ -889,17 +889,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6a76cadd-d362-44b8-8f6d-57f917e2f659
+      - req-7dfab56d-c4ab-4b0b-a401-37a4b33b2d46
       Date:
-      - Fri, 03 Aug 2018 19:35:35 GMT
+      - Mon, 06 Aug 2018 17:01:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -947,41 +982,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -995,7 +995,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:35 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1010,7 +1010,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa4aa0906a314596833be978bca97234
+      - 7733b1d636b247e0b1f7cef2274ccdf6
   response:
     status:
       code: 200
@@ -1021,9 +1021,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8eeb5213-eb14-4284-8613-61d8fd79660c
+      - req-4cd03230-87d8-47fb-ad59-9d8d16a1bf36
       Date:
-      - Fri, 03 Aug 2018 19:35:35 GMT
+      - Mon, 06 Aug 2018 17:01:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -1127,7 +1127,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1145,13 +1145,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:36 GMT
+      - Mon, 06 Aug 2018 17:01:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-90ebee81-39e5-498d-b5b9-03500dea95c9
+      - req-b0592fbe-6bc1-44b0-8df2-b65bdcf6ee5a
       Content-Length:
       - '4131'
       Connection:
@@ -1160,10 +1160,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:36.286460", "expires":
-        "2018-08-03T20:35:36Z", "id": "c9c66d671ba14f8cb06bf86baa891bc7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:53.570275", "expires":
+        "2018-08-06T18:01:53Z", "id": "a261a05cf3864bcba15a9b487e8d8093", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yf6s4U8pQ3SV7U6N3KcreA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ov9WnPJbSkKg1qYjGw7D0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1207,7 +1207,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1222,7 +1222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9c66d671ba14f8cb06bf86baa891bc7
+      - a261a05cf3864bcba15a9b487e8d8093
   response:
     status:
       code: 200
@@ -1233,35 +1233,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-30a92eb6-fc04-4a07-ac6b-9742c2f563b5
+      - req-acc6d49e-5f99-4c45-835e-2629a5de0c24
       Date:
-      - Fri, 03 Aug 2018 19:35:36 GMT
+      - Mon, 06 Aug 2018 17:01:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -1274,58 +1256,76 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1339,7 +1339,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1354,7 +1354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9c66d671ba14f8cb06bf86baa891bc7
+      - a261a05cf3864bcba15a9b487e8d8093
   response:
     status:
       code: 200
@@ -1365,9 +1365,485 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b45a6ea1-83df-40a0-a323-503ef0ed1cc3
+      - req-45f5fd41-0914-4629-bf4e-3c2a56d5a29f
       Date:
-      - Fri, 03 Aug 2018 19:35:36 GMT
+      - Mon, 06 Aug 2018 17:01:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c35c10b5575242ceb871e386b5d8014f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c74f709f-b7d4-4bdc-8a3a-3d6c9615423b
+      Date:
+      - Mon, 06 Aug 2018 17:01:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c35c10b5575242ceb871e386b5d8014f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a7475491-7ec3-4aa1-86a8-6446eedecbb1
+      Date:
+      - Mon, 06 Aug 2018 17:01:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 17:01:54 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-632a7134-1115-43b8-a0d1-2f5b03be7302
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:54.936107", "expires":
+        "2018-08-06T18:01:54Z", "id": "e6bbd7b654644c1999c1e689fdfd30aa", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["t6aT_XpnSy-3yV1oIh3nQg"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e6bbd7b654644c1999c1e689fdfd30aa
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ebbfe071-5148-4e80-aff6-fc91c52c923e
+      Date:
+      - Mon, 06 Aug 2018 17:01:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -1471,139 +1947,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c4f5fca4e7c243ab9625c2fef83caa3c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e52c94b8-5fec-4d58-a2b9-1c90c5bad2e3
-      Date:
-      - Fri, 03 Aug 2018 19:35:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1618,7 +1962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4f5fca4e7c243ab9625c2fef83caa3c
+      - e6bbd7b654644c1999c1e689fdfd30aa
   response:
     status:
       code: 200
@@ -1629,35 +1973,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a0768d3b-0d7d-49b8-9ee3-98dfe6a0b24c
+      - req-9ad5c206-64db-4715-aa2e-bb06020d0a10
       Date:
-      - Fri, 03 Aug 2018 19:35:37 GMT
+      - Mon, 06 Aug 2018 17:01:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -1670,188 +1996,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:37 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Aug 2018 19:35:37 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-c50b1b32-7629-443e-8848-f7c343e1798c
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:38.191151", "expires":
-        "2018-08-03T20:35:38Z", "id": "8248800dadfe4f0a9db23251a8edc9cb", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["13NFJak5QfayAWL8JB9sWw"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8248800dadfe4f0a9db23251a8edc9cb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1a611a1b-0d2f-4807-92d0-78d2fe167d9f
-      Date:
-      - Fri, 03 Aug 2018 19:35:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1899,41 +2066,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1947,139 +2079,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8248800dadfe4f0a9db23251a8edc9cb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-dc85d0bc-ea1f-4ce4-bfd9-5d1e5c776b9c
-      Date:
-      - Fri, 03 Aug 2018 19:35:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -2094,7 +2094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4f5fca4e7c243ab9625c2fef83caa3c
+      - c35c10b5575242ceb871e386b5d8014f
   response:
     status:
       code: 200
@@ -2105,9 +2105,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-d56f991e-8b1e-426b-b80d-aa6a42ed9180
+      - req-5d96e067-7190-4421-a63e-9cfcdd58d131
       Date:
-      - Fri, 03 Aug 2018 19:35:39 GMT
+      - Mon, 06 Aug 2018 17:01:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2122,5 +2122,5 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:39 GMT
+      - Mon, 06 Aug 2018 16:59:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc79d1b4-490d-4b39-9a6b-d520feb7fed1
+      - req-496e0c16-c017-46b8-a91e-14fea61e6f9e
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:40.185466", "expires":
-        "2018-08-03T20:35:40Z", "id": "88486d047cda4473911b4fbce3faab05", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.170184", "expires":
+        "2018-08-06T17:59:39Z", "id": "36135bd8d3c04167b41436b53a798a32", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gIE-F4-aReGNFOmqLQ_Ezg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["spIkHwZCQge83i_v4gU35A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88486d047cda4473911b4fbce3faab05
+      - 36135bd8d3c04167b41436b53a798a32
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:40 GMT
+      - Mon, 06 Aug 2018 16:59:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:40 GMT
+      - Mon, 06 Aug 2018 16:59:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e39aee2a-c080-4ded-aab5-e55e391517b4
+      - req-4b6c02fc-c24f-4092-a689-abd4407ca72c
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:40.626129", "expires":
-        "2018-08-03T20:35:40Z", "id": "c566cb4701d941df99205cc730b02aef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.647531", "expires":
+        "2018-08-06T17:59:39Z", "id": "c1c3a99b350e48339113a3da4355ce77", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8wInE5qsQMW7V1igKd3aew"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["t2aAAtPER4-rwajPNdvDqw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c566cb4701d941df99205cc730b02aef
+      - c1c3a99b350e48339113a3da4355ce77
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:35:40 GMT
+      - Mon, 06 Aug 2018 16:59:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:40 GMT
+      - Mon, 06 Aug 2018 16:59:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e914fb92-d74a-4040-94d8-bfc7a3a99e37
+      - req-ffb22683-68ec-4e0a-919a-1f9758ff410e
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +261,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:40.929080", "expires":
-        "2018-08-03T20:35:40Z", "id": "07a7708d8cc649c3961a52af02e1ba2f", "audit_ids":
-        ["-DvCr_sPRf-iJ60De59Myw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.963630", "expires":
+        "2018-08-06T17:59:39Z", "id": "ab8b05a08e584e2cb1513a1bdf2bb65a", "audit_ids":
+        ["MhytMwrdTgOw6GXM_wfeLQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:40 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +282,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a7708d8cc649c3961a52af02e1ba2f
+      - ab8b05a08e584e2cb1513a1bdf2bb65a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:41 GMT
+      - Mon, 06 Aug 2018 16:59:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f08b6a1-de78-444e-92d0-7160280c3df3
+      - req-0ebad9d7-e79e-4c7a-a0b2-33bb97fdfb99
       Content-Length:
       - '500'
       Connection:
@@ -312,13 +312,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"07a7708d8cc649c3961a52af02e1ba2f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"ab8b05a08e584e2cb1513a1bdf2bb65a"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -330,13 +330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:41 GMT
+      - Mon, 06 Aug 2018 16:59:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5276e931-046a-48dd-bde5-f58e2e01a64c
+      - req-fac52739-9f9d-4058-9e88-c55487583ebd
       Content-Length:
       - '4143'
       Connection:
@@ -345,11 +345,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:41.534713", "expires":
-        "2018-08-03T20:35:40Z", "id": "b73793ee543049fb8964da41396f76a7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:40.468400", "expires":
+        "2018-08-06T17:59:39Z", "id": "b71c3c1f0ba742ab838ac248703a2723", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bgbh_igJRcmslypp2GvvLQ",
-        "-DvCr_sPRf-iJ60De59Myw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KP_lh-N4R8-j9irgMWmzQQ",
+        "MhytMwrdTgOw6GXM_wfeLQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -393,7 +393,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a7708d8cc649c3961a52af02e1ba2f
+      - ab8b05a08e584e2cb1513a1bdf2bb65a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:41 GMT
+      - Mon, 06 Aug 2018 16:59:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb1a3d32-2e38-472d-8368-d7cfd09f81d3
+      - req-edef366a-1822-4fe3-9c8e-99ecbf3f7776
       Content-Length:
       - '500'
       Connection:
@@ -438,7 +438,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:41 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:41 GMT
+      - Mon, 06 Aug 2018 16:59:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3320bcf6-0cbd-492f-a9cf-84f05d21a256
+      - req-080eb5b3-9eac-4be0-931d-a723d0a8b78c
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +471,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:42.067016", "expires":
-        "2018-08-03T20:35:42Z", "id": "f80798dc6ebf4897b50f4c3d732b2b9b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.019845", "expires":
+        "2018-08-06T17:59:40Z", "id": "86ed377f68d84ee99592ce64e33a7dbb", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ujpYARTeTPqa7e_1M-OV8A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["x0ey1kMGT_Sap-w-3s51cw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +518,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f80798dc6ebf4897b50f4c3d732b2b9b
+      - 86ed377f68d84ee99592ce64e33a7dbb
   response:
     status:
       code: 200
@@ -544,7 +544,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:42 GMT
+      - Mon, 06 Aug 2018 16:59:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +553,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +571,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:42 GMT
+      - Mon, 06 Aug 2018 16:59:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-963993ce-a39f-4ee0-aa8a-8ee259b7ad97
+      - req-0c4dffd2-e3aa-4260-8bee-b1f02d597b4a
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +586,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:42.442713", "expires":
-        "2018-08-03T20:35:42Z", "id": "7b6a11b75dfc465bbebd6283bb100f05", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.411701", "expires":
+        "2018-08-06T17:59:41Z", "id": "249087e25526445dac77ca9602389bde", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ZSYZHcWQSWSN8YZXGxSK4A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["B07dGMfGRVu4lWrz-VIFXw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +633,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b6a11b75dfc465bbebd6283bb100f05
+      - 249087e25526445dac77ca9602389bde
   response:
     status:
       code: 200
@@ -659,7 +659,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:42 GMT
+      - Mon, 06 Aug 2018 16:59:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +668,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +686,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:42 GMT
+      - Mon, 06 Aug 2018 16:59:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3ad1fc0-7c85-443d-971a-3d99dbffde89
+      - req-700dc967-537b-43fd-adc6-56264a4a4fd1
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +701,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:42.852565", "expires":
-        "2018-08-03T20:35:42Z", "id": "d9d2a2ce72a048eb936f13db42dd13a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.793285", "expires":
+        "2018-08-06T17:59:41Z", "id": "ee90bcb6e62b445d992c4aecc0783f37", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["R3-QBQFVTSm1ncLTJEOEVw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3D9ZyS0jT_KASe0zUUxkcA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +748,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9d2a2ce72a048eb936f13db42dd13a1
+      - ee90bcb6e62b445d992c4aecc0783f37
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:35:42 GMT
+      - Mon, 06 Aug 2018 16:59:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:42 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +801,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:43 GMT
+      - Mon, 06 Aug 2018 16:59:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a95887de-b886-4ba2-ab63-f3c1b75cca75
+      - req-54b90340-8d88-404b-9cc4-4431f8e67a1d
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +816,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:43.255176", "expires":
-        "2018-08-03T20:35:43Z", "id": "d667618abaa146e1a3057166b9636ea6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:42.079606", "expires":
+        "2018-08-06T17:59:42Z", "id": "0899ff7c58974735a7edb167d2178d60", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7BAGBV5mTsWRjtXmbWSAhQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["iA4JT8HxTNylTXSRZpjR0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +863,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:43 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d667618abaa146e1a3057166b9636ea6
+      - '0899ff7c58974735a7edb167d2178d60'
   response:
     status:
       code: 200
@@ -889,174 +889,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3e81c6cf-0f0e-4609-97c3-c28770b1a80a
+      - req-adb5939f-a3bf-4254-990e-76d597825884
       Date:
-      - Fri, 03 Aug 2018 19:35:43 GMT
+      - Mon, 06 Aug 2018 16:59:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:43 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d667618abaa146e1a3057166b9636ea6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-81065f9c-0720-4abc-b641-94c07e1a895b
-      Date:
-      - Fri, 03 Aug 2018 19:35:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1103,6 +941,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1114,6 +958,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1127,7 +995,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '0899ff7c58974735a7edb167d2178d60'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-89abb468-ae16-4871-bf28-bec119ea364a
+      Date:
+      - Mon, 06 Aug 2018 16:59:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1145,13 +1145,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:35:44 GMT
+      - Mon, 06 Aug 2018 16:59:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c107bd56-9452-454d-9c15-b2bad81fee02
+      - req-9fc84881-cc7d-475d-9695-2f86b572c96a
       Content-Length:
       - '4131'
       Connection:
@@ -1160,10 +1160,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:44.388915", "expires":
-        "2018-08-03T20:35:44Z", "id": "2c69a4c65a1e4960af59e4c872c5a6c7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:42.878084", "expires":
+        "2018-08-06T17:59:42Z", "id": "09fee8bbfe834cc1a7eb3b714b7d17db", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fE0oBrwdSbiUVMlDfUl6qQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["378JHu4RSAOZvyZfNYIEHg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1207,7 +1207,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1222,7 +1222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c69a4c65a1e4960af59e4c872c5a6c7
+      - '09fee8bbfe834cc1a7eb3b714b7d17db'
   response:
     status:
       code: 200
@@ -1233,9 +1233,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7786069c-e11a-4e5e-ae66-f06e1b0e1579
+      - req-e39bb477-85cd-4f93-8f08-9df94aa7f413
       Date:
-      - Fri, 03 Aug 2018 19:35:44 GMT
+      - Mon, 06 Aug 2018 16:59:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -1339,7 +1339,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:44 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1354,7 +1354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c69a4c65a1e4960af59e4c872c5a6c7
+      - '09fee8bbfe834cc1a7eb3b714b7d17db'
   response:
     status:
       code: 200
@@ -1365,174 +1365,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7995e3cb-36da-4eeb-b3ea-7da4dc750e2a
+      - req-c0a396d9-54aa-4189-8c1a-b6a071325fb0
       Date:
-      - Fri, 03 Aug 2018 19:35:44 GMT
+      - Mon, 06 Aug 2018 16:59:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c566cb4701d941df99205cc730b02aef
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fb1790be-0aeb-49a8-a58e-aca98bc70e2a
-      Date:
-      - Fri, 03 Aug 2018 19:35:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1579,6 +1417,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1590,6 +1434,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1603,7 +1471,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:45 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c1c3a99b350e48339113a3da4355ce77
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0e01c5b4-69d4-436d-abb7-988276e06e95
+      Date:
+      - Mon, 06 Aug 2018 16:59:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:59:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1618,7 +1618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c566cb4701d941df99205cc730b02aef
+      - c1c3a99b350e48339113a3da4355ce77
   response:
     status:
       code: 200
@@ -1629,9 +1629,221 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-61e3643e-49e5-4307-9128-917ab4971469
+      - req-3772cec9-c82a-4016-b9cb-762a0b0c1a6a
       Date:
-      - Fri, 03 Aug 2018 19:35:45 GMT
+      - Mon, 06 Aug 2018 16:59:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:59:48 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 16:59:48 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-9568556d-4cac-4b48-abfe-53e9eb23c191
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:48.933473", "expires":
+        "2018-08-06T17:59:48Z", "id": "1ce09af7174e4e5d8f57664e808b2604", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["u2r2ouiQSPO6yV9lb0Jb8A"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 16:59:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1ce09af7174e4e5d8f57664e808b2604
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1aea8e98-146a-45e9-900f-0dedc1e45ded
+      Date:
+      - Mon, 06 Aug 2018 16:59:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -1735,219 +1947,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:45 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Aug 2018 19:35:45 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-b358f5e3-de9b-4066-95f7-919ca01a9b0a
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:35:46.117203", "expires":
-        "2018-08-03T20:35:46Z", "id": "612266ab3f4640429f6c659742f04923", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nt0_Gbo0T1qt9bw7ccNXZw"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:46 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 612266ab3f4640429f6c659742f04923
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3804f8a3-088b-4be5-9098-356d65e992d0
-      Date:
-      - Fri, 03 Aug 2018 19:35:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1962,7 +1962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 612266ab3f4640429f6c659742f04923
+      - 1ce09af7174e4e5d8f57664e808b2604
   response:
     status:
       code: 200
@@ -1973,42 +1973,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f2cd958d-4b7d-4cf1-bc0c-497df48ad476
+      - req-336198b9-65e0-413f-b35c-3237b3aee114
       Date:
-      - Fri, 03 Aug 2018 19:35:46 GMT
+      - Mon, 06 Aug 2018 16:59:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -2055,6 +2025,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -2066,6 +2042,30 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2079,7 +2079,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:46 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -2094,7 +2094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c566cb4701d941df99205cc730b02aef
+      - c1c3a99b350e48339113a3da4355ce77
   response:
     status:
       code: 200
@@ -2105,9 +2105,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-ec6bb485-0334-4904-b268-418a08da51b2
+      - req-1bc1666f-4975-49f6-bbb7-d36c8398ed32
       Date:
-      - Fri, 03 Aug 2018 19:35:47 GMT
+      - Mon, 06 Aug 2018 16:59:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -2116,5 +2116,5 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:35:47 GMT
+  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:17 GMT
+      - Mon, 06 Aug 2018 17:01:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c368016d-8d94-422f-bf19-ef0320c58261
+      - req-407ebd37-42c6-4a87-97f6-ee246caac22f
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:17.717032", "expires":
-        "2018-08-03T20:37:17Z", "id": "a098381fe0db4e4fa61547c943b525b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:08.387326", "expires":
+        "2018-08-06T18:01:08Z", "id": "4133bedfa1114d0e89eb0e37879f1668", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["cyzxh0NtRYuw4oRZAAwwsA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0REhtG72Rse_5jeR08nvpQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:17 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a098381fe0db4e4fa61547c943b525b7
+      - 4133bedfa1114d0e89eb0e37879f1668
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:17 GMT
+      - Mon, 06 Aug 2018 17:01:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:17 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:17 GMT
+      - Mon, 06 Aug 2018 17:01:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-35d65b6c-e7f0-4fdc-b2c6-c9fe30e3851d
+      - req-4f0e0741-942c-464d-9a28-e512ef5f7612
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:18.103485", "expires":
-        "2018-08-03T20:37:18Z", "id": "37d7224c8f974d8f9c36eabedb03eb6e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:08.690472", "expires":
+        "2018-08-06T18:01:08Z", "id": "37527ba51d1e47b1a77fe5eb86a4a1ed", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MjA9u8HKRrG4wrqdeNRp9w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pZFRUfOYSh-dkdzhSpMLQQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37d7224c8f974d8f9c36eabedb03eb6e
+      - 37527ba51d1e47b1a77fe5eb86a4a1ed
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:18 GMT
+      - Mon, 06 Aug 2018 17:01:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dad6971f-7039-42cd-8fe4-170df4e698fe
+      - req-14259d9a-ac2b-4eb4-8a91-6a375d1b853f
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:18 GMT
+      - Mon, 06 Aug 2018 17:01:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2cf3c157-d04e-4112-92fe-d91ea6b712d5
+      - req-d5ee14c9-487b-4a89-b5b4-8b2b30b717cc
       Content-Length:
       - '4117'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:18.643749", "expires":
-        "2018-08-03T20:37:18Z", "id": "4fd30d5ef17340dda3031cea0198e090", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:09.049997", "expires":
+        "2018-08-06T18:01:09Z", "id": "8c995389c85a41f4801fb8446fa3a56a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8bjBkH9uQW-vWkspyMUwgA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tY-OkjIUTRuCikuA11uSrw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -321,7 +321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:18 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -336,7 +336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fd30d5ef17340dda3031cea0198e090
+      - 8c995389c85a41f4801fb8446fa3a56a
   response:
     status:
       code: 200
@@ -347,9 +347,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d2fd5b10-4d01-4198-9400-a0b3cc8fb5d1
+      - req-117e610e-bafa-4df2-a26b-9577bcbca667
       Date:
-      - Fri, 03 Aug 2018 19:37:19 GMT
+      - Mon, 06 Aug 2018 17:01:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -383,7 +383,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -398,7 +398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fd30d5ef17340dda3031cea0198e090
+      - 8c995389c85a41f4801fb8446fa3a56a
   response:
     status:
       code: 200
@@ -409,9 +409,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c5050fed-b365-4bee-9a54-6ffa066a9c05
+      - req-0eeb1cae-4f54-4f5b-bf8b-408d7cf2b723
       Date:
-      - Fri, 03 Aug 2018 19:37:19 GMT
+      - Mon, 06 Aug 2018 17:01:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -467,7 +467,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -482,7 +482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fd30d5ef17340dda3031cea0198e090
+      - 8c995389c85a41f4801fb8446fa3a56a
   response:
     status:
       code: 200
@@ -493,9 +493,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-85b92c2b-4d94-466f-9462-0e5e9da707c7
+      - req-b2933088-3ee4-4546-816f-f0034eb2287a
       Date:
-      - Fri, 03 Aug 2018 19:37:19 GMT
+      - Mon, 06 Aug 2018 17:01:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -507,7 +507,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:19 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:19 GMT
+      - Mon, 06 Aug 2018 17:01:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a53a8b30-75af-435d-baf1-bac8bd5906f5
+      - req-995e056c-1f27-4a07-b6e1-ea5e8436dc0a
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:19.986022", "expires":
-        "2018-08-03T20:37:19Z", "id": "e0374aa5c765484f88e1cb2b430cb584", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:15.028292", "expires":
+        "2018-08-06T18:01:14Z", "id": "44c5ae1b11214ff09c99669c1b030c56", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["IvXiJf6iRbC15ctuX1PRoA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mNd3ZyCQQuKR7oXnzqKb3A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,7 +588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -603,7 +603,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0374aa5c765484f88e1cb2b430cb584
+      - 44c5ae1b11214ff09c99669c1b030c56
   response:
     status:
       code: 200
@@ -614,13 +614,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:37:20 GMT
+      - Mon, 06 Aug 2018 17:01:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -638,13 +638,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:20 GMT
+      - Mon, 06 Aug 2018 17:01:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5d010033-c209-4281-a508-ceb6ef86aa11
+      - req-3615aa26-8411-4e05-9d87-cb3c7fdb10c1
       Content-Length:
       - '370'
       Connection:
@@ -653,13 +653,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:20.280163", "expires":
-        "2018-08-03T20:37:20Z", "id": "f82ca54b2008483495159efbbb0a8077", "audit_ids":
-        ["B197IN4IREqMQYX7U6n3AA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:16.291634", "expires":
+        "2018-08-06T18:01:16Z", "id": "cbe4abbb36dc4a889d310ca4572d25cc", "audit_ids":
+        ["0tznGvS6QReO6e5x-yP27g"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -674,20 +674,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f82ca54b2008483495159efbbb0a8077
+      - cbe4abbb36dc4a889d310ca4572d25cc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:20 GMT
+      - Mon, 06 Aug 2018 17:01:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f37a2996-fe38-4b44-b792-e3f52bcd335e
+      - req-4c9b5e4e-8138-47ab-8436-afc9c655b90f
       Content-Length:
       - '500'
       Connection:
@@ -704,13 +704,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"f82ca54b2008483495159efbbb0a8077"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"cbe4abbb36dc4a889d310ca4572d25cc"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -722,13 +722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:20 GMT
+      - Mon, 06 Aug 2018 17:01:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eecd2ca8-d630-44e2-b80c-81196e883f5a
+      - req-1d6152c0-ab48-4991-a20d-82b54c283691
       Content-Length:
       - '4143'
       Connection:
@@ -737,11 +737,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:20.768993", "expires":
-        "2018-08-03T20:37:20Z", "id": "65d282faf32e4216b46e4404e9c56aa1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:16.939224", "expires":
+        "2018-08-06T18:01:16Z", "id": "a274401090e24370bb2deee0c01aca1c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["k9xa3PlYQ5CHwgjfW7KxLg",
-        "B197IN4IREqMQYX7U6n3AA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zISP-pOmQXalDjRXduFgXQ",
+        "0tznGvS6QReO6e5x-yP27g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -785,7 +785,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -800,20 +800,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f82ca54b2008483495159efbbb0a8077
+      - cbe4abbb36dc4a889d310ca4572d25cc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:20 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f795a64-8555-4798-8775-0481d3876c91
+      - req-d48e9eeb-d32d-4f35-8162-98e40a9d057a
       Content-Length:
       - '500'
       Connection:
@@ -830,7 +830,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:20 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -848,13 +848,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:21 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-471bbbef-8fc4-4ec0-b72c-d1ab054a910b
+      - req-18632503-b97b-4e21-8244-ac0c7883f3db
       Content-Length:
       - '4117'
       Connection:
@@ -863,10 +863,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:21.271992", "expires":
-        "2018-08-03T20:37:21Z", "id": "ebda798d68d64b1d8614dd93afdaba0c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.290243", "expires":
+        "2018-08-06T18:01:17Z", "id": "c85208321df140ef8f6d84512c8aaf81", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gSRCemUcQpO4prp_DjNuKg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fojVoLNWQP-dKJhc_ur7SQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -910,7 +910,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -925,7 +925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebda798d68d64b1d8614dd93afdaba0c
+      - c85208321df140ef8f6d84512c8aaf81
   response:
     status:
       code: 200
@@ -936,7 +936,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:21 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -945,7 +945,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -963,13 +963,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:21 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48def84b-97fb-4320-b4fe-a5c3ef100335
+      - req-c2060bae-5348-4deb-a39f-a87406b828f1
       Content-Length:
       - '4131'
       Connection:
@@ -978,10 +978,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:21.662194", "expires":
-        "2018-08-03T20:37:21Z", "id": "8fdd86335d454e16b17b0d9080e44c3e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.566898", "expires":
+        "2018-08-06T18:01:17Z", "id": "97dd9f1f0ec54eea8878a668370faedd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Q-68zjl5Sb6MK5U14cyoIg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ta_RSzMoThm5_2YXPYj17Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1025,7 +1025,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1040,7 +1040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8fdd86335d454e16b17b0d9080e44c3e
+      - 97dd9f1f0ec54eea8878a668370faedd
   response:
     status:
       code: 200
@@ -1051,7 +1051,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:21 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1060,7 +1060,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:21 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1078,13 +1078,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:21 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e5bf0069-52ef-4a67-b5ca-35a9913d71d6
+      - req-80896249-7cde-4924-b01d-de76aab025ba
       Content-Length:
       - '4118'
       Connection:
@@ -1093,10 +1093,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:22.029080", "expires":
-        "2018-08-03T20:37:21Z", "id": "03ccb17bc29d46169f190765ba7dcbf6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.849140", "expires":
+        "2018-08-06T18:01:17Z", "id": "62896bf235b74e24bcab9f2576cf6038", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["YVZ9vTkcTkKFyI0d6tdJaw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1wiDVEEbSKOGDQXaY_bXFA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1140,7 +1140,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1155,7 +1155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 03ccb17bc29d46169f190765ba7dcbf6
+      - 62896bf235b74e24bcab9f2576cf6038
   response:
     status:
       code: 200
@@ -1166,7 +1166,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:22 GMT
+      - Mon, 06 Aug 2018 17:01:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1175,7 +1175,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1193,13 +1193,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:22 GMT
+      - Mon, 06 Aug 2018 17:01:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-186fc655-088c-430a-b5a7-d685377d851d
+      - req-e06edd2a-2684-485b-b560-06a75833c635
       Content-Length:
       - '4117'
       Connection:
@@ -1208,10 +1208,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:22.383465", "expires":
-        "2018-08-03T20:37:22Z", "id": "6545993424b24143bd2daaedbc873f40", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:18.126146", "expires":
+        "2018-08-06T18:01:18Z", "id": "ea907f15076144d99588f0fe9fc89d0a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UppTobgkSICQXmszFFPo2A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wVBT5_h3Tiinmn4ycYuPnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1255,7 +1255,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:22 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1270,7 +1270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6545993424b24143bd2daaedbc873f40
+      - ea907f15076144d99588f0fe9fc89d0a
   response:
     status:
       code: 200
@@ -1281,35 +1281,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-43463f8c-7bc2-419e-b264-daf8fa048bd5
+      - req-610443d5-279f-4d81-a946-434664fa974b
       Date:
-      - Fri, 03 Aug 2018 19:37:22 GMT
+      - Mon, 06 Aug 2018 17:01:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -1322,108 +1304,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6545993424b24143bd2daaedbc873f40
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fbe5fd5d-7399-4ce2-8b3a-7395fdcfe515
-      Date:
-      - Fri, 03 Aug 2018 19:37:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1471,7 +1374,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea907f15076144d99588f0fe9fc89d0a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8c875450-5df4-40d3-9dc9-103169713fe7
+      Date:
+      - Mon, 06 Aug 2018 17:01:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1495,6 +1442,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1506,6 +1459,53 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1519,7 +1519,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1537,13 +1537,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:23 GMT
+      - Mon, 06 Aug 2018 17:01:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e7fda49-4e33-416c-b401-ccb5cd94419f
+      - req-1f642d6f-d735-475c-a1af-36da3d87a0ba
       Content-Length:
       - '4131'
       Connection:
@@ -1552,10 +1552,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:23.542836", "expires":
-        "2018-08-03T20:37:23Z", "id": "b5f5f7f8bd344c96be3a7d3def25dbb1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:19.062199", "expires":
+        "2018-08-06T18:01:19Z", "id": "eafda5cec7ed4d9eae70ea2ba09cae9f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fAOT-7XbS2qZ5gDKBkLk2g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sTuZvheBRkeJKwT9rRmK4A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1599,7 +1599,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1614,7 +1614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b5f5f7f8bd344c96be3a7d3def25dbb1
+      - eafda5cec7ed4d9eae70ea2ba09cae9f
   response:
     status:
       code: 200
@@ -1625,17 +1625,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1cd4eed3-4790-4ba9-8c6f-473f5d7f2356
+      - req-83a2e358-9925-4452-b87c-da4eec86d79d
       Date:
-      - Fri, 03 Aug 2018 19:37:23 GMT
+      - Mon, 06 Aug 2018 17:01:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1683,41 +1718,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1731,7 +1731,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:23 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1746,7 +1746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b5f5f7f8bd344c96be3a7d3def25dbb1
+      - eafda5cec7ed4d9eae70ea2ba09cae9f
   response:
     status:
       code: 200
@@ -1757,17 +1757,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-465ecd6f-bea2-42f9-b719-cd4300a8d084
+      - req-497ab87d-e413-49f8-af84-a573ce73c6c3
       Date:
-      - Fri, 03 Aug 2018 19:37:24 GMT
+      - Mon, 06 Aug 2018 17:01:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1815,41 +1850,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1863,7 +1863,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1878,7 +1878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0374aa5c765484f88e1cb2b430cb584
+      - 44c5ae1b11214ff09c99669c1b030c56
   response:
     status:
       code: 200
@@ -1889,17 +1889,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3effa174-825b-42b6-b20c-acf769698f68
+      - req-e42d5dc4-d7e5-4010-808e-e6d2811ba228
       Date:
-      - Fri, 03 Aug 2018 19:37:24 GMT
+      - Mon, 06 Aug 2018 17:01:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1947,7 +1982,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 44c5ae1b11214ff09c99669c1b030c56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-707c9b08-f42d-425f-859c-cc438c5ad42d
+      Date:
+      - Mon, 06 Aug 2018 17:01:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1971,6 +2050,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1982,6 +2067,53 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1995,10 +2127,90 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:24 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 17:01:20 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-a3ba0e39-2e98-4128-add8-a5051f7f4ad5
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:20.297612", "expires":
+        "2018-08-06T18:01:20Z", "id": "40784ef2808f449b8b8a7d92985191d0", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5JLYgZr8QEiSUP53R3w8aQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -2010,7 +2222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0374aa5c765484f88e1cb2b430cb584
+      - 40784ef2808f449b8b8a7d92985191d0
   response:
     status:
       code: 200
@@ -2021,9 +2233,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-46fe88f8-9ce9-46ea-82ea-f6f95d1f1e8f
+      - req-82876867-842b-4e79-9af0-07efb83685d3
       Date:
-      - Fri, 03 Aug 2018 19:37:24 GMT
+      - Mon, 06 Aug 2018 17:01:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -2127,219 +2339,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:24 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Aug 2018 19:37:25 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-de7ffdd7-4609-47fd-87bf-366d72348b6a
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:25.225171", "expires":
-        "2018-08-03T20:37:25Z", "id": "04a55d957c494953bd0c5a914699fd6f", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LwWDtAkQRRKTugy_zkTjHA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 04a55d957c494953bd0c5a914699fd6f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-79f730cf-b038-4949-956d-05ed02611832
-      Date:
-      - Fri, 03 Aug 2018 19:37:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2354,7 +2354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04a55d957c494953bd0c5a914699fd6f
+      - 40784ef2808f449b8b8a7d92985191d0
   response:
     status:
       code: 200
@@ -2365,17 +2365,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e35f40a6-f4a8-4435-b3a1-7c9afbd2906b
+      - req-90ada232-fc49-4b6d-a737-114f0cd78a07
       Date:
-      - Fri, 03 Aug 2018 19:37:25 GMT
+      - Mon, 06 Aug 2018 17:01:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2423,41 +2458,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2471,5 +2471,5 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:25 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:09 GMT
+      - Mon, 06 Aug 2018 17:01:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aedd51e3-040c-46dc-a798-9c134064431d
+      - req-091710ed-315a-4d05-a238-3c1602be54f9
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:09.850828", "expires":
-        "2018-08-03T20:37:09Z", "id": "97bb065ca3f846829d6eb01562ebba09", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:21.820491", "expires":
+        "2018-08-06T18:01:21Z", "id": "56e66823b45446b2b6c0193abe192c28", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ft5yi6UYR-CHif1amdaYpA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_MzYkDOuQC2mBelkGt1Acg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97bb065ca3f846829d6eb01562ebba09
+      - 56e66823b45446b2b6c0193abe192c28
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:09 GMT
+      - Mon, 06 Aug 2018 17:01:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:09 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:10 GMT
+      - Mon, 06 Aug 2018 17:01:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ed06a359-fde8-40fe-9aa7-4ee681dc441b
+      - req-f8fe790c-6ad5-4081-9efd-444cf81838e2
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:10.279343", "expires":
-        "2018-08-03T20:37:10Z", "id": "dd567c51c0104cb2a5e7d33de42a085f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.125679", "expires":
+        "2018-08-06T18:01:22Z", "id": "4fb68998789c411ca3a6c1225b031d20", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mPY9cQ5QTWupRrf0jw29ZA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["6dlbEqENT2iH2hiI2T6bbQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd567c51c0104cb2a5e7d33de42a085f
+      - 4fb68998789c411ca3a6c1225b031d20
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:10 GMT
+      - Mon, 06 Aug 2018 17:01:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-844b1121-f8bc-4dd0-8295-ca9fad158abf
+      - req-d6efd2c4-ccf1-4a8e-b038-3d1f1d26c339
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:10 GMT
+      - Mon, 06 Aug 2018 17:01:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d947411a-7aed-47b4-b54d-605a1a55095d
+      - req-6228d5c7-71d6-494d-a74a-901be37224d0
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:10.858760", "expires":
-        "2018-08-03T20:37:10Z", "id": "3a3d041912c0421795c9428d80a76705", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.607053", "expires":
+        "2018-08-06T18:01:22Z", "id": "e5ff1ba4e1b04f3083f38a1fa54529ce", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Yww_Ufe2Q66j0YaFc-uQuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Nrgi7k1mTei525Mi0BtfCw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -337,7 +337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a3d041912c0421795c9428d80a76705
+      - e5ff1ba4e1b04f3083f38a1fa54529ce
   response:
     status:
       code: 200
@@ -348,13 +348,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:37:10 GMT
+      - Mon, 06 Aug 2018 17:01:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:10 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -372,13 +372,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:11 GMT
+      - Mon, 06 Aug 2018 17:01:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bcf3aef4-6a33-42f9-a118-0367ffd3b091
+      - req-480b12a6-5564-436f-bcf7-28c62d56eee9
       Content-Length:
       - '370'
       Connection:
@@ -387,13 +387,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:11.131930", "expires":
-        "2018-08-03T20:37:11Z", "id": "c35e01c303314c2bb9c9da0061b47e77", "audit_ids":
-        ["7a_xfIqkTIGjqRb3Iof1Rg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.896523", "expires":
+        "2018-08-06T18:01:22Z", "id": "02081742577d46ff9ea50eaaaebeceb3", "audit_ids":
+        ["lu13pYLuTc2GKKOXKBX0pA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c35e01c303314c2bb9c9da0061b47e77
+      - '02081742577d46ff9ea50eaaaebeceb3'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:11 GMT
+      - Mon, 06 Aug 2018 17:01:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b6287691-e382-438b-bcaf-e3f534363dd4
+      - req-73b54805-36a7-4130-bbbc-fc6ed3e094c8
       Content-Length:
       - '500'
       Connection:
@@ -438,13 +438,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c35e01c303314c2bb9c9da0061b47e77"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"02081742577d46ff9ea50eaaaebeceb3"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:11 GMT
+      - Mon, 06 Aug 2018 17:01:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f3c62c60-a86f-406c-85ec-c426fd6e62ac
+      - req-8354ef93-eb7c-42cf-8455-7aac478d6176
       Content-Length:
       - '4143'
       Connection:
@@ -471,11 +471,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:11.635186", "expires":
-        "2018-08-03T20:37:11Z", "id": "6498aeb5c9684580a3bfe267f8457ca1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:23.688060", "expires":
+        "2018-08-06T18:01:22Z", "id": "c15c831a4d0a44b2b2173dd113402747", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["R5-YIgneTD6XL_aDOh52dQ",
-        "7a_xfIqkTIGjqRb3Iof1Rg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uqR0bLzcSlqJx1DVI7sUhw",
+        "lu13pYLuTc2GKKOXKBX0pA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -519,7 +519,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -534,20 +534,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c35e01c303314c2bb9c9da0061b47e77
+      - '02081742577d46ff9ea50eaaaebeceb3'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:11 GMT
+      - Mon, 06 Aug 2018 17:01:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6b9939d4-b6e2-4c03-8469-49c7b1409e66
+      - req-f4aceda4-0287-48fb-b3e6-4a1a443e2905
       Content-Length:
       - '500'
       Connection:
@@ -564,7 +564,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:11 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -582,13 +582,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:11 GMT
+      - Mon, 06 Aug 2018 17:01:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb8442bc-1256-4aa6-985b-e68b2637e871
+      - req-624c463a-a2f3-4bb0-8b0c-727c12373256
       Content-Length:
       - '4117'
       Connection:
@@ -597,10 +597,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:12.072431", "expires":
-        "2018-08-03T20:37:12Z", "id": "43b127227f3e45368f65f4ae973f9ce4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.080989", "expires":
+        "2018-08-06T18:01:24Z", "id": "35f1bed92862436a9ee6e5d961274c8d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ED5IaSewQgiTXKlW13M1nw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GU6OzpFyRtWUlj0vjWcJMw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -644,7 +644,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -659,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43b127227f3e45368f65f4ae973f9ce4
+      - 35f1bed92862436a9ee6e5d961274c8d
   response:
     status:
       code: 200
@@ -670,7 +670,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:12 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -679,7 +679,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -697,13 +697,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:12 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5fd6599b-fdfd-445d-8ec3-eaa9735459b4
+      - req-bf7d575d-0673-4186-becf-eb0849011815
       Content-Length:
       - '4131'
       Connection:
@@ -712,10 +712,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:12.488975", "expires":
-        "2018-08-03T20:37:12Z", "id": "291cc597fc1e420085b41a78e40905fb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.426734", "expires":
+        "2018-08-06T18:01:24Z", "id": "54806edc7b14417783f4bb4e797881a1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["uEfamAxSTretQIeH5HEH_g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ca5SzTdkSJecNm7HiovEAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -759,7 +759,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -774,7 +774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 291cc597fc1e420085b41a78e40905fb
+      - 54806edc7b14417783f4bb4e797881a1
   response:
     status:
       code: 200
@@ -785,7 +785,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:12 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -794,7 +794,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -812,13 +812,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:12 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-63003ec2-dbe7-406b-8a63-7a50c377808a
+      - req-f1225153-a7a3-4e7f-b320-93946b24333f
       Content-Length:
       - '4118'
       Connection:
@@ -827,10 +827,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:12.920895", "expires":
-        "2018-08-03T20:37:12Z", "id": "4c08d2994938429c8c141af34c75e7fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.716902", "expires":
+        "2018-08-06T18:01:24Z", "id": "ff1d8a59099a4d2d818c79bb357b70b8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1_wL5nXMQxaGrJlYtr0Q8w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qqoYBEyAR-2Tkkl6Q-XvmQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -874,7 +874,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:12 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -889,7 +889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c08d2994938429c8c141af34c75e7fc
+      - ff1d8a59099a4d2d818c79bb357b70b8
   response:
     status:
       code: 200
@@ -900,7 +900,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:13 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -909,7 +909,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:13 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -927,13 +927,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:13 GMT
+      - Mon, 06 Aug 2018 17:01:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86c8e882-4e15-4184-bbfd-a7447a6ecbbc
+      - req-7ea91920-7790-4734-b336-abdf176fd563
       Content-Length:
       - '4117'
       Connection:
@@ -942,10 +942,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:13.334005", "expires":
-        "2018-08-03T20:37:13Z", "id": "b356d2fb6f1149f5bdc6c9d76aa281b0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:25.028130", "expires":
+        "2018-08-06T18:01:24Z", "id": "e59c3d725c944d17ba3287380d3c7d87", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dHwlZT3MReihwTr2v3g5jA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DCwsqRSGQzWisYgvLtcAzQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -989,7 +989,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:13 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b356d2fb6f1149f5bdc6c9d76aa281b0
+      - e59c3d725c944d17ba3287380d3c7d87
   response:
     status:
       code: 200
@@ -1015,141 +1015,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-fe51942d-3b80-4c7d-9054-40ca5933537f
+      - req-abebe494-a46b-42c7-b253-b833da4f9947
       Date:
-      - Fri, 03 Aug 2018 19:37:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b356d2fb6f1149f5bdc6c9d76aa281b0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7f40ade3-daae-4951-85fc-27f5cb5b3270
-      Date:
-      - Fri, 03 Aug 2018 19:37:13 GMT
+      - Mon, 06 Aug 2018 17:01:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -1253,219 +1121,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:13 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Aug 2018 19:37:14 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-d46e3d6a-2b96-4bd5-be4a-014f038a4569
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:14.279327", "expires":
-        "2018-08-03T20:37:14Z", "id": "d1c48476ce9a43fdb5586b428d2a2442", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xDJ97qH2Tk2R5H2IQ5SYqQ"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d1c48476ce9a43fdb5586b428d2a2442
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-91a3029b-e742-41a9-b36b-61a706ea5ca0
-      Date:
-      - Fri, 03 Aug 2018 19:37:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:14 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1480,7 +1136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c48476ce9a43fdb5586b428d2a2442
+      - e59c3d725c944d17ba3287380d3c7d87
   response:
     status:
       code: 200
@@ -1491,76 +1147,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-85289128-8efc-4dca-84da-82a74c99a901
+      - req-9dab98c0-b341-4e12-afaa-f536f2ea350d
       Date:
-      - Fri, 03 Aug 2018 19:37:14 GMT
+      - Mon, 06 Aug 2018 17:01:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1584,127 +1176,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a3d041912c0421795c9428d80a76705
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2611564d-b1b0-4a2e-ab92-78401e474a66
-      Date:
-      - Fri, 03 Aug 2018 19:37:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1716,138 +1193,53 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a3d041912c0421795c9428d80a76705
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c0f385dc-d415-40f3-9d77-8473de98869a
-      Date:
-      - Fri, 03 Aug 2018 19:37:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1861,13 +1253,13 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:15 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1879,35 +1271,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:15 GMT
+      - Mon, 06 Aug 2018 17:01:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b1d889b8-7a72-47d0-b7a2-e841a9e8bde2
+      - req-c44458e4-3764-4c09-ab45-1f79d691c6c5
       Content-Length:
-      - '4118'
+      - '4131'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:16.090961", "expires":
-        "2018-08-03T20:37:16Z", "id": "7811e8504d7e484fb63cd7aaaa3dfc44", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["zuNjXhFART-f_-0yLMje2w"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:25.823952", "expires":
+        "2018-08-06T18:01:25Z", "id": "a5e51bd9e52e45159fd979b3ee43f970", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GsoF60euSUq0dCIQX0i-nw"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
         "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
         "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
         "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
         "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
         "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
         [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
         "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
@@ -1918,20 +1310,20 @@ http_interactions:
         "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
         "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
         "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
         [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
         "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
         "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
         [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
         "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
         [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
         "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
@@ -1941,7 +1333,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1956,7 +1348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7811e8504d7e484fb63cd7aaaa3dfc44
+      - a5e51bd9e52e45159fd979b3ee43f970
   response:
     status:
       code: 200
@@ -1967,9 +1359,273 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4cabb753-a0d3-46a1-a48c-83810fc55d8f
+      - req-926a2121-20b5-4f1a-9e90-9bf36b5cafd3
       Date:
-      - Fri, 03 Aug 2018 19:37:16 GMT
+      - Mon, 06 Aug 2018 17:01:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a5e51bd9e52e45159fd979b3ee43f970
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-428be09f-3723-4640-abb3-9730ba3bd4db
+      Date:
+      - Mon, 06 Aug 2018 17:01:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e5ff1ba4e1b04f3083f38a1fa54529ce
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-95ac63d4-6fc3-4a9d-96e5-82a5152ea715
+      Date:
+      - Mon, 06 Aug 2018 17:01:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -2073,7 +1729,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2088,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7811e8504d7e484fb63cd7aaaa3dfc44
+      - e5ff1ba4e1b04f3083f38a1fa54529ce
   response:
     status:
       code: 200
@@ -2099,35 +1755,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-55e0cf8b-ee45-4af2-8596-887c614aa3e9
+      - req-c287f38b-1697-4cdd-9929-11e7785cda31
       Date:
-      - Fri, 03 Aug 2018 19:37:16 GMT
+      - Mon, 06 Aug 2018 17:01:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -2140,58 +1778,76 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2205,5 +1861,349 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:16 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 17:01:27 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-c5b587a6-522d-48d3-bd86-e0eea9feeedf
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:27.314932", "expires":
+        "2018-08-06T18:01:27Z", "id": "d9ae62c99f9141b3a65891e4fee0d1fc", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g05fy2b_R4S5cPiN6dM3zQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d9ae62c99f9141b3a65891e4fee0d1fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a261f7e0-b50b-4d69-aa20-384b9f797953
+      Date:
+      - Mon, 06 Aug 2018 17:01:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d9ae62c99f9141b3a65891e4fee0d1fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-dd3af27c-96cf-4f50-92b6-2b3cc8f64b25
+      Date:
+      - Mon, 06 Aug 2018 17:01:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:26 GMT
+      - Mon, 06 Aug 2018 17:01:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69774ed1-304e-4d90-a932-2d2d9df0078e
+      - req-7d9fa120-4409-4b32-b85a-2aaa36272412
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:27.030711", "expires":
-        "2018-08-03T20:37:26Z", "id": "3a5e2dcfdae040b69f4e2ef76a5bfd16", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:28.971310", "expires":
+        "2018-08-06T18:01:28Z", "id": "1013e719859748ada14555f11a0435b5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["TR8WeTmqQYC8aBzZ9Wr-NA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2zOiVfUwQ_G1fw8IakaFiw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:27 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:27 GMT
+      - Mon, 06 Aug 2018 17:01:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:27 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,9 +143,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-0b68ba7e-5cd4-4460-a63c-db6a84aee452
+      - req-7b7f059f-ac16-488a-8631-99b34778135d
       Date:
-      - Fri, 03 Aug 2018 19:37:28 GMT
+      - Mon, 06 Aug 2018 17:01:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:28 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-88eefca2-d031-4544-967b-a22b449548b7
+      - req-0803c51f-a62e-4f19-a85b-6195016df49f
       Date:
-      - Fri, 03 Aug 2018 19:37:28 GMT
+      - Mon, 06 Aug 2018 17:01:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:28 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-0ed3e05f-bdbd-49ed-8b9b-2558ad4fbc00
+      - req-a131a60e-7b09-48f0-aadc-5f9de1bfcf8f
       Date:
-      - Fri, 03 Aug 2018 19:37:29 GMT
+      - Mon, 06 Aug 2018 17:01:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e7a5d573-c74f-4712-b28f-9231232c3b6e
+      - req-a761a7cc-a52b-4327-b1c5-87e1283dcb57
       Date:
-      - Fri, 03 Aug 2018 19:37:29 GMT
+      - Mon, 06 Aug 2018 17:01:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:29 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:29 GMT
+      - Mon, 06 Aug 2018 17:01:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75e7b57a-4ac1-4d66-a9f2-a25481ecdee5
+      - req-7539165b-dab5-4fae-adc8-55ff8b5ff8a4
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:30.000950", "expires":
-        "2018-08-03T20:37:29Z", "id": "98d27b2fae834e7ca6f8ee0cff3949ec", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:31.084469", "expires":
+        "2018-08-06T18:01:31Z", "id": "e186ce13f156403197449ac3a94fd48c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["J3xfORe0TWmvoYzDWQ_2-A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SECWVX_iS9en-mGKJbNbWg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -434,13 +434,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Fri, 03 Aug 2018 19:37:30 GMT
+      - Mon, 06 Aug 2018 17:01:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -466,9 +466,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-18123435-f801-47cb-a6ce-938e505fa0db
+      - req-424c78af-59db-4b44-809f-9435964de6ad
       Date:
-      - Fri, 03 Aug 2018 19:37:30 GMT
+      - Mon, 06 Aug 2018 17:01:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -477,7 +477,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -495,13 +495,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:30 GMT
+      - Mon, 06 Aug 2018 17:01:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e42fb9dd-b631-4dd1-b00e-e81595bbb238
+      - req-f0c7c0a1-6efb-4f49-a195-2113a84dac49
       Content-Length:
       - '4170'
       Connection:
@@ -510,10 +510,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:30.719077", "expires":
-        "2018-08-03T20:37:30Z", "id": "a885ae8b5e614f2189252f61ff49f506", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:31.591743", "expires":
+        "2018-08-06T18:01:31Z", "id": "321e7dc3f9ad44d38d10a1c9793c7244", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZeKaaeWyTBy7jurb5-GrqA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["-6NLkLL0Qn6kWSXvqXq_vA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -573,20 +573,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a885ae8b5e614f2189252f61ff49f506
+      - 321e7dc3f9ad44d38d10a1c9793c7244
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:30 GMT
+      - Mon, 06 Aug 2018 17:01:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f87a607-b578-4391-8cba-f8b2fc0f1930
+      - req-21aaf223-df2b-4468-af6a-843253308922
       Content-Length:
       - '500'
       Connection:
@@ -603,7 +603,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:30 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -618,7 +618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
+      - 1013e719859748ada14555f11a0435b5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -631,9 +631,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-4bb273d4-9d11-4b14-be73-d7529ebacae0
+      - req-39dd42b1-4172-4e6f-a58c-257d11d94d87
       Date:
-      - Fri, 03 Aug 2018 19:37:31 GMT
+      - Mon, 06 Aug 2018 17:01:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -642,7 +642,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -660,13 +660,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:31 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fd7cfac8-1052-40b2-8167-84b2ce1a19fc
+      - req-df0a290c-ca9a-4269-96f9-d155e86164ef
       Content-Length:
       - '4170'
       Connection:
@@ -675,10 +675,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:31.612637", "expires":
-        "2018-08-03T20:37:31Z", "id": "dd1fee70caa34cd39883cfb6bf5de216", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:32.140401", "expires":
+        "2018-08-06T18:01:32Z", "id": "748be19a274448b0b87ca06c1225d378", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["wxL-KFoSQmmn_a2bxs-_kA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HWWpo3-LQfGeG_anNI91nQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -723,7 +723,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -738,7 +738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd1fee70caa34cd39883cfb6bf5de216
+      - 748be19a274448b0b87ca06c1225d378
   response:
     status:
       code: 300
@@ -749,7 +749,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Fri, 03 Aug 2018 19:37:31 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -762,7 +762,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:31 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -777,7 +777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd1fee70caa34cd39883cfb6bf5de216
+      - 748be19a274448b0b87ca06c1225d378
   response:
     status:
       code: 200
@@ -788,9 +788,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d6c08832-b01c-4dfb-a62c-69d2e92b988d
+      - req-6f8a2fc9-d4a4-4ef7-aba2-d9a24da3ac3c
       Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -801,198 +801,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
-      X-Openstack-Nova-Api-Version:
-      - '2.12'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1617'
-      X-Compute-Request-Id:
-      - req-5f9445d0-094d-4886-9c66-edbe7021b9f1
-      Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
-        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
-        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
-        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
-        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
-        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
-      X-Openstack-Nova-Api-Version:
-      - '2.12'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '433'
-      X-Compute-Request-Id:
-      - req-1cb311b1-30f6-4b0f-82d9-4bf1d97a5189
-      Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
-        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
-        "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
-        1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
-        1, "disk": 1, "id": "6"}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a5e2dcfdae040b69f4e2ef76a5bfd16
-      X-Openstack-Nova-Api-Version:
-      - '2.12'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '197'
-      X-Compute-Request-Id:
-      - req-6f583bdb-f220-44d9-80c1-4e31627170f1
-      Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '440'
-      X-Openstack-Request-Id:
-      - req-0e1ceb78-bbfb-46a8-9108-42f254ddea36
-      Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
-        14}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '409'
-      X-Openstack-Request-Id:
-      - req-613565d4-0e25-46c1-8892-ff723ace400a
-      Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:32 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1010,13 +819,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:32 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49be6881-9bcb-478e-9efb-f80bbbf3efe3
+      - req-eacb4c8e-128f-4425-ae78-54f21a87add0
       Content-Length:
       - '370'
       Connection:
@@ -1025,13 +834,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:33.098898", "expires":
-        "2018-08-03T20:37:33Z", "id": "78ecf030eb07433ba8790a7aa70f7978", "audit_ids":
-        ["9oXJoy4qSOqKJMJWyZ2n1w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:32.675622", "expires":
+        "2018-08-06T18:01:32Z", "id": "3922484c86514dcc99f842409448573f", "audit_ids":
+        ["Jds7kGn-SaGuqMVJODPzNQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1046,20 +855,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78ecf030eb07433ba8790a7aa70f7978
+      - 3922484c86514dcc99f842409448573f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:33 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d2a877ca-4813-4649-b75d-658423121e68
+      - req-9f01a3c0-e5bf-41d7-bc35-3f34071e1bf8
       Content-Length:
       - '500'
       Connection:
@@ -1076,13 +885,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"78ecf030eb07433ba8790a7aa70f7978"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"3922484c86514dcc99f842409448573f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1094,13 +903,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:33 GMT
+      - Mon, 06 Aug 2018 17:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-522db29f-43be-4789-9487-ca59510ecb59
+      - req-0836b2a8-e766-450d-8e9c-2800f5b1ca50
       Content-Length:
       - '4143'
       Connection:
@@ -1109,11 +918,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:33.649221", "expires":
-        "2018-08-03T20:37:33Z", "id": "0faf70b6afb94253900b24911a109709", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.071911", "expires":
+        "2018-08-06T18:01:32Z", "id": "b7d5eee97a374a50ba3b8bc870db264c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UG0ZLY1lT0eVY8NrK9yXMw",
-        "9oXJoy4qSOqKJMJWyZ2n1w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Z7Kse_7kTpGCCaRuEO4WZw",
+        "Jds7kGn-SaGuqMVJODPzNQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1157,7 +966,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1172,20 +981,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78ecf030eb07433ba8790a7aa70f7978
+      - 3922484c86514dcc99f842409448573f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:33 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c52386a4-0bdb-4d25-83e1-1f243316ee73
+      - req-5f2d8699-91d4-4beb-952a-b76f8eccea1d
       Content-Length:
       - '500'
       Connection:
@@ -1202,7 +1011,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:33 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1220,13 +1029,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:33 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cd63f197-0cbe-48f4-a34b-73a5694f06e9
+      - req-cbeae936-67bd-4c36-97ab-c7f7d1c6098f
       Content-Length:
       - '4117'
       Connection:
@@ -1235,10 +1044,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:34.088442", "expires":
-        "2018-08-03T20:37:34Z", "id": "f07bbbeb23e641b6941bbb3818109987", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.460040", "expires":
+        "2018-08-06T18:01:33Z", "id": "472274e41a3649caa8929e0848b3de4b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hbmDWEQhSx-9MY86zKz1Pg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hm_TqbmSSi6LdK5eepNV3A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1282,7 +1091,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1297,7 +1106,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f07bbbeb23e641b6941bbb3818109987
+      - 472274e41a3649caa8929e0848b3de4b
   response:
     status:
       code: 200
@@ -1308,7 +1117,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:34 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1317,7 +1126,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1335,13 +1144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:34 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46620beb-2a0d-4c5c-9c5e-a99cbc8ad09e
+      - req-190bf866-a756-4708-bad5-18f7efa35c28
       Content-Length:
       - '4131'
       Connection:
@@ -1350,10 +1159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:34.455642", "expires":
-        "2018-08-03T20:37:34Z", "id": "20bc3753cd15402781c4525efe33b338", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.750079", "expires":
+        "2018-08-06T18:01:33Z", "id": "4d0edf8d676b46229afdbce9d3627a0c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lkAnJh9MQIK2jfGhF9fYwQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1Eu_37OZQHi8vK7dcIydNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1397,7 +1206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1412,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 20bc3753cd15402781c4525efe33b338
+      - 4d0edf8d676b46229afdbce9d3627a0c
   response:
     status:
       code: 200
@@ -1423,7 +1232,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:34 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1432,7 +1241,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1450,13 +1259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:34 GMT
+      - Mon, 06 Aug 2018 17:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a8939056-cc58-460f-af65-aa5e20a01317
+      - req-4b93dc03-6445-4fd7-a3d3-4a5c752e76d5
       Content-Length:
       - '4118'
       Connection:
@@ -1465,10 +1274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:34.839234", "expires":
-        "2018-08-03T20:37:34Z", "id": "f5cb2faf5ad84b9dbc31bd1d7b022b8d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:34.031537", "expires":
+        "2018-08-06T18:01:34Z", "id": "8434b7e4079f46a3bbce4aaf55c5c541", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Z2NBewT3RHG0NeMPsDigQA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["HfIyMx1zTVKmnqFt7hbs7w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1512,7 +1321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1527,7 +1336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5cb2faf5ad84b9dbc31bd1d7b022b8d
+      - 8434b7e4079f46a3bbce4aaf55c5c541
   response:
     status:
       code: 200
@@ -1538,7 +1347,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Fri, 03 Aug 2018 19:37:34 GMT
+      - Mon, 06 Aug 2018 17:01:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1547,7 +1356,478 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:34 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 472274e41a3649caa8929e0848b3de4b
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-cd301338-f5ce-48c9-8c48-5f318b118f6a
+      Date:
+      - Mon, 06 Aug 2018 17:01:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 472274e41a3649caa8929e0848b3de4b
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-96489484-a0e0-4b7c-a1e4-5e8f409369ed
+      Date:
+      - Mon, 06 Aug 2018 17:01:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4d0edf8d676b46229afdbce9d3627a0c
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-97acbf7a-d0c2-4fd3-ad10-6a11349e470a
+      Date:
+      - Mon, 06 Aug 2018 17:01:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4d0edf8d676b46229afdbce9d3627a0c
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-a0e9fe49-afea-46b2-86aa-4abd3b736282
+      Date:
+      - Mon, 06 Aug 2018 17:01:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-db7e2e81-03cf-4695-906a-ece0c5e08bae
+      Date:
+      - Mon, 06 Aug 2018 17:01:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-a0e94151-5873-48ce-8bde-1ee14d0b1b8b
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8434b7e4079f46a3bbce4aaf55c5c541
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-88cf52b4-a539-4e3f-9df6-d665275d1680
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8434b7e4079f46a3bbce4aaf55c5c541
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-864cedfc-d0f3-4d12-a237-d22fca06ddee
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      X-Compute-Request-Id:
+      - req-ed6b4afb-5fe2-4bd7-a57a-03f4d59b9363
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
+        1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
+        1, "disk": 1, "id": "6"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-3f31ec2b-42bd-4d13-af2b-98adb17191f0
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '440'
+      X-Openstack-Request-Id:
+      - req-72e3df59-b925-4177-98b6-80bb9db8fee5
+      Date:
+      - Mon, 06 Aug 2018 17:01:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
+        14}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '409'
+      X-Openstack-Request-Id:
+      - req-6d9ca7f5-1950-41b9-9506-be3967a567ac
+      Date:
+      - Mon, 06 Aug 2018 17:01:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1565,13 +1845,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:35 GMT
+      - Mon, 06 Aug 2018 17:01:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-241ccd40-058c-401f-be1c-5484acc72327
+      - req-ca906362-e505-4311-a57e-68320c236eb1
       Content-Length:
       - '4117'
       Connection:
@@ -1580,10 +1860,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:35.208806", "expires":
-        "2018-08-03T20:37:35Z", "id": "dcbe4c1a1820401eb079193e2c4d9f8b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:36.240424", "expires":
+        "2018-08-06T18:01:36Z", "id": "02e15f58164b485c99de220dbbdbc03b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["y_D_UmaXRKC-hNMJ36E1JQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ait_C091QcSu5_WzG20fww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1627,7 +1907,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:35 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1642,7 +1922,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dcbe4c1a1820401eb079193e2c4d9f8b
+      - 02e15f58164b485c99de220dbbdbc03b
   response:
     status:
       code: 200
@@ -1653,353 +1933,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6574afdf-20b8-402e-9977-60db9cd6cae4
+      - req-5d2e437c-661f-45be-a3ed-d2e4a5a589c2
       Date:
-      - Fri, 03 Aug 2018 19:37:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - dcbe4c1a1820401eb079193e2c4d9f8b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ac5ec0b2-449e-4697-b752-2766da61fcf0
-      Date:
-      - Fri, 03 Aug 2018 19:37:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:35 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Aug 2018 19:37:36 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a4798e9a-cb73-4c12-b20f-3b05e0bad9f1
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:36.220996", "expires":
-        "2018-08-03T20:37:36Z", "id": "f4e1036d77754478b43321e9595c7fb6", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PvL6GOsgRrGAg_SEdfLyfg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4e1036d77754478b43321e9595c7fb6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bb7610aa-7a63-4056-897d-259aeb2de569
-      Date:
-      - Fri, 03 Aug 2018 19:37:36 GMT
+      - Mon, 06 Aug 2018 17:01:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -2103,7 +2039,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2118,7 +2054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4e1036d77754478b43321e9595c7fb6
+      - 02e15f58164b485c99de220dbbdbc03b
   response:
     status:
       code: 200
@@ -2129,35 +2065,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8048909-338d-41ac-bb13-54bc51ac3e8a
+      - req-292cf660-7de8-43ef-ae73-8e035502c4b9
       Date:
-      - Fri, 03 Aug 2018 19:37:36 GMT
+      - Mon, 06 Aug 2018 17:01:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -2170,58 +2088,76 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2235,7 +2171,87 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:36 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 17:01:36 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-db023adb-0cb3-4336-bcb2-71b3aede3b80
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:36.907717", "expires":
+        "2018-08-06T18:01:36Z", "id": "2c39416231ba4f76920e66025b1198eb", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BLW28kmVQUSnQmCNJ2j_YA"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2250,7 +2266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - 2c39416231ba4f76920e66025b1198eb
   response:
     status:
       code: 200
@@ -2261,9 +2277,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-75d2663b-fb23-427e-bac8-3325f9060f8d
+      - req-cea41b83-c1ae-4807-b99f-191866b1776a
       Date:
-      - Fri, 03 Aug 2018 19:37:37 GMT
+      - Mon, 06 Aug 2018 17:01:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2c39416231ba4f76920e66025b1198eb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3c8da589-8db0-478e-a88b-acbaca609670
+      Date:
+      - Mon, 06 Aug 2018 17:01:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
@@ -2367,7 +2515,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d5fe90ad-8a27-41b8-966f-e1d91b962d5f
+      Date:
+      - Mon, 06 Aug 2018 17:01:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2382,7 +2662,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -2393,17 +2673,69 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-01b144b9-aac5-4aa3-b544-cdd5ee729ca7
+      - req-8b7c1dde-a05b-4b2f-a922-04537595bdd3
       Date:
-      - Fri, 03 Aug 2018 19:37:37 GMT
+      - Mon, 06 Aug 2018 17:01:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -2416,12 +2748,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -2434,72 +2760,26 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2517,13 +2797,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:37 GMT
+      - Mon, 06 Aug 2018 17:01:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b8e50d10-2240-43d1-b145-4c5ac2e3536c
+      - req-32f8d320-393b-47a1-ba12-0dec85d8520b
       Content-Length:
       - '4118'
       Connection:
@@ -2532,10 +2812,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:37.631620", "expires":
-        "2018-08-03T20:37:37Z", "id": "a7c31673e6fb4c39b254e62502d87930", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:38.034314", "expires":
+        "2018-08-06T18:01:38Z", "id": "62c051c02683488ba9cc0a197d945652", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["OlRMFzDWRreY769gfk81Ow"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["r-CqgDMtT6W0HfKgi_GRpQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2579,7 +2859,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:37 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2594,7 +2874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7c31673e6fb4c39b254e62502d87930
+      - 62c051c02683488ba9cc0a197d945652
   response:
     status:
       code: 200
@@ -2605,17 +2885,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5a16ef07-3a27-445b-b231-e875458cf976
+      - req-6e3a63e7-23f0-4569-8b26-5480ab45864c
       Date:
-      - Fri, 03 Aug 2018 19:37:38 GMT
+      - Mon, 06 Aug 2018 17:01:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2663,41 +2978,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2711,7 +2991,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2726,7 +3006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7c31673e6fb4c39b254e62502d87930
+      - 62c051c02683488ba9cc0a197d945652
   response:
     status:
       code: 200
@@ -2737,17 +3017,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-40cbd7e9-f540-4b9d-a549-8fada7ae5395
+      - req-5f461a5f-9074-475c-8ebb-be411f71d85f
       Date:
-      - Fri, 03 Aug 2018 19:37:38 GMT
+      - Mon, 06 Aug 2018 17:01:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2795,41 +3110,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2843,7 +3123,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -2858,7 +3138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -2869,9 +3149,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-30b88799-9df0-43ac-a249-2b6bb6ed0bc9
+      - req-d3278a38-8ed6-46eb-b8f5-e151e7bd28b3
       Date:
-      - Fri, 03 Aug 2018 19:37:38 GMT
+      - Mon, 06 Aug 2018 17:01:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2886,7 +3166,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -2901,7 +3181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dcbe4c1a1820401eb079193e2c4d9f8b
+      - 02e15f58164b485c99de220dbbdbc03b
   response:
     status:
       code: 200
@@ -2912,9 +3192,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-278ad05f-8df1-4c06-a211-2c40dc22ce88
+      - req-c27d8701-8407-4376-9d56-cd64241f2a0e
       Date:
-      - Fri, 03 Aug 2018 19:37:38 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2950,7 +3230,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -2965,7 +3245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dcbe4c1a1820401eb079193e2c4d9f8b
+      - 02e15f58164b485c99de220dbbdbc03b
   response:
     status:
       code: 200
@@ -2976,9 +3256,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-be3674fd-f60a-4c76-82b9-2f14b73b3bd4
+      - req-76bd5f5f-fc68-4cd1-afb6-e11c707673b8
       Date:
-      - Fri, 03 Aug 2018 19:37:38 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3014,7 +3294,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:38 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3029,7 +3309,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4e1036d77754478b43321e9595c7fb6
+      - 2c39416231ba4f76920e66025b1198eb
   response:
     status:
       code: 200
@@ -3040,9 +3320,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-34a6160c-f188-4b17-ac49-19b8fbb7bad1
+      - req-a8e2e81f-ab8b-488a-86fd-3694b526fecc
       Date:
-      - Fri, 03 Aug 2018 19:37:39 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3078,7 +3358,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3093,7 +3373,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4e1036d77754478b43321e9595c7fb6
+      - 2c39416231ba4f76920e66025b1198eb
   response:
     status:
       code: 200
@@ -3104,9 +3384,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-02943af9-7422-41f1-957b-fb15daca26c0
+      - req-b85cb0e9-9187-48d9-bc65-7ae4403f18d1
       Date:
-      - Fri, 03 Aug 2018 19:37:39 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3142,7 +3422,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3157,7 +3437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -3168,9 +3448,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-50ef46bc-929d-422c-85d9-98672cab57aa
+      - req-974598d8-ce52-4ff7-ad4d-d43764b22f4b
       Date:
-      - Fri, 03 Aug 2018 19:37:39 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3206,7 +3486,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3221,7 +3501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -3232,9 +3512,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-d04e739d-f44c-4cc3-8d10-395a58a74b4b
+      - req-09fa0760-8afb-47bf-aa86-68c66651b080
       Date:
-      - Fri, 03 Aug 2018 19:37:39 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3270,7 +3550,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:39 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3285,7 +3565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7c31673e6fb4c39b254e62502d87930
+      - 62c051c02683488ba9cc0a197d945652
   response:
     status:
       code: 200
@@ -3296,9 +3576,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-caa620f9-047c-4975-a8ed-bd64dea5a353
+      - req-f3972123-067c-466b-913c-529f0a5641a4
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3334,7 +3614,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3349,7 +3629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7c31673e6fb4c39b254e62502d87930
+      - 62c051c02683488ba9cc0a197d945652
   response:
     status:
       code: 200
@@ -3360,9 +3640,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-afdb9f15-59f8-4ac6-91a6-12627a37b687
+      - req-6f30e6ad-f7b1-46f8-9bb1-c8a612b658b6
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3398,7 +3678,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -3413,7 +3693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -3424,9 +3704,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-7e0aa3bd-6b82-4253-b554-fc5a93585e23
+      - req-d5390d7d-e469-4e57-9d01-bac8b7a368be
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -3435,7 +3715,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -3450,7 +3730,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -3461,9 +3741,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-3eb28fbc-1f22-4e0a-8cb5-b54fa8360038
+      - req-aa7af5e2-e348-4d31-8361-99eda89a41d4
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -3549,7 +3829,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -3564,7 +3844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98d27b2fae834e7ca6f8ee0cff3949ec
+      - e186ce13f156403197449ac3a94fd48c
   response:
     status:
       code: 200
@@ -3575,9 +3855,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-b5584c72-2ccb-4d5d-a48e-673ede93cd46
+      - req-ad8425b8-a84c-4ed3-a088-c287efd136ba
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -3591,7 +3871,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3609,13 +3889,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Aug 2018 19:37:40 GMT
+      - Mon, 06 Aug 2018 17:01:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ca6a1bed-0f48-4cb8-9f38-1e53b2a4ddfb
+      - req-2355608a-819e-416e-b937-14259596c4d2
       Content-Length:
       - '4117'
       Connection:
@@ -3624,10 +3904,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-03T19:37:40.875096", "expires":
-        "2018-08-03T20:37:40Z", "id": "def0fb046f174683833ede03c3fedba7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:40.407978", "expires":
+        "2018-08-06T18:01:40Z", "id": "c4392a5fbcdd45d6aa5f6223a63b03dc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_hinqbR3SJyXR_K6wya7vw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DiH6_VbQSvGB5GHHKW4Myg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3671,7 +3951,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:40 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -3686,22 +3966,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - def0fb046f174683833ede03c3fedba7
+      - c4392a5fbcdd45d6aa5f6223a63b03dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86ff38be-1f94-4f3b-92e1-2f6116940119
+      - req-c4e332b6-2bc8-4f89-9516-56038a513338
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-86ff38be-1f94-4f3b-92e1-2f6116940119
+      - req-c4e332b6-2bc8-4f89-9516-56038a513338
       Date:
-      - Fri, 03 Aug 2018 19:37:41 GMT
+      - Mon, 06 Aug 2018 17:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -3722,7 +4002,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:41 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -3737,22 +4017,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - def0fb046f174683833ede03c3fedba7
+      - c4392a5fbcdd45d6aa5f6223a63b03dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd951b3a-a55a-490b-abe0-9e401a610d28
+      - req-f5febc9a-cad9-48dd-a4b2-0f9ef4ab0d43
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-fd951b3a-a55a-490b-abe0-9e401a610d28
+      - req-f5febc9a-cad9-48dd-a4b2-0f9ef4ab0d43
       Date:
-      - Fri, 03 Aug 2018 19:37:42 GMT
+      - Mon, 06 Aug 2018 17:01:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -3773,5 +4053,2791 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Fri, 03 Aug 2018 19:37:42 GMT
+  recorded_at: Mon, 06 Aug 2018 17:01:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2088'
+      X-Compute-Request-Id:
+      - req-7b2cbe4d-10c7-46e1-84cc-ac16a443923b
+      Date:
+      - Mon, 06 Aug 2018 17:01:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z",
+        "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
+        "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
+        [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
+        "OS-EXT-IPS:type": "fixed"}, {"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c",
+        "version": 4, "addr": "172.16.17.4", "OS-EXT-IPS:type": "floating"}]}, "links":
+        [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "rel": "bookmark"}], "key_name": "EmsRefreshSpec-KeyPair", "image": {"id":
+        "bb799f70-5e02-461b-8324-17ee88259c7b", "links": [{"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/images/bb799f70-5e02-461b-8324-17ee88259c7b",
+        "rel": "bookmark"}]}, "OS-EXT-STS:task_state": null, "OS-EXT-STS:vm_state":
+        "active", "OS-EXT-SRV-ATTR:instance_name": "instance-00000004", "OS-SRV-USG:launched_at":
+        "2016-11-11T13:51:08.000000", "OS-EXT-SRV-ATTR:hypervisor_hostname": "11.22.33.44",
+        "flavor": {"id": "6", "links": [{"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}]}, "id": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "security_groups":
+        [{"name": "EmsRefreshSpec-SecurityGroup2"}, {"name": "EmsRefreshSpec-SecurityGroup"}],
+        "OS-SRV-USG:terminated_at": null, "OS-EXT-AZ:availability_zone": "nova", "user_id":
+        "80ea157498b44d08aa6d6f54b8a7c3e7", "name": "EmsRefreshSpec-PoweredOn", "created":
+        "2016-11-11T13:50:32Z", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig":
+        "MANUAL", "os-extended-volumes:volumes_attached": [{"id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"},
+        {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
+        "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
+        {}}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '285'
+      X-Compute-Request-Id:
+      - req-da57e7a4-cb55-4dd8-bf58-261c425f199f
+      Date:
+      - Mon, 06 Aug 2018 17:01:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
+        "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.5"}], "port_id":
+        "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3931'
+      X-Compute-Request-Id:
+      - req-682cf67f-49cb-4eb9-8dcd-2c830094fcc2
+      Date:
+      - Mon, 06 Aug 2018 17:01:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-SecurityGroup"},
+        "ip_protocol": "tcp", "to_port": 4, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {}, "id": "15d247b8-904d-45a5-8c51-1691a92ef179"}, {"from_port":
+        80, "group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-SecurityGroup"},
+        "ip_protocol": "tcp", "to_port": 80, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {}, "id": "16c45d6d-a1bd-48ea-8147-350e89b6821e"}, {"from_port":
+        1, "group": {}, "ip_protocol": "udp", "to_port": 65535, "parent_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range": {"cidr": "0.0.0.0/0"},
+        "id": "2dd82e10-6b62-4c2c-8255-c2e3b63d9119"}, {"from_port": 443, "group":
+        {}, "ip_protocol": "tcp", "to_port": 443, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {"cidr": "1:2:3:4:5:6:7:abc8/128"}, "id": "40f0d754-2b5b-4965-ac5b-4b2d662225c1"},
+        {"from_port": -1, "group": {}, "ip_protocol": "icmp", "to_port": -1, "parent_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range": {"cidr": "1.2.3.4/30"},
+        "id": "427cb9f4-2116-4b03-b7e3-d87dfca202bd"}, {"from_port": 1, "group": {},
+        "ip_protocol": "tcp", "to_port": 2, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {"cidr": "1.2.3.4/30"}, "id": "6738adbb-1a50-4802-b67f-bafee1e5c18a"},
+        {"from_port": 80, "group": {}, "ip_protocol": "tcp", "to_port": 80, "parent_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range": {"cidr": "0.0.0.0/0"},
+        "id": "6bd2821c-157b-4424-800e-0c602a8b2fa2"}, {"from_port": -1, "group":
+        {}, "ip_protocol": "icmp", "to_port": -1, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {"cidr": "0.0.0.0/0"}, "id": "7c00b697-21eb-4700-85d6-15ec59ee7de8"},
+        {"from_port": 443, "group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "name": "EmsRefreshSpec-SecurityGroup"}, "ip_protocol": "tcp", "to_port":
+        443, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range":
+        {}, "id": "956f6c84-b896-4fa7-8f26-afc7f30671ef"}, {"from_port": 1, "group":
+        {}, "ip_protocol": "tcp", "to_port": 65535, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {"cidr": "0.0.0.0/0"}, "id": "a7a38b2d-04c4-45ad-be2d-9c4684787221"},
+        {"from_port": 3, "group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "name": "EmsRefreshSpec-SecurityGroup"}, "ip_protocol": "udp", "to_port":
+        4, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range":
+        {}, "id": "b33fb74e-81b6-4359-8be9-edd662fb9572"}, {"from_port": -1, "group":
+        {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-SecurityGroup"},
+        "ip_protocol": "icmp", "to_port": -1, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {}, "id": "b6848646-5fa1-40ee-b988-2649224ea767"}, {"from_port":
+        443, "group": {}, "ip_protocol": "tcp", "to_port": 443, "parent_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range": {"cidr": "::/0"}, "id":
+        "d6bb1846-d362-4065-a380-ebc3b684313c"}, {"from_port": 1, "group": {}, "ip_protocol":
+        "udp", "to_port": 2, "parent_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "ip_range": {"cidr": "1.2.3.4/30"}, "id": "f3444292-5a22-4f76-84f4-71ee60393bee"},
+        {"from_port": 80, "group": {}, "ip_protocol": "tcp", "to_port": 80, "parent_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "ip_range": {"cidr": "1.2.3.4/30"},
+        "id": "f79f0e32-b186-4778-952e-20827a60ef73"}], "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "name": "EmsRefreshSpec-SecurityGroup",
+        "description": "EmsRefreshSpec-SecurityGroup description"}, {"rules": [],
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "id": "e4836528-d0df-425e-a117-ae8ec6f356d4",
+        "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
+        description"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '20'
+      X-Compute-Request-Id:
+      - req-b7db218b-f6fa-45e7-9978-bd9b1df28ecd
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"floating_ips": []}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '374'
+      X-Openstack-Request-Id:
+      - req-934a595a-e0de-4f40-9d00-785da2e9fb90
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "router_id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "fixed_ip_address": "192.168.0.5",
+        "floating_ip_address": "172.16.17.4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
+        "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '371'
+      X-Openstack-Request-Id:
+      - req-045b7c5c-c2a4-4702-8300-7d0187c3c624
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "router_id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "fixed_ip_address": "192.168.0.5",
+        "floating_ip_address": "172.16.17.4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
+        "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://11.22.33.44:5000/v2.0/tenants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 321e7dc3f9ad44d38d10a1c9793c7244
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-69c8e713-1df0-4347-acc5-4afd76387483
+      Content-Length:
+      - '500'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
+        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
+        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      X-Compute-Request-Id:
+      - req-dd71635b-666d-426b-99a2-c8d3c30c8a41
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
+        1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
+        1, "disk": 1, "id": "6"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 748be19a274448b0b87ca06c1225d378
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '599'
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Openstack-Request-Id:
+      - req-05f93e1e-7943-4b28-bec9-be4afb967b04
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
+        "bare", "created_at": "2016-11-11T13:49:09Z", "size": 13287936, "disk_format":
+        "qcow2", "updated_at": "2016-11-11T13:49:13Z", "visibility": "private", "self":
+        "/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b", "min_disk": 0, "protected":
+        false, "id": "bb799f70-5e02-461b-8324-17ee88259c7b", "file": "/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/file",
+        "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
+        "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 472274e41a3649caa8929e0848b3de4b
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-21b4eae6-a551-4cf9-840b-144582221fd4
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 472274e41a3649caa8929e0848b3de4b
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-74ef3999-f207-4099-9b95-397d3d425d3b
+      Date:
+      - Mon, 06 Aug 2018 17:01:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4d0edf8d676b46229afdbce9d3627a0c
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-ad0508ff-1b8f-419e-b890-3b24e8b77479
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4d0edf8d676b46229afdbce9d3627a0c
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-18fad80f-354b-4e6c-8d6e-9d561c038987
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-1ee5d7a9-6e6e-412f-9868-500cf73740bf
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-1e4ebe93-8c72-4dc8-b5a9-c001ab7466c6
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8434b7e4079f46a3bbce4aaf55c5c541
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-64d1aadb-3427-4853-9bd0-041f925a2a8a
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8434b7e4079f46a3bbce4aaf55c5c541
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1617'
+      X-Compute-Request-Id:
+      - req-9de4fdc7-2766-4433-9d7a-c61eef78d5ab
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair", "fingerprint": "4d:d0:d7:0a:f6:87:3e:05:04:91:49:91:ef:49:1f:33"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNbYzQK57vApkpA9G7AlbXmYHUgtqKsFIqOtp/X+ZmM3xgtXAmrKuQzwpKXyjUED6FRj8gHl3lueGzXJrrl6G5bUYfH8iWhVi+pFmx24JIM4cvwSNl+q12FCrZjM0nRuFnYoBbd+gVyqpve1cDC7vlUUM9xtgaYTCbv4RepsdfeWw/HohSO1inpx297TSfWOXpVP2CTv67tvTbVGPv+r9RV4R1lHMZYJXVf3pjjJ0NB6LT9SogyDPNQL12PVwFNTYG9a/N/Fa33aanILwU2ffAgquyIcGT26YXp5br8J/3L7Wt+Lw+CkmhHKlgr+yLfkWHYp4X+uFBLoxUl0wPQkft
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-2", "fingerprint": "95:42:c9:d1:33:ec:4f:2c:4f:e8:55:00:ba:b0:4c:78"}},
+        {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
+        Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      X-Compute-Request-Id:
+      - req-34281c21-0b61-4816-b6c4-86ed7b26a3ed
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
+        1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
+        1, "disk": 1, "id": "6"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1013e719859748ada14555f11a0435b5
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '197'
+      X-Compute-Request-Id:
+      - req-2a75a0e9-1f30-421f-86df-e8138b911edf
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '440'
+      X-Openstack-Request-Id:
+      - req-835c6826-e37a-4c50-b0a8-925f5c0507e6
+      Date:
+      - Mon, 06 Aug 2018 17:01:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
+        14}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '409'
+      X-Openstack-Request-Id:
+      - req-c26750d8-c34b-499c-9116-9fb06bc0db15
+      Date:
+      - Mon, 06 Aug 2018 17:01:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 02e15f58164b485c99de220dbbdbc03b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-45ddb394-813e-498e-8d0f-caca10ffcef9
+      Date:
+      - Mon, 06 Aug 2018 17:01:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 02e15f58164b485c99de220dbbdbc03b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0b669053-0bb4-48d9-9796-8bff49a38ded
+      Date:
+      - Mon, 06 Aug 2018 17:01:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2c39416231ba4f76920e66025b1198eb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-22207b93-bd2f-4e7e-b2c7-c9b6b4be218e
+      Date:
+      - Mon, 06 Aug 2018 17:01:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2c39416231ba4f76920e66025b1198eb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ce904637-fcd8-4da9-932f-f5a3d824f278
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4278874f-3eb3-4a24-8ba7-a09a2fa50592
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9e0e10bd-0a32-41d2-96ff-77eefdf4aa29
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 62c051c02683488ba9cc0a197d945652
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-57a8549c-8048-4e12-8482-84da5d348404
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 62c051c02683488ba9cc0a197d945652
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-308eb5b7-f000-4ce7-bc8b-dc3dfbda6ff8
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '954'
+      X-Openstack-Request-Id:
+      - req-e4add033-fba0-4578-a3f1-a4fe93864412
+      Date:
+      - Mon, 06 Aug 2018 17:01:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-0-5", "ip_address": "192.168.0.5", "fqdn": "host-192-168-0-5.openstacklocal."}],
+        "device_owner": "compute:None", "binding:profile": {}, "fixed_ips": [{"subnet_id":
+        "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.5"}], "id":
+        "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "security_groups": ["e4836528-d0df-425e-a117-ae8ec6f356d4",
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"], "device_id": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "name": "", "admin_state_up": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "dns_name": "", "binding:vif_details": {"port_filter": true, "ovs_hybrid_plug":
+        true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 02e15f58164b485c99de220dbbdbc03b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-8c1ce982-503d-4ca4-a63d-67c8382bc2b6
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 02e15f58164b485c99de220dbbdbc03b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-bb8a89d8-bd8b-41a7-ad21-1b0380fba8c6
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2c39416231ba4f76920e66025b1198eb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-d090734d-91b6-4be3-b650-e3a637b5954d
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2c39416231ba4f76920e66025b1198eb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-2f831344-76b6-4491-b29e-22883ed22f70
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-73d7f486-4adc-43e5-84b5-cd3dcc7b7e9f
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-2f1a4566-f5c9-400f-9ddc-318699059e84
+      Date:
+      - Mon, 06 Aug 2018 17:01:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 62c051c02683488ba9cc0a197d945652
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-b214df4f-29fd-461a-af5c-7b3e99bc8743
+      Date:
+      - Mon, 06 Aug 2018 17:01:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 62c051c02683488ba9cc0a197d945652
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2617'
+      X-Openstack-Request-Id:
+      - req-a1e414bd-1656-4aef-bcea-f2a091fd83cb
+      Date:
+      - Mon, 06 Aug 2018 17:01:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
+        "allowed_address_pairs": [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname":
+        "host-192-168-1-1", "ip_address": "192.168.1.1", "fqdn": "host-192-168-1-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "ip_address": "192.168.1.1"}],
+        "id": "02b5cbb1-6072-429c-b185-89f44b552d40", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:b5:f7:9c"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-192-168-0-1",
+        "ip_address": "192.168.0.1", "fqdn": "host-192-168-0-1.openstacklocal."}],
+        "device_owner": "network:router_interface", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "104c081f-97dd-42b7-8930-98abbd015c74", "ip_address": "192.168.0.1"}],
+        "id": "400d31a8-18da-40c3-82f5-47c250b56d01", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mac_address": "fa:16:3e:3e:2a:33"}, {"status": "ACTIVE", "binding:host_id":
+        "11.22.33.44", "allowed_address_pairs":
+        [], "extra_dhcp_opts": [], "dns_assignment": [{"hostname": "host-172-16-17-2",
+        "ip_address": "172.16.17.2", "fqdn": "host-172-16-17-2.openstacklocal."}],
+        "device_owner": "network:router_gateway", "binding:profile": {}, "fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}],
+        "id": "9330caba-d3ec-4675-b68a-b80fffae6365", "security_groups": [], "device_id":
+        "57e17608-8ac6-44a6-803e-f42ec15e9d1e", "name": "", "admin_state_up": true,
+        "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "dns_name": "", "binding:vif_details":
+        {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
+        "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '443'
+      X-Openstack-Request-Id:
+      - req-41f45717-2caa-40b7-b1fe-8c12d66cdd91
+      Date:
+      - Mon, 06 Aug 2018 17:01:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
+        "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "enable_snat": true, "external_fixed_ips":
+        [{"subnet_id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "ip_address": "172.16.17.2"}]},
+        "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '6900'
+      X-Openstack-Request-Id:
+      - req-d94a4019-03bf-4d84-a63c-71fd2d296eca
+      Date:
+      - Mon, 06 Aug 2018 17:01:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "description": "EmsRefreshSpec-SecurityGroup description", "id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "security_group_rules": [{"remote_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "direction": "ingress", "remote_ip_prefix": null, "protocol": "tcp", "ethertype":
+        "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
+        4, "port_range_min": 3, "id": "15d247b8-904d-45a5-8c51-1691a92ef179", "security_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb",
+        "direction": "ingress", "remote_ip_prefix": null, "protocol": "tcp", "ethertype":
+        "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
+        80, "port_range_min": 80, "id": "16c45d6d-a1bd-48ea-8147-350e89b6821e", "security_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id": null, "direction":
+        "egress", "remote_ip_prefix": null, "protocol": null, "ethertype": "IPv6",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max": null, "port_range_min":
+        null, "id": "17cc28a4-c274-41fb-9288-486dc091027c", "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"},
+        {"remote_group_id": null, "direction": "ingress", "remote_ip_prefix": "0.0.0.0/0",
+        "protocol": "udp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 65535, "port_range_min": 1, "id": "2dd82e10-6b62-4c2c-8255-c2e3b63d9119",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "1:2:3:4:5:6:7:abc8/128",
+        "protocol": "tcp", "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 443, "port_range_min": 443, "id": "40f0d754-2b5b-4965-ac5b-4b2d662225c1",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "1.2.3.4/30", "protocol":
+        "icmp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": null, "port_range_min": null, "id": "427cb9f4-2116-4b03-b7e3-d87dfca202bd",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "1.2.3.4/30", "protocol":
+        "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 2, "port_range_min": 1, "id": "6738adbb-1a50-4802-b67f-bafee1e5c18a",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "0.0.0.0/0", "protocol":
+        "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 80, "port_range_min": 80, "id": "6bd2821c-157b-4424-800e-0c602a8b2fa2",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "direction": "egress", "remote_ip_prefix":
+        null, "protocol": "tcp", "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 443, "port_range_min": 443, "id": "7ad6e769-1ed8-4e6e-8bae-0ca789da3b3a",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "0.0.0.0/0", "protocol":
+        "icmp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": null, "port_range_min": null, "id": "7c00b697-21eb-4700-85d6-15ec59ee7de8",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "direction": "ingress", "remote_ip_prefix":
+        null, "protocol": "tcp", "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 443, "port_range_min": 443, "id": "956f6c84-b896-4fa7-8f26-afc7f30671ef",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "0.0.0.0/0", "protocol":
+        "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 65535, "port_range_min": 1, "id": "a7a38b2d-04c4-45ad-be2d-9c4684787221",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "egress", "remote_ip_prefix": null, "protocol": null, "ethertype":
+        "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
+        null, "port_range_min": null, "id": "a94d2ef9-c809-4f78-b0ab-cadbad30d431",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "egress", "remote_ip_prefix": "::/0", "protocol": "tcp",
+        "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
+        443, "port_range_min": 443, "id": "aaf1f08a-a8d1-4455-92d7-11135ac1e369",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "direction": "ingress", "remote_ip_prefix":
+        null, "protocol": "udp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 4, "port_range_min": 3, "id": "b33fb74e-81b6-4359-8be9-edd662fb9572",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        "fd147cb7-7456-43d9-a01f-c06e21b4e6fb", "direction": "ingress", "remote_ip_prefix":
+        null, "protocol": "icmp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": null, "port_range_min": null, "id": "b6848646-5fa1-40ee-b988-2649224ea767",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "egress", "remote_ip_prefix": "1.2.3.4/30", "protocol":
+        "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 443, "port_range_min": 443, "id": "c58980f5-abc9-4d16-96b5-a4a9dda744c1",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "::/0", "protocol": "tcp",
+        "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max":
+        443, "port_range_min": 443, "id": "d6bb1846-d362-4065-a380-ebc3b684313c",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "1.2.3.4/30", "protocol":
+        "udp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 2, "port_range_min": 1, "id": "f3444292-5a22-4f76-84f4-71ee60393bee",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}, {"remote_group_id":
+        null, "direction": "ingress", "remote_ip_prefix": "1.2.3.4/30", "protocol":
+        "tcp", "ethertype": "IPv4", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
+        "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e186ce13f156403197449ac3a94fd48c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '880'
+      X-Openstack-Request-Id:
+      - req-db8bcc28-6fdf-4e3d-a6d9-62a65f0fb96c
+      Date:
+      - Mon, 06 Aug 2018 17:01:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "description": "EmsRefreshSpec-SecurityGroup2 description", "id": "e4836528-d0df-425e-a117-ae8ec6f356d4",
+        "security_group_rules": [{"remote_group_id": null, "direction": "egress",
+        "remote_ip_prefix": null, "protocol": null, "ethertype": "IPv4", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "port_range_max": null, "port_range_min":
+        null, "id": "1a94b699-e28c-44fb-9b26-a84eeb44d540", "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"},
+        {"remote_group_id": null, "direction": "egress", "remote_ip_prefix": null,
+        "protocol": null, "ethertype": "IPv6", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
+        "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4392a5fbcdd45d6aa5f6223a63b03dc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-bea0a8ef-3652-4b8c-b7fe-b327680a59ff
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1406'
+      X-Openstack-Request-Id:
+      - req-bea0a8ef-3652-4b8c-b7fe-b327680a59ff
+      Date:
+      - Mon, 06 Aug 2018 17:01:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
+        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
+        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
+        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:49 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4392a5fbcdd45d6aa5f6223a63b03dc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-3ad5062a-1e83-4d2b-8075-ca244f4f85f1
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1408'
+      X-Openstack-Request-Id:
+      - req-3ad5062a-1e83-4d2b-8075-ca244f4f85f1
+      Date:
+      - Mon, 06 Aug 2018 17:01:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "31311772-106c-4128-a1f0-f3b4cd4e34e3",
+        "host_name": null, "volume_id": "2c774148-c11a-434c-aabb-7fa9c82c37ce", "device":
+        "/dev/vde", "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
+        "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Mon, 06 Aug 2018 17:01:49 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596058 in combination with https://github.com/ManageIQ/manageiq-content/pull/371 and https://github.com/ManageIQ/manageiq-content/pull/372