### PR TITLE
Set tenant access when creating non public flavor

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
@@ -3,7 +3,13 @@ class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
 
   def self.raw_create_flavor(ext_management_system, create_options)
     ext_management_system.with_provider_connection({:service => 'Compute'}) do |service|
-      service.flavors.create(create_options)
+      cloud_tenant_refs = create_options.delete("cloud_tenant_refs")
+      flavor = service.flavors.create(create_options)
+      unless flavor.is_public
+        cloud_tenant_refs.each do |cloud_tenant_ref|
+          service.add_flavor_access(flavor.id, cloud_tenant_ref)
+        end
+      end
     end
   rescue => err
     _log.error "flavor=[#{name}], error=[#{err}]"


### PR DESCRIPTION
Set tenant access when creating non public flavor. After a non-public flavor is created add tenant access. Array with tenants comes with `create_options ` from UI.
https://bugzilla.redhat.com/show_bug.cgi?id=1609564


@aufi 
