### PR TITLE
New Cloud provider: Fix event creds validation for AMQP

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -12,39 +12,49 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   # OpenStack interactions
   #
   module ClassMethods
+    def amqp_available?(params)
+      require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
+      OpenstackRabbitEventMonitor.available?(
+        :hostname => params[:amqp_hostname],
+        :username => params[:amqp_userid],
+        :password => params[:amqp_password],
+        :port     => params[:amqp_api_port]
+      )
+    end
+    private :amqp_available?
+
+    def ems_connect?(password, params, service)
+      ems = new
+      ems.name                   = params[:name].strip
+      ems.provider_region        = params[:provider_region]
+      ems.api_version            = params[:api_version].strip
+      ems.security_protocol      = params[:default_security_protocol].strip
+      ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
+
+      user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].strip
+
+      endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
+      authentication = {:userid => user, :password => MiqPassword.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
+      ems.connection_configurations = [{:endpoint       => endpoint,
+                                        :authentication => authentication}]
+
+      begin
+        ems.connect(:service => service)
+      rescue => err
+        miq_exception = translate_exception(err)
+        raise unless miq_exception
+
+        _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+        raise miq_exception
+      end
+    end
+    private :ems_connect?
+
     def raw_connect(password, params, service = "Compute")
-      if params[:amqp_hostname].present?
-        require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
-        OpenstackRabbitEventMonitor.available?(
-          :hostname => params[:amqp_hostname],
-          :username => params[:amqp_userid],
-          :password => params[:amqp_password],
-          :port     => params[:amqp_api_port]
-        )
+      if params[:cred_type] == 'amqp'
+        amqp_available?(params)
       else
-        ems = new
-        ems.name                   = params[:name].strip
-        ems.provider_region        = params[:provider_region]
-        ems.api_version            = params[:api_version].strip
-        ems.security_protocol      = params[:default_security_protocol].strip
-        ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
-
-        user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].strip
-
-        endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
-        authentication = {:userid => user, :password => MiqPassword.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
-        ems.connection_configurations = [{:endpoint       => endpoint,
-                                          :authentication => authentication}]
-
-        begin
-          ems.connect(:service => service)
-        rescue => err
-          miq_exception = translate_exception(err)
-          raise unless miq_exception
-
-          _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-          raise miq_exception
-        end
+        ems_connect?(password, params, service)
       end
     end
 


### PR DESCRIPTION
Splits `#raw_connect` to target separately AMQP availability and ems default connect.

https://bugzilla.redhat.com/show_bug.cgi?id=1593663